### PR TITLE
Feature/433 ordering in fedavg

### DIFF
--- a/fedbiomed/researcher/aggregators/aggregator.py
+++ b/fedbiomed/researcher/aggregators/aggregator.py
@@ -45,6 +45,17 @@ class Aggregator:
             norm = [_w / _s for _w in weights]
         return norm
 
+    @staticmethod
+    def get_weights_from_node_id(node_id: str, weights: List[Dict[str, float]]) -> float:
+        """Gets the aggregation weights associated to a given node id.
+
+        weights is a list of single-item dictionaries, each dictionary has the
+        node id as key, and the weight as value.
+        """
+        list_of_weights = [x[node_id] for x in weights if node_id in x]
+        assert len(list_of_weights) == 1
+        return list_of_weights[0]
+
     def aggregate(self, model_params: list, weights: list, *args, **kwargs) -> Dict:
         """
         Strategy to aggregate models

--- a/fedbiomed/researcher/aggregators/aggregator.py
+++ b/fedbiomed/researcher/aggregators/aggregator.py
@@ -9,12 +9,11 @@ top class for all aggregators
 import os
 from typing import Dict, Any, List, Optional, Tuple
 
-from fedbiomed.common.constants  import ErrorNumbers, TrainingPlans
+from fedbiomed.common.constants import ErrorNumbers, TrainingPlans
 from fedbiomed.common.exceptions import FedbiomedAggregatorError
-from fedbiomed.common.logger     import logger
+from fedbiomed.common.logger import logger
 from fedbiomed.common.training_plans import BaseTrainingPlan
 from fedbiomed.researcher.datasets import FederatedDataSet
-
 
 
 class Aggregator:
@@ -53,7 +52,12 @@ class Aggregator:
         node id as key, and the weight as value.
         """
         list_of_weights = [x[node_id] for x in weights if node_id in x]
-        assert len(list_of_weights) == 1
+        if len(list_of_weights) != 1:
+            msg = f'{ErrorNumbers.FB401.value}. Could not get weights for node {node_id}.' \
+                  f'Expected exactly 1 entry with this id, instead got {len(list_of_weights)} entries.'
+            logger.debug(msg + f'\nThe full  list of node ids in the weights array is '
+                               f'{[list(w.keys()) for w in weights]}')
+            raise FedbiomedAggregatorError(msg)
         return list_of_weights[0]
 
     def aggregate(self, model_params: list, weights: list, *args, **kwargs) -> Dict:

--- a/fedbiomed/researcher/aggregators/fedavg.py
+++ b/fedbiomed/researcher/aggregators/fedavg.py
@@ -26,6 +26,10 @@ class FedAverage(Aggregator):
         """ Aggregates  local models sent by participating nodes into a global model, following Federated Averaging
         strategy.
 
+        weights is a list of single-item dictionaries, each dictionary has the node id as key, and the weight as value.
+        model_params is a list of single-item dictionaries, each dictionary has the node is as key,
+        and a framework-specific representation of the model parameters as value.
+
         Args:
             model_params: contains each model layers
             weights: contains all weights of a given layer.
@@ -33,8 +37,13 @@ class FedAverage(Aggregator):
         Returns:
             Aggregated parameters
         """
-        model_params_processed = [list(model_param.values())[0] for model_param in model_params] # model params are contained in a dictionary with node_id as key, we just retrieve the params
-        weights_processed = [weight if isinstance(weight, float) else list(weight.values())[0] for weight in weights]
+        model_params_processed = list()
+        weights_processed = list()
+        for model_param in model_params:
+            node_id = next(iter(model_param.keys()))
+            model_params_processed.append(list(model_param.values())[0])
+            weight = self.get_weights_from_node_id(node_id, weights)
+            weights_processed.append(weight)
         weights_processed = self.normalize_weights(weights_processed)
 
         return federated_averaging(model_params_processed, weights_processed)

--- a/tests/test_fedavg.py
+++ b/tests/test_fedavg.py
@@ -28,7 +28,6 @@ class TestFedaverage(unittest.TestCase):
 
     def test_fed_average_01_torch(self):
         """ Testing aggregation for torch model """
-        print("MODELS", self.models)
         aggregated_params = self.aggregator.aggregate(self.models, self.weights)
         # ===============================================================
         # Assert Federated Average
