### PR TITLE
Make fedbiomed-network conda env optional

### DIFF
--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Install researcher dependencies
       run: | 
         source ~/.bashrc
-        ./scripts/configure_conda researcher network
+        ./scripts/configure_conda researcher
         ./scripts/fedbiomed_run network
       shell: bash
 

--- a/docs/tutorials/installation/0-basic-software-installation.md
+++ b/docs/tutorials/installation/0-basic-software-installation.md
@@ -179,7 +179,7 @@ fedbiomed-researcher     /home/mylogin/.conda/envs/fedbiomed-researcher
 !!! note "Conda environment for Fed-BioMed Network Component"
     The Fed-BioMed network component, which consists of two modules, namely `MQTT` and `Restful`, runs in a Docker container. Although `fedbiomed-network` exists as a conda environment, it is not directly used on the local system where Fed-BioMed is installed. However, it can be used to launch the `restful` module locally instead of using Docker.
     
-    The conda environment can be install with the following command
+    The conda environment can be installed with the following command
 
     ```
     ${FEDBIOMED_DIR}/scripts/configure_conda network

--- a/docs/tutorials/installation/0-basic-software-installation.md
+++ b/docs/tutorials/installation/0-basic-software-installation.md
@@ -165,27 +165,38 @@ Create or update the conda environments with :
 $ ${FEDBIOMED_DIR}/scripts/configure_conda
 ```
 
-List the existing conda environments and check the 3 environments `fedbiomed-network` `fedbiomed-node` `fedbiomed-researcher` were created :
+List the existing conda environments and check the 3 environments `fedbiomed-gui` `fedbiomed-node` `fedbiomed-researcher` were created :
 
 ```
 $ conda env list
 [...]
-fedbiomed-network        /home/mylogin/.conda/envs/fedbiomed-network
+fedbiomed-network        /home/mylogin/.conda/envs/fedbiomed-gui
 fedbiomed-node           /home/mylogin/.conda/envs/fedbiomed-node
 fedbiomed-researcher     /home/mylogin/.conda/envs/fedbiomed-researcher
 [...]
 ```
 
-!!! note "Conda environment for Fed-BioMed Node GUI"
-    Fed-BioMed comes with a user interface that allows data owners (node users) to deploy datasets and manage requested 
-    training plans easily. To be able to use Node GUI you need to install Fed-BioMed GUI conda environment as well. 
-    You can use following command to install GUI conda environment.
+!!! note "Conda environment for Fed-BioMed Network Component"
+    The Fed-BioMed network component, which consists of two modules, namely `MQTT` and `Restful`, runs in a Docker container. Although `fedbiomed-network` exists as a conda environment, it is not directly used on the local system where Fed-BioMed is installed. However, it can be used to launch the `restful` module locally instead of using Docker.
     
+    The conda environment can be install with the following command
+
     ```
-    $ ${FEDBIOMED_DIR}/scripts/configure_conda gui
+    ${FEDBIOMED_DIR}/scripts/configure_conda network
     ```
 
-    Please follow [Node GUI user guide](../../user-guide/nodes/node-gui.md) to get more information about launching GUI on your local.
+!!! note "Conda environment for Fed-BioMed Node GUI"
+    Fed-BioMed comes with a user interface that allows data owners (node users) to deploy datasets and manage requested 
+    training plans easily. `fedbiomed-gui` environment is not going to be used unless Node GUI launched. If Node GUI is not 
+    planned to be used you can install only `fedbiomed-node` and `fedbiomed-researcher` environment. 
+
+    ```
+    ${FEDBIOMED_DIR}/scripts/configure_conda node researcher
+    ```
+    
+    Please see [Node GUI user guide](../../user-guide/nodes/node-gui.md) to get more information about launching GUI on your local.
+
+
 
 ## The Next Step
 

--- a/docs/tutorials/installation/0-basic-software-installation.md
+++ b/docs/tutorials/installation/0-basic-software-installation.md
@@ -187,14 +187,14 @@ fedbiomed-researcher     /home/mylogin/.conda/envs/fedbiomed-researcher
 
 !!! note "Conda environment for Fed-BioMed Node GUI"
     Fed-BioMed comes with a user interface that allows data owners (node users) to deploy datasets and manage requested 
-    training plans easily. `fedbiomed-gui` environment is not going to be used unless Node GUI launched. If Node GUI is not 
-    planned to be used you can install only `fedbiomed-node` and `fedbiomed-researcher` environment. 
+    training plans easily. The `fedbiomed-gui` environment is not going to be used unless the Node GUI is launched. 
+    If you don't plan on using the GUI, you can install only the `fedbiomed-node` and `fedbiomed-researcher` environments.
 
     ```
     ${FEDBIOMED_DIR}/scripts/configure_conda node researcher
     ```
     
-    Please see [Node GUI user guide](../../user-guide/nodes/node-gui.md) to get more information about launching GUI on your local.
+    Please see [Node GUI user guide](../../user-guide/nodes/node-gui.md) to get more information about launching GUI on your local machine.
 
 
 

--- a/scripts/configure_conda
+++ b/scripts/configure_conda
@@ -3,8 +3,14 @@
 # create all necessary environments
 #
 
-# list of env to find/intialise
+# List of available environemnt for Fed-BiOmed
 fed_envs=(network node researcher gui)
+
+# Environments that are required to be installed for Fed-BioMed components
+# Note: network component is only necessary if restful module of network component  
+# is to be started locally rather than docker.
+fed_envs_auto_create=(node researcher gui)
+
 
 # detect how the file is run
 ([[ -n $ZSH_EVAL_CONTEXT && $ZSH_EVAL_CONTEXT =~ :file$ ]] ||
@@ -186,7 +192,7 @@ esac
 # verify COMPONENTS
 if [ ${#COMPONENTS[@]} == 0 ]
 then
-    FINAL_COMPONENTS=("${fed_envs[@]}")
+    FINAL_COMPONENTS=("${fed_envs_auto_create[@]}")
 else
     # verify that given components are allowed
     for c in ${COMPONENTS[@]}

--- a/scripts/configure_conda
+++ b/scripts/configure_conda
@@ -3,7 +3,7 @@
 # create all necessary environments
 #
 
-# List of available environemnt for Fed-BiOmed
+# List of available environemnts for Fed-BioMed
 fed_envs=(network node researcher gui)
 
 # Environments that are required to be installed for Fed-BioMed components

--- a/scripts/fedbiomed_run
+++ b/scripts/fedbiomed_run
@@ -233,14 +233,12 @@ case $1 in
         #
         case $2 in
             stop)
-                source ${basedir}/scripts/fedbiomed_environment network
                 docker-compose down
                 ;;
             help|-h|--help)
                 usage network
                 ;;
             *)
-                source ${basedir}/scripts/fedbiomed_environment network
                 CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) \
                              CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') \
                              CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') \


### PR DESCRIPTION

**PR description**
closes #787 

- Network component is managed through docker
- It is not required to be install unless user wants to run restful locally

This pull request does following changes: 
 - makes network conda environment optionally installed
 - removes network conda env activation before docker command in `fedbiomed_run`
 - don't install network component before starting network in action.yml
 - Adds note to installation guide to explain `fedbiomed-network` conda env is optional

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state`/`load_state` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`