### PR TITLE
Feature/79 Set random seed

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,8 +11,8 @@ on:
       - synchronize
       - reopened
       - closed
-      - review-requested
-      - ready-for-review
+      - review_requested
+      - ready_for_review
 
     branches:
       - master

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,7 +11,7 @@ on:
       - synchronize
       - reopened
       - closed
-      - assigned 
+      - review-requested
       - ready-for-review
 
     branches:

--- a/docs/user-guide/researcher/experiment.md
+++ b/docs/user-guide/researcher/experiment.md
@@ -262,6 +262,34 @@ We list here the known constraints:
 
 - the [Scaffold](../../user-guide/researcher/aggregation.md#scaffold) aggregator **requires** using `num_updates`
 
+#### Setting a random seed for reproducibility
+
+The `random_seed` argument allows to set a random seed at the beginning of each round. 
+The same seed is used for the built-in `random` module, `numpy.random` and `torch.random`, effectively equivalent to:
+```python
+import random
+import numpy as np
+import torch
+
+random.seed(training_args['random_seed'])
+np.random.seed(training_args['random_seed'])
+torch.manual_seed(training_args['random_seed'])
+```
+
+!!! warning "`random_seed` is reset at every round"
+    The random_seed argument will be reset to the specified value at the beginning of every round.
+
+Because of this, the same sequence will be used for random effects like shuffling the dataset for all the rounds within
+an `exp.run()` execution. This is not what the user typically wants. A simple workaround is to manually change the seed
+at every round and use `exp.run_once` instead:
+
+```python
+for i in range(num_rounds):
+    training_args['random_seed'] = 42 + i
+    exp.set_training_args(training_args)
+    exp.run_once()
+```
+
 #### Sub-arguments for optimizer and differential privacy
 
 In Pytorch experiments, you may include sub arguments such as `optimizer_args` 

--- a/docs/user-guide/researcher/experiment.md
+++ b/docs/user-guide/researcher/experiment.md
@@ -264,8 +264,14 @@ We list here the known constraints:
 
 #### Setting a random seed for reproducibility
 
-The `random_seed` argument allows to set a random seed at the beginning of each round. 
+The `random_seed` argument allows to set a random seed on the node at the beginning of each round. 
+
+!!! info "`random_seed` is set only on the nodes"
+    If you wish to set the random seed for the researcher, you must do so in your script or notebook, following the
+    example below.
+
 The same seed is used for the built-in `random` module, `numpy.random` and `torch.random`, effectively equivalent to:
+
 ```python
 import random
 import numpy as np

--- a/docs/user-guide/researcher/experiment.md
+++ b/docs/user-guide/researcher/experiment.md
@@ -264,14 +264,8 @@ We list here the known constraints:
 
 #### Setting a random seed for reproducibility
 
-The `random_seed` argument allows to set a random seed on the node at the beginning of each round. 
-
-!!! info "`random_seed` is set only on the nodes"
-    If you wish to set the random seed for the researcher, you must do so in your script or notebook, following the
-    example below.
-
+The `random_seed` argument allows to set a random seed at the beginning of each round. 
 The same seed is used for the built-in `random` module, `numpy.random` and `torch.random`, effectively equivalent to:
-
 ```python
 import random
 import numpy as np

--- a/docs/user-guide/researcher/experiment.md
+++ b/docs/user-guide/researcher/experiment.md
@@ -265,6 +265,18 @@ We list here the known constraints:
 #### Setting a random seed for reproducibility
 
 The `random_seed` argument allows to set a random seed at the beginning of each round. 
+
+!!! info "`random_seed` is set both on the node and the researcher"
+    The `random_seed` is set whenever the `TrainingPlan` is instantiated: both on the researcher side before sending 
+    the train command for a new round, and on the node side at the beginning of the configuration of the new training 
+    round.
+
+Setting the `random_seed` affects:
+
+- the random initialization of model parameters at the beginning of the experiment
+- the random shuffling of data in the `DataLoader`
+- any other random effect on the node and researcher side.
+
 The same seed is used for the built-in `random` module, `numpy.random` and `torch.random`, effectively equivalent to:
 ```python
 import random

--- a/fedbiomed/common/training_args.py
+++ b/fedbiomed/common/training_args.py
@@ -300,7 +300,7 @@ class TrainingArgs:
         | fedprox_mu | set the value of mu and enable FedProx correction |
         | dp_args | arguments for Differential Privacy |
         | share_persistent_buffers | toggle whether nodes share the full state_dict (when True) or only trainable parameters (False) in a TorchTrainingPlan |
-        | random_seed | set random seed at the beginning of each round |
+        | random_seed | set random seed on the node at the beginning of each round |
 
         """
         return {

--- a/fedbiomed/common/training_args.py
+++ b/fedbiomed/common/training_args.py
@@ -300,7 +300,7 @@ class TrainingArgs:
         | fedprox_mu | set the value of mu and enable FedProx correction |
         | dp_args | arguments for Differential Privacy |
         | share_persistent_buffers | toggle whether nodes share the full state_dict (when True) or only trainable parameters (False) in a TorchTrainingPlan |
-        | random_seed | set random seed on the node at the beginning of each round |
+        | random_seed | set random seed at the beginning of each round |
 
         """
         return {

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -85,11 +85,11 @@ class BaseTrainingPlan(metaclass=ABCMeta):
             aggregator_args: Arguments managed by and shared with the
                 researcher-side aggregator.
         """
-        # Set random seed
+        # Set random seed: the seed can be either None or an int provided by the researcher.
+        # when it is None, both random.seed and np.random.seed rely on the OS to generate a random seed.
         rseed = training_args['random_seed']
-        if rseed is not None:
-            random.seed(rseed)
-            np.random.seed(rseed)
+        random.seed(rseed)
+        np.random.seed(rseed)
 
     def add_dependency(self, dep: List[str]) -> None:
         """Add new dependencies to the TrainingPlan.

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Base class defining the shared API of all training plans."""
-
+import random
 from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Optional, TypedDict, Union
@@ -69,7 +69,6 @@ class BaseTrainingPlan(metaclass=ABCMeta):
     def model(self):
         """Gets model instance of the training plan"""
 
-    @abstractmethod
     def post_init(
             self,
             model_args: Dict[str, Any],
@@ -86,6 +85,11 @@ class BaseTrainingPlan(metaclass=ABCMeta):
             aggregator_args: Arguments managed by and shared with the
                 researcher-side aggregator.
         """
+        # Set random seed
+        rseed = training_args['random_seed']
+        if rseed is not None:
+            random.seed(rseed)
+            np.random.seed(rseed)
 
     def add_dependency(self, dep: List[str]) -> None:
         """Add new dependencies to the TrainingPlan.

--- a/fedbiomed/common/training_plans/_sklearn_training_plan.py
+++ b/fedbiomed/common/training_plans/_sklearn_training_plan.py
@@ -90,6 +90,7 @@ class SKLearnTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
             aggregator_args: Arguments managed by and shared with the
                 researcher-side aggregator.
         """
+        super().post_init(model_args, training_args, aggregator_args)
         self._model = SkLearnModel(self._model_cls)
         model_args.setdefault("verbose", 1)
         self._model_args = model_args

--- a/fedbiomed/common/training_plans/_torchnn.py
+++ b/fedbiomed/common/training_plans/_torchnn.py
@@ -137,6 +137,7 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
                 match expectations, or if the optimizer, model and dependencies
                 configuration goes wrong.
         """
+        super().post_init(model_args, training_args, aggregator_args)
         # Assign model arguments.
         self._model_args = model_args
         # Assign scalar attributes.
@@ -149,6 +150,10 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         self._num_updates = self._training_args.get('num_updates', 1)
         self._dry_run = self._training_args.get('dry_run')
         self._share_persistent_buffers = training_args.get('share_persistent_buffers', True)
+        # Set random seed
+        rseed = training_args['random_seed']
+        if rseed is not None:
+            torch.manual_seed(rseed)
         # Optionally set up differential privacy.
         self._dp_controller = DPController(training_args.dp_arguments() or None)
         # Add dependencies

--- a/fedbiomed/common/training_plans/_torchnn.py
+++ b/fedbiomed/common/training_plans/_torchnn.py
@@ -152,8 +152,8 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         self._share_persistent_buffers = training_args.get('share_persistent_buffers', True)
         # Set random seed
         rseed = training_args['random_seed']
-        if rseed is not None:
-            torch.manual_seed(rseed)
+        rseed = rseed if rseed is not None else torch.seed()
+        torch.manual_seed(rseed)
         # Optionally set up differential privacy.
         self._dp_controller = DPController(training_args.dp_arguments() or None)
         # Add dependencies

--- a/tests/test_fedbiosklearn.py
+++ b/tests/test_fedbiosklearn.py
@@ -41,9 +41,12 @@ class Custom:
         return {'Metric': 42.0}
 
 
-class FakeTrainingArgs:
+class FakeTrainingArgs(dict):
     """Mimics TrainingArgs class
     """
+    def __init__(self):
+        self['random_seed'] = 42
+
     def optimizer_arguments(self):
         return {'lr': 1e-2}
 

--- a/tests/test_torchnn.py
+++ b/tests/test_torchnn.py
@@ -68,6 +68,8 @@ class TestTorchnn(unittest.TestCase):
     optimizer = NativeTorchOptimizer(model, Adam([torch.zeros([2, 4])]))
 
     class FakeTrainingArgs(dict):
+        def __init__(self):
+            self['random_seed'] = 42
 
         def pure_training_arguments(self):
             return {"dry_run": True, "epochs": 1, "batch_size": 10, "log_interval": 10}


### PR DESCRIPTION
Closes #79 .

This PR introduces the option to set the random seed on the node at the beginning of the round.

## Design choice: how to deal with impossibility to save random state between rounds on the node

There was a design choice to be made, related to the fact that Fed-BioMed does not store any state on the node between rounds. In fact, the constraint is even stricter: a Fed-BioMed node may even be restarted between two rounds!

The options I considered were:

###  Reset the random seed at the beginning of every round to the same value

Pros: it is clean. Even though it can lead to counterintuitive behaviour, once you are aware of this quirk it is very easy to understand what's happening and to compare different runs.
Cons: when using `exp.run()`, the same seed will be set at every round. This invalidates the users' expectations w.r.t. to randomization effects like shuffling the dataset, since it will always be shuffled in the same way

### Reset the random seed at the beginning of every round to a value provided automatically by the experiment class

Pros: different rounds have different random behaviour
Cons: it becomes more difficult to achieve reproducibility, because the user must remember that they cannot compare two runs with the same random seed directly, and instead they need to know how the experiment changed the random seed in each run. 

### Both of the above, with a switch in the experiment class

Pros: maximum flexibility
Cons: requires changing the experiment (i.e. the user) interface

### Implement a separate message to request setting the random seed on the node

Pros: avoids the confusion of resetting the random seed at every round
Cons: the researcher does not know what happens between rounds. It may happen that the machine is restarted, and then the random seed would be lost.

I preferred the option of `resetting the random seed at every round to the same value` because:
1) once documented, at least the user always knows clearly what is going on
2) there is a simple workaround, which is to use `run_once` and change the seed at every round
3) I did not want to change the experiment interface, adding yet-another option