@@ -83,6 +82,18 @@ class TestFedaverage(unittest.TestCase):
         self.assertDictEqual(self.aggregator._aggregator_args,
                              state['parameters'],
                              'The state of the aggregator class has not been loaded correctly')
+
+    def test_fed_average_06_order_of_weight_and_model_params(self):
+        """Tests bug #433 where weights and model params have scrambled order."""
+        weights = [
+            {'node_7ea1c779': 0.9},
+            {'node_02a6e376': 0.1},
+        ]
+        model_params = [{'node_02a6e376': {'coef_': np.array([0.])}},
+                        {'node_7ea1c779': {'coef_': np.array([10.])}}]
+        agg_params = self.aggregator.aggregate(model_params=model_params,
+                                               weights=weights)
+        self.assertEqual(agg_params['coef_'][0], 9.)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/tests/test_fedavg.py
+++ b/tests/test_fedavg.py
@@ -19,7 +19,7 @@ class TestFedaverage(unittest.TestCase):
     def setUp(self):
         self.model = Linear(10, 3)
         self.models = [{f'node_{i}': copy.deepcopy(self.model).state_dict()} for i in range(4)]
-        self.weights = [random() for _ in self.models]
+        self.weights = [{f'node_{i}': random()} for i, _ in enumerate(self.models)]
         self.aggregator = FedAverage()
 
     # after the tests
@@ -38,10 +38,14 @@ class TestFedaverage(unittest.TestCase):
     def test_fed_average_02_sklearn_sgd_t1(self):
         """ Testing aggregation for sklearn sgd test 1"""
 
-        model_params = [{'node_1':{'coef_': np.array([3, 8, 8, 3, 1]), 'intercept_': np.array([4])}},
+        model_params = [{'node_1': {'coef_': np.array([3, 8, 8, 3, 1]), 'intercept_': np.array([4])}},
                         {'node_2': {'coef_': np.array([0.4, 1.6, 2, 1, 0.1]), 'intercept_': np.array([1])}},
-                        {'mode_3': {'coef_': np.array([2, 5, 5, 3, 1]), 'intercept_': np.array([6])}}]
-        weights = [0.2, 0.2, 0.6]
+                        {'node_3': {'coef_': np.array([2, 5, 5, 3, 1]), 'intercept_': np.array([6])}}]
+        weights = [
+            {'node_1': 0.2},
+            {'node_2': 0.2},
+            {'node_3': 0.6}
+        ]
 
         aggregated_params = self.aggregator.aggregate(model_params, weights)
         self.assertTrue(np.allclose(aggregated_params['coef_'], np.array([1.88, 4.92, 5., 2.6, 0.82])))
@@ -50,7 +54,10 @@ class TestFedaverage(unittest.TestCase):
     def test_fed_average_03_sklearn_sgd_t2(self):
         """ Testing aggregation for sklearn sgd test 2"""
 
-        weights = [0.27941176470588236, 0.7205882352941176]
+        weights = [
+            {'node_1': 0.27941176470588236},
+            {'node_2': 0.7205882352941176}
+        ]
 
         model_params = [{'node_1': {'coef_': np.array([-0.02629813, 0.04612957, -0.00321454, 0.08003535, 0.30818439]),
                          'intercept_': np.array([0.161345])}},


### PR DESCRIPTION
In GitLab by @sharkovsky on Jan 9, 2023, 18:46

Fixes #433. 

Implementation logic: try to minimize changes, and delegate to #417 the improvement of the representation of model parameters and weights. 
One exception to this is the addition of the `compute_weights_for_averaging` function in `strategy`, which will become very useful to simplify the implememtation of custom strategies (e.g. for `MedicalFolderDataset`).
I also provide a test that reproduces the bug.

**MR description**

TO_BE_FILLED_BY_MR_CREATOR

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree the
[Developer Certificate of Origin (DCO)](https://gitlab.inria.fr/fedbiomed/fedbiomed/-/blob/develop/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for MR review**

General:

* give a glance to [DoD](https://fedbiomed.gitlabpages.inria.fr/latest/developer/Fed-BioMed_DoD.pdf)
* check [coding rules and coding style](https://fedbiomed.gitlabpages.inria.fr/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state`/`load_state` in aggregators, strategies, secagg, etc.)