### PR TITLE
v4.4: Update environments, scripts and packages from develop

### DIFF
--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -18,14 +18,15 @@ runs:
     - name: Install researcher dependencies
       run: | 
         source ~/.bashrc
-        ./scripts/configure_conda researcher network
+        conda clean -i -y
+        ./scripts/configure_conda researcher
         ./scripts/fedbiomed_run network
-      shell: bash
+      shell: bash -l {0}
 
     - name: Run unit tests 
       run: |
-          PYTHONPATH=${PYTHONPATH:-$PWD} conda run -n fedbiomed-researcher nosetests -w ${{ inputs.test-dir }} --cover-xml --cover-erase --with-coverage --cover-package=fedbiomed --with-xunit -v --process-restartworker
-      shell: bash
+          PYTHONPATH=${PYTHONPATH:-$PWD} conda run -n fedbiomed-researcher pytest -v --cov=fedbiomed --cov-report term --cov-report xml:${{ inputs.test-dir }}/coverage.xml ${{ inputs.test-dir }}
+      shell: bash  -l {0}
       
     - name: Get coverage rate
       id: coverage-rate
@@ -35,11 +36,10 @@ runs:
           root=tree.getroot();print(root.attrib['line-rate'])")
         echo $COVERAGE 
         echo "coverage=$(echo $COVERAGE)" >> $GITHUB_OUTPUT
-      shell: bash
+      shell: bash -l {0}
     
     - name: Stop network
       if: always()
       run: | 
-        source ~/.bashrc
         ./scripts/fedbiomed_run network stop
-      shell: bash
+      shell: bash -l {0}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,8 +11,8 @@ on:
       - synchronize
       - reopened
       - closed
-      - assigned 
-      - ready-for-review
+      - review_requested
+      - ready_for_review
 
     branches:
       - master
@@ -60,8 +60,12 @@ jobs:
         run: scripts/docs/fedbiomed_doc.sh --build-dir build-repo --build-main --build-current-as v1.0.1 
 
   unit-test:
-    name: Ubuntu 22.04 unit tests
-    runs-on: [self-hosted, Linux, ubuntu-22-04]
+    name: unit tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22-04, fedora38, macosx-m1]
+    runs-on: ${{ matrix.os }}
       
     if: github.event.pull_request.draft == false
     steps:
@@ -92,19 +96,29 @@ jobs:
           test-dir: tests
 
       - name: Upload coverage reports to Codecov
-        if: steps.filter.outputs.module == 'true'
+        if: steps.filter.outputs.module == 'true' && matrix.os != 'macosx-m1'
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: tests/coverage.xml
-          flags: unittests # optional
+          flags: unittests-${{ matrix.os }} # optional
           name: codecov-umbrella # optional
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)
-
+      
+      - name: Notify upload impossible on m1
+        if: steps.filter.outputs.module == 'true' && matrix.os == 'macosx-m1'
+        run: |
+          echo "No codecov-action available for macos-m1" # to check from time to time
+          
+          
   mnist-test: 
     name: Test MNIST Notebook 
-    runs-on: [self-hosted, Linux, ubuntu-22-04]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22-04, fedora38, macosx-m1]
+    runs-on: ${{ matrix.os }}
     needs: unit-test
 
     if: github.event.pull_request.draft == false
@@ -132,9 +146,12 @@ jobs:
           ./scripts/configure_conda node
           ./scripts/fedbiomed_run network
           ./scripts/run_test_mnist ../../../..
+        shell: bash -l {0}
       
       - name: Stop network component 
         if: always()
         run: |
           source ~/.bashrc
           ./scripts/fedbiomed_run network stop
+        shell: bash -l {0}
+

--- a/envs/development/conda/fedbiomed-gui.yaml
+++ b/envs/development/conda/fedbiomed-gui.yaml
@@ -10,41 +10,43 @@ channels:
 
 dependencies:
   # common
-  - python >=3.9,<3.10
-  - nodejs == 16.13.1
-  - yarn >=1.22.19,<=1.22.99
-  - pip
-  - ipython
-  - flask >= 2.0.0,<2.0.2
-  - paho-mqtt >=1.5.1,<2.0.0
+  - python >=3.10,<3.11
+  - nodejs ~=18.15.0
+  - yarn >=3.5.1,<3.6
+  - pip >= 23.0
+  - ipython ~=8.13.2
+  - flask >= 2.3.2,<2.4.0
+  - paho-mqtt ~=1.6.1
   # tests
-  - tinydb >=4.4.0,<5.0.0
-  - tabulate >=0.8.9,<0.9.0
-  - jsonschema >=4.2.0,< 4.2.1
-  - requests >=2.25.1,<3.0.0
-  - git
-  - packaging >=23.0,<24.0
+  - tinydb ~=4.7.1
+  - tabulate >=0.9.0,<0.10.0
+  - jsonschema >=4.17.3,<4.18.0
+  - requests ~=2.29.0
+  - git ~=2.40.1
+  - packaging ~=23.1
   # these two have to be aligned
   - cryptography ~=39.0
   - pyopenssl ~=23.0
-  # sklearn
-  #   scipy >= 1.9 from conda-forge needs recent GLIBC thus causes issue 389
-  #   with many current systems
-  #   another option is to install scipy from pip
-  - scipy >=1.8.0,<1.9.0
-  - scikit-learn >=1.0.0,<1.1.0
-  - itk
+  # other
   - pip:
+      - itk >=5.3.0,<5.4.0
+      # sklearn
+      #   + scipy >= 1.9 from conda-forge needs recent GLIBC thus causes issue 389 with many current systems
+      #   + another option is to install scipy from pip which supports older GLIBC
+      - scipy >=1.10.0,<1.11.0
+      - scikit-learn >=1.2.0,<1.3.0
       # nn
-      - torch >=1.8.0,<2.0.0
-      - torchvision >=0.9.0,<0.15.0
+      # torch 2.x recently released (2023-03) and not yet supported by some deps including: opacus, declearn
+      - torch ~=1.13.0
+      - torchvision >=0.14.0,<0.15.0
       - monai >=1.1.0,<1.2.0
       # other
-      - gunicorn >=20.1, <20.9
-      - pandas >=1.2.3,<2.0.0
-      - cachelib == 0.7.0
-      - python-minifier ==2.5.0
-      - PyJWT == 2.4.0
-      - Flask-JWT-Extended == 4.4.2
+      - gunicorn ~=20.1.0
+      # pandas 2.x recently released (2023-04) but few breaking changes
+      - pandas ~=2.0.1
+      - cachelib >=0.10.2,<0.11.0
+      - python-minifier ~=2.5.0
+      - PyJWT >=2.7.0,<2.8.0
+      - Flask-JWT-Extended >=4.4.4,<4.5.0
       # FLamby
       - git+https://github.com/owkin/FLamby@main

--- a/envs/development/conda/fedbiomed-network.yaml
+++ b/envs/development/conda/fedbiomed-network.yaml
@@ -10,13 +10,14 @@ channels:
 
 dependencies:
   # common
-  - python >=3.9,<3.10
-  - pip
+  - python >=3.10,<3.11
+  - pip >= 23.0
   # http server
-  - django = 3.1.7
-  - djangorestframework = 3.12.2
-  - django-cleanup
-  - gunicorn
+  # django 4.2.0 not yet supported by: djangorestframework, django-cleanup
+  - django >=4.1.7,<4.2.0
+  - djangorestframework >=3.14.0,<3.15.0
+  - django-cleanup ~=7.0.0
+  - gunicorn ~=20.1.0
   # for utilities
   - pip:
-      - persist-queue
+      - persist-queue >=0.8.0,<0.9.0

--- a/envs/development/conda/fedbiomed-node-macosx.yaml
+++ b/envs/development/conda/fedbiomed-node-macosx.yaml
@@ -1,7 +1,6 @@
 #
-# environment for fedbiomed-node on macosx
+# environment for fedbiomed-node on macos
 #
-# it fixes a pb with tensorboard and torch for macosx
 #
 #
 name: fedbiomed-node
@@ -11,48 +10,54 @@ channels:
 
 dependencies:
   # minimal environment
-  - python >=3.9,<3.10
-  - pip
-  - jupyter
-  - ipython
+  # python 3.11 recently released 2022-11 and not yet supported by some deps including: torchvision
+  - python >=3.10,<3.11
+  - pip >= 23.0
+  # ipython currently used by febiomed.common.utils
+  - ipython ~=8.13.2
   # tests
-  - pytest >6.2.2
-  - tinydb >=4.4.0,<5.0.0
-  - tabulate >=0.8.9,<0.9.0
+  - pytest ~=7.2.0
+  - pytest-cov ~=4.1.0
+  - tinydb ~=4.7.1
+  - tabulate >=0.9.0,<0.10.0
   # code
-  - GitPython >=3.1.14,<4.0.0
-  - requests >=2.25.1,<3.0.0
-  - paho-mqtt >=1.5.1,<2.0.0
-  - validators >=0.18.2,<0.19.0
-  - tqdm >=4.59.0,<5.0.0
-  - git
-  - packaging >=23.0,<24.0
+  - requests ~=2.29.0
+  - paho-mqtt ~=1.6.1
+  - validators >=0.20.0,<0.21.0
+  - git ~=2.40.1
+  - packaging ~=23.1
   # these two have to be aligned
-  - cryptography ~=39.0
-  - pyopenssl ~=23.0
-  # git notebook striper
-  - nbstripout
-  - joblib >=1.0.1
-  # nn
+  - cryptography ~=40.0.0
+  - pyopenssl ~=23.1.1
+  #
+  - joblib >=1.2.0,<1.3.0
+  # other
   - pip:
+      # no itk available from conda for macosx-m1
+      - itk >=5.3.0,<5.4.0
+      # sklearn
+      #   + scipy >= 1.9 from conda-forge needs recent GLIBC thus causes issue 389 with many current systems
+      #   + another option is to install scipy from pip which supports older GLIBC
+      - scipy >=1.10.0,<1.11.0
+      - scikit-learn >=1.2.0,<1.3.0
       # nn
-      - torch >=1.8.0,<2.0.0
-      - torchvision >=0.9.0,<0.15.0
-      - opacus >=1.2.0,<1.3.0
+      # torch 2.x recently released (2023-03) and not yet supported by some deps including: opacus, declearn
+      - torch ~=1.13.0
+      - torchvision >=0.14.0,<0.15.0
+      - opacus >=1.4.0,<1.5.0
       - monai >=1.1.0,<1.2.0
       # other
       - msgpack ~=1.0
       - persist-queue >=0.5.1,<0.6.0
       - pytorch-ignite >=0.4.4,<0.5.0
-      - pandas >=1.2.3,<2.0.0
-      - openpyxl >= 3.0.9,<3.1
-      - scikit-learn >=1.0.0,<1.1.0
-      - python-minifier ==2.5.0
+      # pandas 2.x recently released (2023-04) but few breaking changes
+      - pandas ~=2.0.1
+      - python-minifier ~=2.5.0
       # FLamby
       - git+https://github.com/owkin/FLamby@main
       # declearn
-      - declearn[torch] ~= 2.1.0
+      - declearn[torch] ~=2.1.0
       - gmpy2 >=2.1,< 2.2
 #### Notebook-specific packages ####
 # This section contains packages that are needed only to run specific notebooks
-      - unet == 0.7.7
+      - unet >=0.7.7,<0.8.0

--- a/envs/development/conda/fedbiomed-node.yaml
+++ b/envs/development/conda/fedbiomed-node.yaml
@@ -10,56 +10,54 @@ channels:
 
 dependencies:
   # minimal environment
-  - python >=3.9,<3.10
-  - pip
-  - jupyter
-  - ipython
+  # python 3.11 recently released 2022-11 and not yet supported by some deps including: torchvision
+  - python >=3.10,<3.11
+  - pip >= 23.0
+  # ipython currently used by febiomed.common.utils
+  - ipython ~=8.13.2
   # tests
-  - pytest >6.2.2
-  - tinydb >=4.4.0,<5.0.0
-  - tabulate >=0.8.9,<0.9.0
+  - pytest ~=7.2.0
+  - pytest-cov ~=4.1.0
+  - tinydb ~=4.7.1
+  - tabulate >=0.9.0,<0.10.0
   # code
-  - GitPython >=3.1.14,<4.0.0
-  - requests >=2.25.1,<3.0.0
-  - paho-mqtt >=1.5.1,<2.0.0
-  - validators >=0.18.2,<0.19.0
-  - tqdm >=4.59.0,<5.0.0
-  - git
-  - packaging >=23.0,<24.0
+  - requests ~=2.29.0
+  - paho-mqtt ~=1.6.1
+  - validators >=0.20.0,<0.21.0
+  - git ~=2.40.1
+  - packaging ~=23.1
   # these two have to be aligned
-  - cryptography ~=39.0
-  - pyopenssl ~=23.0
-  # git notebook striper
-  - nbstripout
-  - joblib >=1.0.1
-  # sklearn
-  #   scipy >= 1.9 from conda-forge needs recent GLIBC thus causes issue 389
-  #   with many current systems
-  #   another option is to install scipy from pip
-  - scipy >=1.8.0,<1.9.0
-  - scikit-learn >=1.0.0,<1.1.0
+  - cryptography ~=40.0.0
+  - pyopenssl ~=23.1.1
+  #
+  - joblib >=1.2.0,<1.3.0
   # other
-  - itk
-  # nn
   - pip:
+      # no itk available from conda for macosx-m1
+      - itk >=5.3.0,<5.4.0
+      # sklearn
+      #   + scipy >= 1.9 from conda-forge needs recent GLIBC thus causes issue 389 with many current systems
+      #   + another option is to install scipy from pip which supports older GLIBC
+      - scipy >=1.10.0,<1.11.0
+      - scikit-learn >=1.2.0,<1.3.0
       # nn
-      - torch >=1.8.0,<2.0.0
-      - torchvision >=0.9.0,<0.15.0
-      - opacus >=1.2.0,<1.3.0
+      # torch 2.x recently released (2023-03) and not yet supported by some deps including: opacus, declearn
+      - torch ~=1.13.0
+      - torchvision >=0.14.0,<0.15.0
+      - opacus >=1.4.0,<1.5.0
       - monai >=1.1.0,<1.2.0
       # other
       - msgpack ~=1.0
       - persist-queue >=0.5.1,<0.6.0
       - pytorch-ignite >=0.4.4,<0.5.0
-      - pandas >=1.2.3,<2.0.0
-      - openpyxl >= 3.0.9,<3.1
-      - JSON-log-formatter
-      - python-minifier ==2.5.0
+      # pandas 2.x recently released (2023-04) but few breaking changes
+      - pandas ~=2.0.1
+      - python-minifier ~=2.5.0
       # FLamby
       - git+https://github.com/owkin/FLamby@main
       # declearn
-      - declearn[torch] ~= 2.1.0
+      - declearn[torch] ~=2.1.0
       - gmpy2 >=2.1,< 2.2
 #### Notebook-specific packages ####
 # This section contains packages that are needed only to run specific notebooks
-      - unet == 0.7.7
+      - unet >=0.7.7,<0.8.0

--- a/envs/development/conda/fedbiomed-researcher-macosx.yaml
+++ b/envs/development/conda/fedbiomed-researcher-macosx.yaml
@@ -1,7 +1,6 @@
 #
 # environment for fedbiomed-researcher on macosx
 #
-# it fixes a pb with tensorboard and torch for macosx
 #
 #
 name: fedbiomed-researcher
@@ -11,57 +10,61 @@ channels:
 
 dependencies:
   # minimal environment
-  - python >=3.9,<3.10
-  - pip
-  - jupyter
-  - ipython
+  - python >=3.10,<3.11
+  - pip >= 23.0
+  # TODO: consider migrating for classical notebooks to notebook7 or jupyterlab
+  # https://jupyter-notebook.readthedocs.io/en/latest/migrate_to_notebook7.html
+  - jupyter ~=1.0.0
+  - ipython ~=8.13.2
   # tests
-  - pytest >6.2.2
-  - tinydb >=4.4.0,<5.0.0
-  - tabulate >=0.8.9,<0.9.0
-  - nose
-  - coverage
+  - pytest ~=7.2.0
+  - pytest-cov ~=4.1.0
+  - tinydb ~=4.7.1
+  - tabulate >=0.9.0,<0.10.0
   # tools
-  - colorama
-  - pyyaml
+  - colorama >=0.4.6,<0.5
   # code
-  - GitPython >=3.1.14,<4.0.0
-  - requests >=2.25.1,<3.0.0
-  - paho-mqtt >=1.5.1,<2.0.0
-  - validators >=0.18.2,<0.19.0
-  - tqdm >=4.59.0,<5.0.0
-  - git
-  - packaging >=23.0,<24.0
+  - requests ~=2.29.0
+  - paho-mqtt ~=1.6.1
+  - validators >=0.20.0,<0.21.0
+  - git ~=2.40.1
+  - packaging ~=23.1
   # these two have to be aligned
-  - cryptography ~=39.0
-  - pyopenssl ~=23.0
-  # git notebook striper
-  - nbstripout
-  - joblib >=1.0.1
-  # nn
+  - cryptography ~=40.0.0
+  - pyopenssl ~=23.1.1
+  # git notebook striper - TODO: consider removing if not used anymore ...
+  - nbstripout >=0.6.1,<0.7.0
+  - joblib >=1.2.0,<1.3.0
+  # other
   - pip:
+      # no itk available from conda for macosx-m1
+      - itk >=5.3.0,<5.4.0
+      # sklearn
+      #   + scipy >= 1.9 from conda-forge needs recent GLIBC thus causes issue 389 with many current systems
+      #   + another option is to install scipy from pip which supports older GLIBC
+      - scipy >=1.10.0,<1.11.0
+      - scikit-learn >=1.2.0,<1.3.0
       # nn
-      - torch >=1.8.0,<2.0.0
-      - torchvision >=0.9.0,<0.15.0
-      - opacus >=1.2.0,<1.3.0
+      # torch 2.x recently released (2023-03) and not yet supported by some deps including: opacus, declearn
+      - torch ~=1.13.0
+      - torchvision >=0.14.0,<0.15.0
+      - opacus >=1.4.0,<1.5.0
       - monai >=1.1.0,<1.2.0
       # other
       - msgpack ~=1.0
       - persist-queue >=0.5.1,<0.6.0
-      - pandas >=1.2.3,<2.0.0
-      - openpyxl >= 3.0.9,<3.1
-      - scikit-learn >=1.0.0,<1.1.0
-      - itk
-      - python-minifier ==2.5.0
-      - tensorboard
+      # pandas 2.x recently released (2023-04) but few breaking changes
+      - pandas ~=2.0.1
+      - tensorboard ~=2.13.0
+      - python-minifier ~=2.5.0
       # for nbconvert
-      - jupyter_contrib_nbextensions
-      - pathvalidate
+      - jupyter-contrib-nbextensions >=0.7.0,<0.8.0
+      - pathvalidate ~=3.0.0
       # FLamby
       - git+https://github.com/owkin/FLamby@main
       # declearn
-      - declearn[torch] ~= 2.1.0
+      - declearn[torch] ~=2.1.0
       - gmpy2 >=2.1,< 2.2
 #### Notebook-specific packages ####
 # This section contains packages that are needed only to run specific notebooks
-      - unet == 0.7.7
+      - unet >=0.7.7,<0.8.0

--- a/envs/development/conda/fedbiomed-researcher.yaml
+++ b/envs/development/conda/fedbiomed-researcher.yaml
@@ -10,63 +10,61 @@ channels:
 
 dependencies:
   # minimal environment
-  - python >=3.9,<3.10
-  - pip
-  - jupyter
-  - ipython
+  - python >=3.10,<3.11
+  - pip >= 23.0
+  # TODO: consider migrating for classical notebooks to notebook7 or jupyterlab
+  # https://jupyter-notebook.readthedocs.io/en/latest/migrate_to_notebook7.html
+  - jupyter ~=1.0.0
+  - ipython ~=8.13.2
   # tests
-  - pytest >6.2.2
-  - tinydb >=4.4.0,<5.0.0
-  - tabulate >=0.8.9,<0.9.0
-  - nose
-  - coverage
+  - pytest ~=7.2.0
+  - pytest-cov ~=4.1.0
+  - tinydb ~=4.7.1
+  - tabulate >=0.9.0,<0.10.0
   # tools
-  - colorama
-  - pyyaml
+  - colorama >=0.4.6,<0.5
   # code
-  - GitPython >=3.1.14,<4.0.0
-  - requests >=2.25.1,<3.0.0
-  - paho-mqtt >=1.5.1,<2.0.0
-  - validators >=0.18.2,<0.19.0
-  - tqdm >=4.59.0,<5.0.0
-  - git
-  - packaging >=23.0,<24.0
+  - requests ~=2.29.0
+  - paho-mqtt ~=1.6.1
+  - validators >=0.20.0,<0.21.0
+  - git ~=2.40.1
+  - packaging ~=23.1
   # these two have to be aligned
-  - cryptography ~=39.0
-  - pyopenssl ~=23.0
-  # git notebook striper
-  - nbstripout
-  - joblib >=1.0.1
-  # sklearn
-  #   scipy >= 1.9 from conda-forge needs recent GLIBC thus causes issue 389
-  #   with many current systems
-  #   another option is to install scipy from pip
-  - scipy >=1.8.0,<1.9.0
-  - scikit-learn >=1.0.0,<1.1.0
+  - cryptography ~=40.0.0
+  - pyopenssl ~=23.1.1
+  # git notebook striper - TODO: consider removing if not used anymore ...
+  - nbstripout >=0.6.1,<0.7.0
+  - joblib >=1.2.0,<1.3.0
   # other
-  - itk
   - pip:
+      # no itk available from conda for macosx-m1
+      - itk >=5.3.0,<5.4.0
+      # sklearn
+      #   + scipy >= 1.9 from conda-forge needs recent GLIBC thus causes issue 389 with many current systems
+      #   + another option is to install scipy from pip which supports older GLIBC
+      - scipy >=1.10.0,<1.11.0
+      - scikit-learn >=1.2.0,<1.3.0
       # nn
-      - torch >=1.8.0,<2.0.0
-      - torchvision >=0.9.0,<0.15.0
-      - opacus >=1.2.0,<1.3.0
+      # torch 2.x recently released (2023-03) and not yet supported by some deps including: opacus, declearn
+      - torch ~=1.13.0
+      - torchvision >=0.14.0,<0.15.0
+      - opacus >=1.4.0,<1.5.0
       - monai >=1.1.0,<1.2.0
       # other
       - msgpack ~=1.0
       - persist-queue >=0.5.1,<0.6.0
-      - pandas >=1.2.3,<2.0.0
-      - openpyxl >= 3.0.9,<3.1
-      - tensorboard
-      - JSON-log-formatter
-      - python-minifier ==2.5.0
+      # pandas 2.x recently released (2023-04) but few breaking changes
+      - pandas ~=2.0.1
+      - tensorboard ~=2.13.0
+      - python-minifier ~=2.5.0
       # for nbconvert
-      - jupyter_contrib_nbextensions
-      - pathvalidate
+      - jupyter-contrib-nbextensions >=0.7.0,<0.8.0
+      - pathvalidate ~=3.0.0
       # FLamby
       - git+https://github.com/owkin/FLamby@main
       # declearn
-      - declearn[torch] ~= 2.1.0
+      - declearn[torch] ~=2.1.0
       - gmpy2 >=2.1,< 2.2
 #### Notebook-specific packages ####
 # This section contains packages that are needed only to run specific notebooks
-      - unet == 0.7.7
+      - unet >=0.7.7,<0.8.0

--- a/envs/development/docker/docker-compose.yml
+++ b/envs/development/docker/docker-compose.yml
@@ -18,8 +18,8 @@ services:
     environment:
       - PRODUCTION=1
       - DJANGO_SUPERUSER_USERNAME=admin
-      - DJANGO_SUPERUSER_EMAIL=santiago-smith.silva-rincon@inria.fr
-      - DJANGO_SUPERUSER_PASSWORD=admin123
+      - DJANGO_SUPERUSER_EMAIL=admin@nowhere.foo
+      - DJANGO_SUPERUSER_PASSWORD=admin
     ports:
       - "8844:8000"
     volumes:

--- a/envs/development/docker/restful/build_files/Dockerfile
+++ b/envs/development/docker/restful/build_files/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM python:3.10-alpine
 ENV PYTHONUNBUFFERED 1
 
 # http restful server, expected on port 8844 by fedbiomed

--- a/envs/development/docker/restful/build_files/requirements.txt
+++ b/envs/development/docker/restful/build_files/requirements.txt
@@ -1,4 +1,4 @@
-django==3.1.7
-djangorestframework==3.12.2
-django-cleanup
-gunicorn
+django>=4.1.7,<4.2.0
+djangorestframework>=3.14.0,<3.15.0
+django-cleanup~=7.0.0
+gunicorn~=20.1.0

--- a/envs/development/docker/restful/run_mounts/app/fedbiomed/urls.py
+++ b/envs/development/docker/restful/run_mounts/app/fedbiomed/urls.py
@@ -26,14 +26,14 @@ urlpatterns = [
 from django.conf import settings
 from django.conf.urls.static import static
 from django.views.static import serve
-from django.conf.urls import url
+from django.urls import re_path
 
 
 # Serve files in production
 if not settings.DEBUG:
     urlpatterns += [
-        url(r'^media/(?P<path>.*)$', serve, {'document_root': settings.MEDIA_ROOT}),
-        url(r'^static/(?P<path>.*)$', serve, {'document_root': settings.STATIC_ROOT}),
+        re_path(r'^media/(?P<path>.*)$', serve, {'document_root': settings.MEDIA_ROOT}),
+        re_path(r'^static/(?P<path>.*)$', serve, {'document_root': settings.STATIC_ROOT}),
     ]
 else:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/envs/vpn/README.md
+++ b/envs/vpn/README.md
@@ -17,21 +17,21 @@ Which machine to use ?
 ## requirements
 
 Supported operating systems for using containers :
-  - tested on **Fedora 35**, should work for recent RedHat based Linux
-  - tested on **Ubuntu 20.04**, should work for recent Debian based Linux
-  - tested on recent **MacOS X**
-  - tested on **Windows 10** 21H2 with WSL2 using a Ubuntu-20.04 distribution, should work with most Windows 10/11 and other recent Linux distributions
+  - tested on **Fedora 38**, should work for recent RedHat based Linux
+  - should work for **Ubuntu 22.04 LTS** and recent Debian based Linux
+  - tested on recent **MacOS X** (12.6.6 and 13)
+  - should work on **Windows 11** with WSL2 using a Ubuntu-22.04 distribution
 
 Pre-requisites for using containers :
 
 * **`docker >= 20.10.0`** is needed to build mqtt, see [there](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2). With older docker version it fails with a `make: sh: Operation not permitted`
-* **`docker-compose` >= 1.27.0** is needed for extended file format for [GPU support in docker](https://docs.docker.com/compose/gpu-support/) even if you're not using GPU in container.
-  -  some distributions (eg Ubuntu 20.04) don't provide a package with a recent enough version.
-  - Type `docker-compose --version` to check installed version.
-  - You can use your usual package manager to  install up-to-date version (eg: `sudo apt-get update && sudo apt-get install docker-compose` for apt, `sudo dnf clean metadata && sudo dnf update docker-compose` for dnf).
-  - If no suitable package exist for your system, you can use [`docker-compose` install page](https://docs.docker.com/compose/install/).
+* **`docker compose` >= 2.0** is needed for extended file format for [GPU support in docker](https://docs.docker.com/compose/gpu-support/) even if you're not using GPU in container.
+  -  some distributions (eg Fedora 32) don't provide a package with a recent enough version.
+  - Type `docker compose version` to check installed version (if it gives an error and `docker-compose --version` succeeds then you have a compose v1 installed)
+  - You can use your usual package manager to  install up-to-date version (eg: `sudo apt-get update && sudo apt-get remove docker-compose && sudo apt-get install docker-compose-plugin` for apt, `sudo dnf clean metadata && sudo dnf remove docker-compose && sudo dnf update docker-compose-plugin` for dnf).
+  - If no suitable package exist for your system, you can use the [docker compose plugin install page](https://docs.docker.com/compose/install/linux/).
 
-Installation notes for Windows 10 with WSL2 Ubuntu-20.04:
+Installation notes for Windows 11 with WSL2 Ubuntu-22.04:
 * build of containers `mqtt` `restful` may fail in `cargo install` step with error `spurious network error [...] Timeout was reached`. This is due to bad name resolution of `crates.io` package respository with default WSL2 DNS configuration. If this happens connect to wsl (`wsl` from Windows command line tool), get admin privileges (`sudo bash`) and create a [`/etc/wsl.conf`](https://docs.microsoft.com/fr-fr/windows/wsl/wsl-config) file containing:
 ```bash
 [network]
@@ -65,7 +65,7 @@ Usually build each image separately when initializing each container (see after)
 ## **TODO**: check if we can use different id than the account building the images
 #
 ## when running on a single machine : build all needed containers at one time with
-#[user@laptop $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g')  docker-compose build base vpnserver mqtt restful basenode node gui researcher
+#[user@laptop $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g')  docker compose build base vpnserver mqtt restful basenode node gui researcher
 ```
 
 ### initializing vpnserver
@@ -75,8 +75,8 @@ Run this only at first launch of container or after cleaning :
 * build container
 ```bash
 [user@network $] cd ./envs/vpn/docker
-[user@network $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker-compose build base
-[user@network $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker-compose build vpnserver
+[user@network $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker compose build base
+[user@network $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker compose build vpnserver
 ```
 * set the VPN server public IP *VPN_SERVER_PUBLIC_ADDR*
 ```bash
@@ -85,11 +85,11 @@ Run this only at first launch of container or after cleaning :
 ```
 * launch container
 ```bash
-[user@network $] docker-compose up -d vpnserver
+[user@network $] docker compose up -d vpnserver
 ```
 * connect and generate config for components
 ```bash
-[user@network $] docker-compose exec vpnserver bash
+[user@network $] docker compose exec vpnserver bash
 [root@vpnserver-container #] python ./vpn/bin/configure_peer.py genconf management mqtt
 [root@vpnserver-container #] python ./vpn/bin/configure_peer.py genconf management restful
 [root@vpnserver-container #] python ./vpn/bin/configure_peer.py genconf node NODETAG
@@ -99,7 +99,7 @@ Run this only at first launch of container or after cleaning :
 Run this for all launches of the container :
 * launch container
 ```bash
-[user@network $] docker-compose up -d vpnserver
+[user@network $] docker compose up -d vpnserver
 ```
 
 ### initializing mqtt
@@ -109,7 +109,7 @@ Run this only at first launch of container or after cleaning :
 * build container
 ```bash
 [user@network $] cd ./envs/vpn/docker
-[user@network $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g')  docker-compose build mqtt
+[user@network $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g')  docker compose build mqtt
 ```
 * generate VPN client for this container (see above in vpnserver)
 * configure the VPN client for this container
@@ -119,30 +119,30 @@ Run this only at first launch of container or after cleaning :
 ```
 * launch container
 ```bash
-[user@network $] docker-compose up -d mqtt
+[user@network $] docker compose up -d mqtt
 ```
 * retrieve the *publickey*
 ```bash
-[user@network $] docker-compose exec mqtt wg show wg0 public-key
+[user@network $] docker compose exec mqtt wg show wg0 public-key
 ```
 * connect to the VPN server to declare the container as a VPN client with cut-paste of *publickey*
 ```bash
-[user@network $] docker-compose exec vpnserver python ./vpn/bin/configure_peer.py add management mqtt *publickey*
+[user@network $] docker compose exec vpnserver python ./vpn/bin/configure_peer.py add management mqtt *publickey*
 ## other option :
-#[user@network $] docker-compose exec vpnserver bash
+#[user@network $] docker compose exec vpnserver bash
 #[root@vpnserver-container #] python ./vpn/bin/configure_peer.py add management mqtt *publickey*
 ```
 * check the container correctly established a VPN with vpnserver:
 ```bash
 # 10.220.0.1 is vpnserver contacted inside the VPN
 # it should answer to the ping
-[user@network $] docker-compose exec mqtt ping -c 3 -W 1 10.220.0.1
+[user@network $] docker compose exec mqtt ping -c 3 -W 1 10.220.0.1
 ```
 
 Run this for all launches of the container :
 * launch container
 ```bash
-[user@network $] docker-compose up -d mqtt
+[user@network $] docker compose up -d mqtt
 ```
 
 ### initializing restful
@@ -152,7 +152,7 @@ Run this only at first launch of container or after cleaning :
 * build container
 ```bash
 [user@network $] cd ./envs/vpn/docker
-[user@network $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g')  docker-compose build restful
+[user@network $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g')  docker compose build restful
 ```
 * generate VPN client for this container (see above in vpnserver)
 * configure the VPN client for this container
@@ -162,27 +162,27 @@ Run this only at first launch of container or after cleaning :
 ```
 * launch container
 ```bash
-[user@network $] docker-compose up -d restful
+[user@network $] docker compose up -d restful
 ```
 * retrieve the *publickey*
 ```bash
-[user@network $] docker-compose exec restful wg show wg0 public-key
+[user@network $] docker compose exec restful wg show wg0 public-key
 ```
 * connect to the VPN server to declare the container as a VPN client with cut-paste of *publickey*
 ```bash
-[user@network $] docker-compose exec vpnserver python ./vpn/bin/configure_peer.py add management restful *publickey*
+[user@network $] docker compose exec vpnserver python ./vpn/bin/configure_peer.py add management restful *publickey*
 ```
 * check the container correctly established a VPN with vpnserver:
 ```bash
 # 10.220.0.1 is vpnserver contacted inside the VPN
 # it should answer to the ping
-[user@network $] docker-compose exec restful ping -c 3 -W 1 10.220.0.1
+[user@network $] docker compose exec restful ping -c 3 -W 1 10.220.0.1
 ```
 
 Run this for all launches of the container :
 * launch container
 ```bash
-[user@network $] docker-compose up -d restful
+[user@network $] docker compose up -d restful
 ```
 
 ### initializing node
@@ -197,13 +197,13 @@ Run this only at first launch of container or after cleaning :
 
 * build container
 ```bash
-[user@node $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker-compose build basenode
-[user@node $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker-compose build node
+[user@node $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker compose build basenode
+[user@node $] MPSPDZ_URL="$(grep -A 2 modules/MP-SPDZ ../../../.gitmodules | grep 'url =' | awk '{ print $3 }')" MPSPDZ_COMMIT="$(cd ../../../modules ; git ls-tree HEAD | grep MP-SPDZ | awk '{ print $3 }')" CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker compose build node
 ```
   Alternative: build an (thiner) image without GPU support if you will never use it 
 ```bash
-[user@build $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker-compose build basenode-no-gpu
-[user@build $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker-compose build node
+[user@build $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker compose build basenode-no-gpu
+[user@build $] MPSPDZ_URL="$(grep -A 2 modules/MP-SPDZ ../../../.gitmodules | grep 'url =' | awk '{ print $3 }')" MPSPDZ_COMMIT="$(cd ../../../modules ; git ls-tree HEAD | grep MP-SPDZ | awk '{ print $3 }')" CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker compose build node
 ```
 
 Then follow the common instructions for nodes (below).
@@ -228,13 +228,13 @@ On the build machine
 * in this example, we build the container with user `fedbiomed` (id `1234`) and group `fedbiomed` (id `1234`). Account name and id used on the node machine may differ (see below).
 * build container
 ```bash
-[user@build $] CONTAINER_UID=1234 CONTAINER_GID=1234 CONTAINER_USER=fedbiomed CONTAINER_GROUP=fedbiomed docker-compose build basenode
-[user@build $] CONTAINER_UID=1234 CONTAINER_GID=1234 CONTAINER_USER=fedbiomed CONTAINER_GROUP=fedbiomed docker-compose build node
+[user@build $] CONTAINER_UID=1234 CONTAINER_GID=1234 CONTAINER_USER=fedbiomed CONTAINER_GROUP=fedbiomed docker compose build basenode
+[user@build $] MPSPDZ_URL="$(grep -A 2 modules/MP-SPDZ ../../../.gitmodules | grep 'url =' | awk '{ print $3 }')" MPSPDZ_COMMIT="$(cd ../../../modules ; git ls-tree HEAD | grep MP-SPDZ | awk '{ print $3 }')" CONTAINER_UID=1234 CONTAINER_GID=1234 CONTAINER_USER=fedbiomed CONTAINER_GROUP=fedbiomed docker compose build node
 ```
   Alternative: build an (thiner) image without GPU support if you will never use it 
 ```bash
-[user@build $] CONTAINER_UID=1234 CONTAINER_GID=1234 CONTAINER_USER=fedbiomed CONTAINER_GROUP=fedbiomed docker-compose build basenode-no-gpu
-[user@build $] CONTAINER_UID=1234 CONTAINER_GID=1234 CONTAINER_USER=fedbiomed CONTAINER_GROUP=fedbiomed docker-compose build node
+[user@build $] CONTAINER_UID=1234 CONTAINER_GID=1234 CONTAINER_USER=fedbiomed CONTAINER_GROUP=fedbiomed docker compose build basenode-no-gpu
+[user@build $] MPSPDZ_URL="$(grep -A 2 modules/MP-SPDZ ../../../.gitmodules | grep 'url =' | awk '{ print $3 }')" MPSPDZ_COMMIT="$(cd ../../../modules ; git ls-tree HEAD | grep MP-SPDZ | awk '{ print $3 }')" CONTAINER_UID=1234 CONTAINER_GID=1234 CONTAINER_USER=fedbiomed CONTAINER_GROUP=fedbiomed docker compose build node
 ```
 * save image for container
 ```bash
@@ -244,7 +244,7 @@ On the build machine
 ```bash
 [user@build $] cd ./envs/vpn/docker
 # if needed, clean the configurations in ./node/run_mounts before
-[user@build $] tar cvzf /tmp/vpn-node-files.tar.gz ./docker-compose_run_node.yml ./node/run_mounts
+[user@build $] tar cvzf /tmp/vpn-node-files.tar.gz ./docker compose_run_node.yml ./node/run_mounts
 ```
 
 On the node machine
@@ -259,7 +259,7 @@ On the node machine
 [user@node $] mkdir -p ./envs/vpn/docker
 [user@node $] cd ./envs/vpn/docker
 [user@node $] tar xvzf /tmp/vpn-node-files.tar.gz
-[user@node $] mv docker-compose_run_node.yml docker-compose.yml
+[user@node $] mv docker compose_run_node.yml docker compose.yml
 ```
 * if needed load data to be passed to container
 ```bash
@@ -290,28 +290,28 @@ Run this only at first launch of container or after cleaning :
 * launch container
 ```bash
 [user@node $] NODE=node
-[user@node $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker-compose up -d $NODE
+[user@node $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker compose up -d $NODE
 ```
 Alternative: launch container with Nvidia GPU support activated. Before launching, install [all the pre-requisites for GPU support](#gpu-support-in-container).
 ```bash
 [user@node $] NODE=node-gpu
-[user@node $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker-compose up -d $NODE
+[user@node $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker compose up -d $NODE
 ```
   * note : `CONTAINER_{UID,GID,USER,GROUP}` are not necessary if using the same identity as in for the build, but they need to have a read/write access to the directories mounted from the host machine's filesystem.
-  * note : when using a different identity than at build time, `docker-compose up` may take up to a few dozen seconds to complete and node be ready for using. This is the time for re-assigning some installed resources in the container to the new account.
+  * note : when using a different identity than at build time, `docker compose up` may take up to a few dozen seconds to complete and node be ready for using. This is the time for re-assigning some installed resources in the container to the new account.
 * retrieve the *publickey*
 ```bash
-[user@node $] docker-compose exec $NODE wg show wg0 public-key
+[user@node $] docker compose exec $NODE wg show wg0 public-key
 ```
 * connect to the VPN server to declare the container as a VPN client with cut-paste of *publickey*
 ```bash
-[user@network $] docker-compose exec vpnserver python ./vpn/bin/configure_peer.py add node NODETAG *publickey*
+[user@network $] docker compose exec vpnserver python ./vpn/bin/configure_peer.py add node NODETAG *publickey*
 ```
 * check the container correctly established a VPN with vpnserver:
 ```bash
 # 10.220.0.1 is vpnserver contacted inside the VPN
 # it should answer to the ping
-[user@node $] docker-compose exec $NODE ping -c 3 -W 1 10.220.0.1
+[user@node $] docker compose exec $NODE ping -c 3 -W 1 10.220.0.1
 ```
 
 Run this for all launches of the container :
@@ -319,12 +319,12 @@ Run this for all launches of the container :
 * launch container
 ```bash
 # `CONTAINER_{UID,GID,USER,GROUP}` are not needed if they are the same as used for build
-[user@node $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker-compose up -d $NODE
+[user@node $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker compose up -d $NODE
 ```
 * TODO: better package/scripting needed
   Connect again to the node and launch manually, now that the VPN is established
 ```bash
-[user@node $] docker-compose exec -u $(id -u) $NODE bash
+[user@node $] docker compose exec -u $(id -u) $NODE bash
 # TODO : make more general by including it in the VPN configuration and user environment ?
 # TODO : create scripts in VPN environment
 # need proper parameters at first launch to create configuration file
@@ -389,7 +389,7 @@ Run this only at first launch of container or after cleaning :
 
 * build container
 ```bash
-[user@node $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker-compose build gui
+[user@node $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker compose build gui
 ```
 
 #### specific instructions: building gui image on a different machine
@@ -411,7 +411,7 @@ On the build machine
 * in this example, we build the container with user `fedbiomed` (id `1234`) and group `fedbiomed` (id `1234`). Account name and id used on the node machine may differ (see below).
 * build container
 ```bash
-[user@build $] CONTAINER_UID=1234 CONTAINER_GID=1234 CONTAINER_USER=fedbiomed CONTAINER_GROUP=fedbiomed docker-compose build gui
+[user@build $] CONTAINER_UID=1234 CONTAINER_GID=1234 CONTAINER_USER=fedbiomed CONTAINER_GROUP=fedbiomed docker compose build gui
 ```
 * save image for container
 ```bash
@@ -440,10 +440,10 @@ Run this for all launches of the container :
 
 * launch container
 ```bash
-[user@node $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker-compose up -d gui
+[user@node $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker compose up -d gui
 ```
   * note : `CONTAINER_{UID,GID,USER,GROUP}` are not necessary if using the same identity as in for the build, but they need to have a read/write access to the directories mounted from the node machine's filesystem.
-  * note : when using a different identity than at build time, `docker-compose up` may take up to a few dozen seconds to complete and node be ready for using. This is the time for re-assigning some installed resources in the container to the new account.
+  * note : when using a different identity than at build time, `docker compose up` may take up to a few dozen seconds to complete and node be ready for using. This is the time for re-assigning some installed resources in the container to the new account.
 
 
 #### using the gui
@@ -454,7 +454,7 @@ Use the node gui from outside the gui container :
 By default, only connections from `localhost` are authorized. To enable connection to the GUI from any IP address
   - specify the bind IP address at container launch time (eg: your node public IP address `NODE_IP`, or `0.0.0.0` to listen on all node addresses)
 ```bash
-[user@node $] GUI_SERVER_IP=0.0.0.0 docker-compose up -d gui
+[user@node $] GUI_SERVER_IP=0.0.0.0 docker compose up -d gui
 ```
   - connect to `http://${NODE_IP}:8484`
   - **warning** allowing connections from non-`localhost` exposes the gui to attacks from the network. Only use with proper third party security measures (web proxy, firewall, etc.) Currently, the provided gui container does not include a user authentication mechanism or encrypted communications for the user.
@@ -467,8 +467,8 @@ Run this only at first launch of container or after cleaning :
 
 * build container
 ```bash
-[user@researcher $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker-compose build base
-[user@researcher $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker-compose build researcher
+[user@researcher $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker compose build base
+[user@researcher $] MPSPDZ_URL="$(grep -A 2 modules/MP-SPDZ ../../../.gitmodules | grep 'url =' | awk '{ print $3 }')" MPSPDZ_COMMIT="$(cd ../../../modules ; git ls-tree HEAD | grep MP-SPDZ | awk '{ print $3 }')" CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker compose build researcher
 ```
 * generate VPN client for this container (see above in vpnserver)
 * configure the VPN client for this container
@@ -482,21 +482,21 @@ Run this only at first launch of container or after cleaning :
 ```
 * launch container
 ```bash
-[user@researcher $] docker-compose up -d researcher
+[user@researcher $] docker compose up -d researcher
 ```
 * retrieve the *publickey*
 ```bash
-[user@researcher $] docker-compose exec researcher wg show wg0 public-key
+[user@researcher $] docker compose exec researcher wg show wg0 public-key
 ```
 * connect to the VPN server to declare the container as a VPN client with cut-paste of *publickey*
 ```bash
-[user@network $] docker-compose exec vpnserver python ./vpn/bin/configure_peer.py add researcher researcher1 *publickey*
+[user@network $] docker compose exec vpnserver python ./vpn/bin/configure_peer.py add researcher researcher1 *publickey*
 ```
 * check the container correctly established a VPN with vpnserver:
 ```bash
 # 10.220.0.1 is vpnserver contacted inside the VPN
 # it should answer to the ping
-[user@researcher $] docker-compose exec researcher ping -c 3 -W 1 10.220.0.1
+[user@researcher $] docker compose exec researcher ping -c 3 -W 1 10.220.0.1
 ```
 
 Run this for all launches of the container :
@@ -504,7 +504,7 @@ Run this for all launches of the container :
 * TODO: better package/scripting needed
   Connect again to the researcher and launch manually, now that the VPN is established
 ```bash
-[user@researcher $] docker-compose exec -u $(id -u) researcher bash
+[user@researcher $] docker compose exec -u $(id -u) researcher bash
 # TODO : make more general by including it in the VPN configuration and user environment ?
 # TODO : create scripts in VPN environment
 # need proper parameters at first launch to create configuration file
@@ -545,7 +545,7 @@ tensorboard --logdir "$tensorboard_dir"
 To enable connection to the researcher and the tensorboard from any IP address using `RESEARCHER_HOST`
   - specify the bind IP address at container launch time (eg: your server public IP address `SERVER_IP`, or `0.0.0.0` to listen on all server addresses)
 ```bash
-[user@researcher $] RESEARCHER_HOST=${SERVER_IP} docker-compose up -d researcher
+[user@researcher $] RESEARCHER_HOST=${SERVER_IP} docker compose up -d researcher
 ```
   - connect to `http://${SERVER_IP}:8888` and `http://${SERVER_IP}:6006`
   - **warning** allowing connections from non-`localhost` exposes the researcher to attacks from the network. Only use with proper third party security measures (web proxy, firewall, etc.) Currently, the provided researcher container does not include a user authentication mechanism or encrypted communications for the user.
@@ -570,38 +570,30 @@ You can access the host machine GPU accelerator from a node container to speed u
 
 Before using a GPU for Fed-BioMed in a `node` docker container, you need to meet the requirements for the host machine:
 
-* a **Nvidia GPU** recent enough (**`Kepler` or newer** generation) to support `450.x` Nvidia drivers that are needed for CUDA 11.x
+* a **Nvidia GPU** recent enough (**`Maxwell` or newer** generation) to support `>=525.60.13` Nvidia drivers that are needed for CUDA 12.1.1 (used in containers)
   Recommended GPU memory is **>= 4GB or more** depending on your training plans size.
 * a **supported operating system**
-  - tested on **Fedora 35**, should work for recent RedHat based Linux
-  - partly tested on **Ubuntu 20.04**, should work for recent Debian based Linux
-  - not tested on Windows with WSL2, but should work with Windows 10 version 21H2 or higher, that [support GPU in WSL2](https://docs.microsoft.com/en/windows/wsl/tutorials/gpu-compute)
+  - tested on **Fedora 38**, should work for recent RedHat based Linux
+  - should work for **Ubuntu 22.04 LTS** and other recent Debian based Linux
+  - not tested on Windows with WSL2, but should work with Windows 11, that [support GPU in WSL2](https://docs.microsoft.com/en/windows/wsl/tutorials/gpu-compute)
   - not supported on MacOS (few Nvidia cards, docker virtualized)
-* **Nvidia drivers and CUDA >= 11.5.0** (the version used by Fed-BioMed container with GPU support)
+* **Nvidia drivers >=525.60.13** (for CUDA 12.1.1 support, the version used in Fed-BioMed container with GPU support)
 * **[Nvidia container toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)**
-* **`docker-compose` version >= 1.27.0** (already installed for container support)
+* **`docker compose` version >= 2.0** (already installed for container support)
 
 
 Installation guidelines for requirements:
 
-* Nvidia drivers and CUDA: Type `nvidia-smi` to check driver version installed. You can use your usual package manager (`apt`, `dnf`) or [nvidia CUDA toolkit](https://developer.nvidia.com/cuda-downloads) download. In both cases, commands depend on your machine configuration.
-* Nvidia container toolkit: check list of supported systems and [specific instructions](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html). First enable the repository, then install the package (eg: `sudo apt-get update && sudo apt-get install nvidia-docker2` on Ubuntu/Debian, `sudo dnf install nvidia-docker2` on CentOS).
-  - if your system version is not supported, you can try to use an approaching version. For example, for Fedora 35 we installed and ran the CentOS 8 version with:
-```bash
-distribution=centos8
-curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.repo | \
-  sudo tee /etc/yum.repos.d/nvidia-docker.repo
-sudo dnf install nvidia-docker2
-```
-
+* Nvidia drivers: Type `nvidia-smi` to check driver version installed. You can use your usual package manager (`apt`, `dnf`). Exact command depends on your machine configuration.
+* Nvidia container toolkit: check list of supported systems and [specific instructions](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html). First enable the repository, as root, then install the package (eg: `sudo apt-get update && sudo apt-get install nvidia-container-toolkit` on Ubuntu/Debian, `sudo dnf install nvidia-container-toolkit` on Fedora). Then configure and relaunch the docker daemon: `nvidia-ctk runtime configure --runtime=docker && systemctl restart docker`.
 
 FAQ for issues with GPU in containers :
-* `docker-compose` file format error when launching any container :
+* `docker compose` file format error when launching any container :
 ```bash
 ERROR: The Compose file './docker-compose.yml' is invalid because:
 Unsupported config option for services.node-gpu-other: 'runtime'
 ```
-  - you need to update you `docker-compose` version
+  - you need to update you `docker compose` version
 * `runtime` error when launching `node-gpu` container :
 ```bash
 ERROR: for node-gpu  Cannot create container for service node-gpu:
@@ -623,20 +615,20 @@ You can connect to a container only if the corresponding container is already ru
 
 * connect on the VPN server / node / mqtt server / restful as root to configure the VPN
 ```bash
-[user@network $] docker-compose exec vpnserver bash
-[user@network $] docker-compose exec mqtt bash
-[user@network $] docker-compose exec restful bash
-[user@node $] docker-compose exec node bash
-[user@researcher $] docker-compose exec researcher bash
+[user@network $] docker compose exec vpnserver bash
+[user@network $] docker compose exec mqtt bash
+[user@network $] docker compose exec restful bash
+[user@node $] docker compose exec node bash
+[user@researcher $] docker compose exec researcher bash
 ```
 * connect on the node as user to handle experiments
 ```bash
-[user@node $] docker-compose exec -u $(id -u) node bash
-[user@node $] docker-compose exec -u $(id -u) gui bash
-[user@researcher $] docker-compose exec -u $(id -u) researcher bash
+[user@node $] docker compose exec -u $(id -u) node bash
+[user@node $] docker compose exec -u $(id -u) gui bash
+[user@researcher $] docker compose exec -u $(id -u) researcher bash
 ```
 
-Note : can also use commands in the form, so you don't have to be in the docker-compose file directory
+Note : can also use commands in the form, so you don't have to be in the docker compose file directory
 ```bash
 [user@node $] docker container exec -ti -u $(id -u) fedbiomed-vpn-node bash
 [user@node $] docker container exec -ti -u $(id -u) fedbiomed-vpn-gui bash
@@ -651,7 +643,7 @@ Note : can also use commands in the form, so you don't have to be in the docker-
 [user@network $] cd ./envs/vpn/docker
 
 # level 1 : container instance
-[user@network $] docker-compose rm -sf vpnserver
+[user@network $] docker compose rm -sf vpnserver
 
 # level 2 : configuration
 [user@network #] rm -rf vpnserver/run_mounts/config/{config.env,config_peers,ip_assign,wireguard}
@@ -667,7 +659,7 @@ Note : can also use commands in the form, so you don't have to be in the docker-
 [user@network $] cd ./envs/vpn/docker
 
 # level 1 : container instance
-[user@network $] docker-compose rm -sf mqtt
+[user@network $] docker compose rm -sf mqtt
 
 # level 2 : configuration
 [user@network $] rm -rf ./mqtt/run_mounts/config/{config.env,wireguard}
@@ -683,7 +675,7 @@ Note : can also use commands in the form, so you don't have to be in the docker-
 [user@network $] cd ./envs/vpn/docker
 
 # level 1 : container instance
-[user@network $] docker-compose rm -sf restful
+[user@network $] docker compose rm -sf restful
 
 # level 2 : configuration
 [user@network $] rm -rf ./restful/run_mounts/config/{config.env,wireguard}
@@ -703,7 +695,7 @@ Note : can also use commands in the form, so you don't have to be in the docker-
 [user@node $] cd ./envs/vpn/docker
 
 # level 1 : container instance
-[user@node $] docker-compose rm -sf node
+[user@node $] docker compose rm -sf node
 
 # level 2 : configuration
 [user@node $] rm -rf ./node/run_mounts/config/{config.env,wireguard}
@@ -722,7 +714,7 @@ Note : can also use commands in the form, so you don't have to be in the docker-
 [user@node $] cd ./envs/vpn/docker
 
 # level 1 : container instance
-[user@node $] docker-compose rm -sf gui
+[user@node $] docker compose rm -sf gui
 
 # level 2 : configuration
 [user@node $] rm -rf ./node/run_mounts/{data,etc,var}/*
@@ -740,7 +732,7 @@ Same as node
 [user@researcher $] cd ./envs/vpn/docker
 
 # level 1 : container instance
-[user@researcher $] docker-compose rm -sf researcher
+[user@researcher $] docker compose rm -sf researcher
 
 # level 2 : configuration
 [user@researcher $] rm -rf ./researcher/run_mounts/config/{config.env,wireguard}
@@ -771,8 +763,8 @@ Peers in VPN server can be listed or removed through `configure_peer.py`.
 Following code snippet will generate configurations for `mqtt` and `restful` component register their public keys in 
 VPN server. 
 ```bash
-[user@network $] docker-compose up -d vpnserver
-[user@network $] docker-compose exec vpnserver bash
+[user@network $] docker compose up -d vpnserver
+[user@network $] docker compose exec vpnserver bash
 [root@vpnserver-container #] python ./vpn/bin/configure_peer.py genconf management mqtt
 [root@vpnserver-container #] python ./vpn/bin/configure_peer.py genconf management restful
 [root@vpnserver-container #] python ./vpn/bin/configure_peer.py add management mqtt 1OIHVWcDq5+CaDKrQ3G3QAuVnr41ONVFBto1ylBroZg=
@@ -833,6 +825,6 @@ Different values at build time and runtime is also supported by `vpnserver` `mqt
 
 Example : build a researcher container with a default user/group `fedbiomed` (id `1234`), run it with the same account as the account on the researcher machine.
 ```bash
-[user@researcher $] CONTAINER_UID=1234 CONTAINER_GID=1234 CONTAINER_USER=fedbiomed CONTAINER_GROUP=fedbiomed docker-compose build researcher
-[user@researcher $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker-compose up -d researcher
+[user@researcher $] MPSPDZ_URL="$(grep -A 2 modules/MP-SPDZ ../../../.gitmodules | grep 'url =' | awk '{ print $3 }')" MPSPDZ_COMMIT="$(cd ../../../modules ; git ls-tree HEAD | grep MP-SPDZ | awk '{ print $3 }')" CONTAINER_UID=1234 CONTAINER_GID=1234 CONTAINER_USER=fedbiomed CONTAINER_GROUP=fedbiomed docker compose build researcher
+[user@researcher $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker compose up -d researcher
 ```

--- a/envs/vpn/conda/fedbiomed-gui.yaml
+++ b/envs/vpn/conda/fedbiomed-gui.yaml
@@ -7,44 +7,46 @@ name: fedbiomed-gui
 
 channels:
   - conda-forge
-  
+
 dependencies:
   # common
-  - python >=3.9,<3.10
-  - nodejs == 16.13.1
-  - yarn >=1.22.19,<=1.22.99
-  - pip
-  - ipython
-  - flask >= 2.0.0,<2.0.2
-  - paho-mqtt >=1.5.1,<2.0.0
+  - python >=3.10,<3.11
+  - nodejs ~=18.15.0
+  - yarn >=3.5.1,<3.6
+  - pip >= 23.0
+  - ipython ~=8.13.2
+  - flask >= 2.3.2,<2.4.0
+  - paho-mqtt ~=1.6.1
   # tests
-  - tinydb >=4.4.0,<5.0.0
-  - tabulate >=0.8.9,<0.9.0
-  - jsonschema >=4.2.0,< 4.2.1
-  - requests >=2.25.1,<3.0.0
-  - git
-  - packaging >=23.0,<24.0
+  - tinydb ~=4.7.1
+  - tabulate >=0.9.0,<0.10.0
+  - jsonschema >=4.17.3,<4.18.0
+  - requests ~=2.29.0
+  - git ~=2.40.1
+  - packaging ~=23.1
   # these two have to be aligned
   - cryptography ~=39.0
   - pyopenssl ~=23.0
-  # sklearn
-  #   scipy >= 1.9 from conda-forge needs recent GLIBC thus causes issue 389
-  #   with many current systems
-  #   another option is to install scipy from pip
-  - scipy >=1.8.0,<1.9.0
-  - scikit-learn >=1.0.0,<1.1.0
-  - itk
+  # other
+  - itk >=5.3.0,<5.4.0
   - pip:
+      # sklearn
+      #   + scipy >= 1.9 from conda-forge needs recent GLIBC thus causes issue 389 with many current systems
+      #   + another option is to install scipy from pip which supports older GLIBC
+      - scipy >=1.10.0,<1.11.0
+      - scikit-learn >=1.2.0,<1.3.0
       # nn
-      - torch >=1.8.0,<2.0.0
-      - torchvision >=0.9.0,<0.15.0
+      # torch 2.x recently released (2023-03) and not yet supported by some deps including: opacus, declearn
+      - torch ~=1.13.0
+      - torchvision >=0.14.0,<0.15.0
       - monai >=1.1.0,<1.2.0
       # other
-      - gunicorn >=20.1, <20.9
-      - pandas >=1.2.3,<2.0.0
-      - cachelib == 0.7.0
-      - python-minifier ==2.5.0
-      - PyJWT == 2.4.0
-      - Flask-JWT-Extended == 4.4.2
+      - gunicorn ~=20.1.0
+      # pandas 2.x recently released (2023-04) but few breaking changes
+      - pandas ~=2.0.1
+      - cachelib >=0.10.2,<0.11.0
+      - python-minifier ~=2.5.0
+      - PyJWT >=2.7.0,<2.8.0
+      - Flask-JWT-Extended >=4.4.4,<4.5.0
       # FLamby
       - git+https://github.com/owkin/FLamby@main

--- a/envs/vpn/conda/fedbiomed-node.yaml
+++ b/envs/vpn/conda/fedbiomed-node.yaml
@@ -10,56 +10,54 @@ channels:
 
 dependencies:
   # minimal environment
-  - python >=3.9,<3.10
-  - pip
-  - jupyter
-  - ipython
+  # python 3.11 recently released 2022-11 and not yet supported by some deps including: torchvision
+  - python >=3.10,<3.11
+  - pip >= 23.0
+  # ipython currently used by febiomed.common.utils
+  - ipython ~=8.13.2
   # tests
-  - pytest >6.2.2
-  - tinydb >=4.4.0,<5.0.0
-  - tabulate >=0.8.9,<0.9.0
+  - pytest ~=7.2.0
+  - pytest-cov ~=4.1.0
+  - tinydb ~=4.7.1
+  - tabulate >=0.9.0,<0.10.0
   # code
-  - GitPython >=3.1.14,<4.0.0
-  - requests >=2.25.1,<3.0.0
-  - paho-mqtt >=1.5.1,<2.0.0
-  - validators >=0.18.2,<0.19.0
-  - tqdm >=4.59.0,<5.0.0
-  - git
-  - packaging >=23.0,<24.0
+  - requests ~=2.29.0
+  - paho-mqtt ~=1.6.1
+  - validators >=0.20.0,<0.21.0
+  - git ~=2.40.1
+  - packaging ~=23.1
   # these two have to be aligned
-  - cryptography ~=39.0
-  - pyopenssl ~=23.0
-  # git notebook striper
-  - nbstripout
-  - joblib >=1.0.1
-  # sklearn
-  #   scipy >= 1.9 from conda-forge needs recent GLIBC thus causes issue 389
-  #   with many current systems
-  #   another option is to install scipy from pip
-  - scipy >=1.8.0,<1.9.0
-  - scikit-learn >=1.0.0,<1.1.0
+  - cryptography ~=40.0.0
+  - pyopenssl ~=23.1.1
+  #
+  - joblib >=1.2.0,<1.3.0
   # other
-  - itk
-  # nn
   - pip:
+      # no itk available from conda for macosx-m1
+      - itk >=5.3.0,<5.4.0
+      # sklearn
+      #   + scipy >= 1.9 from conda-forge needs recent GLIBC thus causes issue 389 with many current systems
+      #   + another option is to install scipy from pip which supports older GLIBC
+      - scipy >=1.10.0,<1.11.0
+      - scikit-learn >=1.2.0,<1.3.0
       # nn
-      - torch >=1.8.0,<2.0.0
-      - torchvision >=0.9.0,<0.15.0
-      - opacus >=1.2.0,<1.3.0
+      # torch 2.x recently released (2023-03) and not yet supported by some deps including: opacus, declearn
+      - torch ~=1.13.0
+      - torchvision >=0.14.0,<0.15.0
+      - opacus >=1.4.0,<1.5.0
       - monai >=1.1.0,<1.2.0
       # other
       - msgpack ~=1.0
       - persist-queue >=0.5.1,<0.6.0
       - pytorch-ignite >=0.4.4,<0.5.0
-      - pandas >=1.2.3,<2.0.0
-      - openpyxl >= 3.0.9,<3.1
-      - JSON-log-formatter
-      - python-minifier ==2.5.0
+      # pandas 2.x recently released (2023-04) but few breaking changes
+      - pandas ~=2.0.1
+      - python-minifier ~=2.5.0
       # FLamby
       - git+https://github.com/owkin/FLamby@main
       # declearn
-      - declearn[torch] ~= 2.0.1
+      - declearn[torch] ~=2.1.0
       - gmpy2 >=2.1,< 2.2
 #### Notebook-specific packages ####
 # This section contains packages that are needed only to run specific notebooks
-      - unet == 0.7.7
+      - unet >=0.7.7,<0.8.0

--- a/envs/vpn/conda/fedbiomed-researcher.yaml
+++ b/envs/vpn/conda/fedbiomed-researcher.yaml
@@ -10,63 +10,61 @@ channels:
 
 dependencies:
   # minimal environment
-  - python >=3.9,<3.10
-  - pip
-  - jupyter
-  - ipython
+  - python >=3.10,<3.11
+  - pip >= 23.0
+  # TODO: consider migrating for classical notebooks to notebook7 or jupyterlab
+  # https://jupyter-notebook.readthedocs.io/en/latest/migrate_to_notebook7.html
+  - jupyter ~=1.0.0
+  - ipython ~=8.13.2
   # tests
-  - pytest >6.2.2
-  - tinydb >=4.4.0,<5.0.0
-  - tabulate >=0.8.9,<0.9.0
-  - nose
-  - coverage
+  - pytest ~=7.2.0
+  - pytest-cov ~=4.1.0
+  - tinydb ~=4.7.1
+  - tabulate >=0.9.0,<0.10.0
   # tools
-  - colorama
-  - pyyaml
+  - colorama >=0.4.6,<0.5
   # code
-  - GitPython >=3.1.14,<4.0.0
-  - requests >=2.25.1,<3.0.0
-  - paho-mqtt >=1.5.1,<2.0.0
-  - validators >=0.18.2,<0.19.0
-  - tqdm >=4.59.0,<5.0.0
-  - git
-  - packaging >=23.0,<24.0
+  - requests ~=2.29.0
+  - paho-mqtt ~=1.6.1
+  - validators >=0.20.0,<0.21.0
+  - git ~=2.40.1
+  - packaging ~=23.1
   # these two have to be aligned
-  - cryptography ~=39.0
-  - pyopenssl ~=23.0
-  # git notebook striper
-  - nbstripout
-  - joblib >=1.0.1
-  # sklearn
-  #   scipy >= 1.9 from conda-forge needs recent GLIBC thus causes issue 389
-  #   with many current systems
-  #   another option is to install scipy from pip
-  - scipy >=1.8.0,<1.9.0
-  - scikit-learn >=1.0.0,<1.1.0
+  - cryptography ~=40.0.0
+  - pyopenssl ~=23.1.1
+  # git notebook striper - TODO: consider removing if not used anymore ...
+  - nbstripout >=0.6.1,<0.7.0
+  - joblib >=1.2.0,<1.3.0
   # other
-  - itk
   - pip:
+      # no itk available from conda for macosx-m1
+      - itk >=5.3.0,<5.4.0
+      # sklearn
+      #   + scipy >= 1.9 from conda-forge needs recent GLIBC thus causes issue 389 with many current systems
+      #   + another option is to install scipy from pip which supports older GLIBC
+      - scipy >=1.10.0,<1.11.0
+      - scikit-learn >=1.2.0,<1.3.0
       # nn
-      - torch >=1.8.0,<2.0.0
-      - torchvision >=0.9.0,<0.15.0
-      - opacus >=1.2.0,<1.3.0
+      # torch 2.x recently released (2023-03) and not yet supported by some deps including: opacus, declearn
+      - torch ~=1.13.0
+      - torchvision >=0.14.0,<0.15.0
+      - opacus >=1.4.0,<1.5.0
       - monai >=1.1.0,<1.2.0
       # other
       - msgpack ~=1.0
       - persist-queue >=0.5.1,<0.6.0
-      - pandas >=1.2.3,<2.0.0
-      - openpyxl >= 3.0.9,<3.1
-      - tensorboard
-      - JSON-log-formatter
-      - python-minifier ==2.5.0
+      # pandas 2.x recently released (2023-04) but few breaking changes
+      - pandas ~=2.0.1
+      - tensorboard ~=2.13.0
+      - python-minifier ~=2.5.0
       # for nbconvert
-      - jupyter_contrib_nbextensions
-      - pathvalidate
+      - jupyter-contrib-nbextensions >=0.7.0,<0.8.0
+      - pathvalidate ~=3.0.0
       # FLamby
       - git+https://github.com/owkin/FLamby@main
       # declearn
-      - declearn[torch] ~= 2.0.1
+      - declearn[torch] ~=2.1.0
       - gmpy2 >=2.1,< 2.2
 #### Notebook-specific packages ####
 # This section contains packages that are needed only to run specific notebooks
-      - unet == 0.7.7
+      - unet >=0.7.7,<0.8.0

--- a/envs/vpn/docker/base/build_files/Dockerfile
+++ b/envs/vpn/docker/base/build_files/Dockerfile
@@ -1,29 +1,26 @@
 # temporary builder image for wireguard tools
 # - need coherent system version with base image
-# - may need update for properly compiling boringtun (eg: cargo build package failing on `buster-slim`)
+# - may need update for properly compiling boringtun
+# - 2023-05: `bookworm` is not officially released, stick to `bullseye` for now
 FROM debian:bullseye-slim as builder
 
 RUN apt-get update && apt-get install -y git build-essential curl
 
 # install boringtun userspace implementation of wireguard
 # 
-# - match versions of debian & boringtun : 0.4.0 is now supported by bullseye with current system/cargo packages
-#   0.5.2 not yet supported
+# - match versions of debian & boringtun : up to date 0.5.2 compiles ok for bullseye, but could not have it working
+#   Continue with 0.4.0
 # - glitch: bullseye's apt-get cargo is too old vs boringtun's cargo packages dependencies, need to install
 #   up to date rust/cargo
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && . /root/.cargo/env && \
     cargo install --locked --bin boringtun --version ~0.4.0 boringtun
 
 # install needed wireguard-tools
-ENV WITH_WGQUICK=yes
-RUN git clone https://git.zx2c4.com/wireguard-tools && \
-    make -C wireguard-tools/src && \
-    make -C wireguard-tools/src install
-
+RUN apt-get install -y wireguard-tools
 
 # docker base image for VPN server, Fed-BioMed node and researcher
 # - need proper python version for Fed-BioMed
-FROM python:3.9-slim-bullseye
+FROM python:3.10-slim-bullseye
 
 RUN apt-get update && apt-get install -y iptables iproute2 iputils-ping bash vim net-tools procps build-essential kmod
 

--- a/envs/vpn/docker/basegpu/build_files/Dockerfile
+++ b/envs/vpn/docker/basegpu/build_files/Dockerfile
@@ -1,47 +1,27 @@
 # temporary builder image for wireguard tools
 # - need coherent system version with base image
 # - may need update for properly compiling boringtun
-FROM nvidia/cuda:11.5.0-base-ubuntu20.04 as builder
-
-# install wget though nvidia cuda linux gpg key is obsolete
-RUN apt-key del 7fa2af80 && apt-get update || true && apt install -y wget
-# update nvidia cuda linux gpg repository key
-# https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/
-RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb && \
-    dpkg -i cuda-keyring_1.0-1_all.deb && \
-    sed -i '/developer\.download\.nvidia\.com\/compute\/cuda\/repos/d' /etc/apt/sources.list && \
-    sed -i '/developer\.download\.nvidia\.com\/compute\/cuda\/repos/d' /etc/apt/sources.list.d/*
+# - 2023-05: `12.1.1-base-ubuntu22.04` is uptodate version 
+FROM nvidia/cuda:12.1.1-base-ubuntu22.04 as builder
 
 RUN apt-get update && apt-get install -y git build-essential cargo
 
 # install boringtun userspace implementation of wireguard
 # 
-# match versions of ubuntu & boringtun
-#   0.5.2 not yet supported
+# - match versions of debian & boringtun : up to date 0.5.2 compiles ok for bullseye, but could not have it working
+#   Continue with 0.4.0
 RUN cargo install --locked --bin boringtun --version ~0.4.0 boringtun
 
 # install needed wireguard-tools
-ENV WITH_WGQUICK=yes
-RUN git clone https://git.zx2c4.com/wireguard-tools && \
-    make -C wireguard-tools/src && \
-    make -C wireguard-tools/src install
+RUN apt-get install -y wireguard-tools
 
 
 # docker base image for VPN server, Fed-BioMed node and researcher
 # - need proper python version for Fed-BioMed
-FROM nvidia/cuda:11.5.0-base-ubuntu20.04
-
-# install wget though nvidia cuda linux gpg key is obsolete
-RUN apt-key del 7fa2af80 && apt-get update || true && apt install -y wget
-# update nvidia cuda linux gpg repository key
-# https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/
-RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb && \
-    dpkg -i cuda-keyring_1.0-1_all.deb && \
-    sed -i '/developer\.download\.nvidia\.com\/compute\/cuda\/repos/d' /etc/apt/sources.list && \
-    sed -i '/developer\.download\.nvidia\.com\/compute\/cuda\/repos/d' /etc/apt/sources.list.d/*
+FROM nvidia/cuda:12.1.1-base-ubuntu22.04
 
 RUN apt-get update && \
-    apt-get install -y python3.9-full && \
+    apt-get install -y python3.10-full && \
     apt-get install -y iptables iproute2 iputils-ping bash vim net-tools procps build-essential kmod
 
 # get wireguard from builder image

--- a/envs/vpn/docker/docker-compose.yml
+++ b/envs/vpn/docker/docker-compose.yml
@@ -70,22 +70,6 @@ x-node2:
 
 services:
   #
-  # intermediate step : image for building wireguard for base image
-  # we usually dont want to build or launch this service (only used for building "base")
-  builder:
-    container_name: fedbiomed-vpn-builder
-    hostname: fedbiomed-vpn-builder
-    build:
-      context: ./base/build_files
-      target: builder
-    image: fedbiomed/vpn-builder
-    entrypoint: /bin/true
-    # profiles will handle not-launched-by-default services when 
-    # >=1.28 becomes common https://docs.docker.com/compose/profiles/
-    # 
-    # profiles:
-    #  - debug # not started by `docker-compose up` except if `--profile debug`
-  #
   # intermediate step : base image for building vpn and researcher containers
   # we usually dont want to launch this service (used for building other services)
   base:

--- a/envs/vpn/docker/docker-compose_run_node.yml
+++ b/envs/vpn/docker/docker-compose_run_node.yml
@@ -6,7 +6,7 @@ version: "3.7"
 # Minimal dockerfile permits minimal file tree
 # because *all* files dependencies referenced in `docker-compose.yml`
 # (eg: `./*/build_files`, `./*/run_mounts/config/config.env`)
-# need to exist for *all* containers everytime we run a docker-compose command
+# need to exist for *all* containers everytime we run a `docker compose` command
 # thus we would have to copy file trees for vpnserver, researcher, etc. when only
 # running a node
 x-node:

--- a/envs/vpn/docker/gui/build_files/bashrc_append
+++ b/envs/vpn/docker/gui/build_files/bashrc_append
@@ -3,9 +3,9 @@
 #
 
 # needed to assign here `CONTAINER_{USER,GROUP,UID,GID}` values to handle the case where
-# - container is launched with `docker-compose up` (no value passed as in
-#  `CONTAINER_USER=myuser ... docker-compose up`)
-# - then doing a `docker-compose exec` : in this case `CONTAINER_{USER,GROUP,UID,GID}`
+# - container is launched with `docker compose up` (no value passed as in
+#  `CONTAINER_USER=myuser ... docker compose up`)
+# - then doing a `docker compose exec` : in this case `CONTAINER_{USER,GROUP,UID,GID}`
 #   use the (empty) values from the environment (see docker-compose.yml)
 #   that override values from the image (see Dockerfile)
 export CONTAINER_USER=${CONTAINER_USER:-${CONTAINER_BUILD_USER:-root}}

--- a/envs/vpn/docker/mqtt/build_files/Dockerfile
+++ b/envs/vpn/docker/mqtt/build_files/Dockerfile
@@ -1,29 +1,23 @@
 # temporary builder image for wireguard tools
 # - need coherent system version with mosquitto image
-# - may need update for properly compiling boringtun (eg: cargo build of failing on `buster-slim`)
-FROM alpine:3.14 as builder
+# - may need update for properly compiling boringtun
+# - 2023-05: `3.18.0` is uptodate version
+FROM alpine:3.18.0 as builder
 
-RUN apk update && apk add git alpine-sdk linux-headers
+RUN apk update && apk add git alpine-sdk linux-headers cargo
 
 # install boringtun userspace implementation of wireguard
 # 
-# - match versions of alpine & boringtun : 0.4.0 is now supported by bullseye with current system/cargo packages
-#   0.5.2 not yet supported
-# - glitch: alpine's apk cargo is too old vs boringtun's cargo packages dependencies, need to install
-#   up to date rust/cargo
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && . /root/.cargo/env && \
-    cargo install --locked --bin boringtun --version ~0.4.0 boringtun
+# - match versions of debian & boringtun : up to date 0.5.2 compiles ok for bullseye, but could not have it working
+#   Continue with 0.4.0
+RUN cargo install --locked --bin boringtun --version ~0.4.0 boringtun
 
-# install needed wireguard-tools
-ENV WITH_WGQUICK=yes
-RUN git clone https://git.zx2c4.com/wireguard-tools && \
-    make -C wireguard-tools/src && \
-    make -C wireguard-tools/src install
+RUN apk add wireguard-tools
 
 #
 # docker image for mosquitto server
 #
-FROM eclipse-mosquitto
+FROM eclipse-mosquitto:2.0.15
 
 ARG CONTAINER_GID
 ARG CONTAINER_UID

--- a/envs/vpn/docker/mqtt/build_files/bashrc_append
+++ b/envs/vpn/docker/mqtt/build_files/bashrc_append
@@ -4,9 +4,9 @@
 [ -f /config/config.env ] && source /config/config.env
 
 # needed to assign here `CONTAINER_{USER,GROUP,UID,GID}` values to handle the case where
-# - container is launched with `docker-compose up` (no value passed as in
-#  `CONTAINER_USER=myuser ... docker-compose up`)
-# - then doing a `docker-compose exec` : in this case `CONTAINER_{USER,GROUP,UID,GID}`
+# - container is launched with `docker compose up` (no value passed as in
+#  `CONTAINER_USER=myuser ... docker compose up`)
+# - then doing a `docker compose exec` : in this case `CONTAINER_{USER,GROUP,UID,GID}`
 #   use the (empty) values from the environment (see docker-compose.yml)
 #   that override values from the image (see Dockerfile)
 export CONTAINER_USER=${CONTAINER_USER:-${CONTAINER_BUILD_USER:-root}}

--- a/envs/vpn/docker/node/build_files/bashrc_append
+++ b/envs/vpn/docker/node/build_files/bashrc_append
@@ -4,9 +4,9 @@
 [ -f /config/config.env ] && source /config/config.env
 
 # needed to assign here `CONTAINER_{USER,GROUP,UID,GID}` values to handle the case where
-# - container is launched with `docker-compose up` (no value passed as in
-#  `CONTAINER_USER=myuser ... docker-compose up`)
-# - then doing a `docker-compose exec` : in this case `CONTAINER_{USER,GROUP,UID,GID}`
+# - container is launched with `docker compose up` (no value passed as in
+#  `CONTAINER_USER=myuser ... docker compose up`)
+# - then doing a `docker compose exec` : in this case `CONTAINER_{USER,GROUP,UID,GID}`
 #   use the (empty) values from the environment (see docker-compose.yml)
 #   that override values from the image (see Dockerfile)
 export CONTAINER_USER=${CONTAINER_USER:-${CONTAINER_BUILD_USER:-root}}

--- a/envs/vpn/docker/researcher/build_files/bashrc_append
+++ b/envs/vpn/docker/researcher/build_files/bashrc_append
@@ -4,9 +4,9 @@
 [ -f /config/config.env ] && source /config/config.env
 
 # needed to assign here `CONTAINER_{USER,GROUP,UID,GID}` values to handle the case where
-# - container is launched with `docker-compose up` (no value passed as in
-#  `CONTAINER_USER=myuser ... docker-compose up`)
-# - then doing a `docker-compose exec` : in this case `CONTAINER_{USER,GROUP,UID,GID}`
+# - container is launched with `docker compose up` (no value passed as in
+#  `CONTAINER_USER=myuser ... docker compose up`)
+# - then doing a `docker compose exec` : in this case `CONTAINER_{USER,GROUP,UID,GID}`
 #   use the (empty) values from the environment (see docker-compose.yml)
 #   that override values from the image (see Dockerfile)
 export CONTAINER_USER=${CONTAINER_USER:-${CONTAINER_BUILD_USER:-root}}

--- a/envs/vpn/docker/restful/build_files/Dockerfile
+++ b/envs/vpn/docker/restful/build_files/Dockerfile
@@ -1,31 +1,23 @@
 # temporary builder image for wireguard tools
 # - need coherent system version with mosquitto image
-# - may need update for properly compiling boringtun (eg: cargo build of package failing on `buster-slim`)
-FROM python:3.9-alpine as builder
+# - may need update for properly compiling boringtun
+FROM python:3.10-alpine3.18 as builder
 
-RUN apk update && apk add git alpine-sdk linux-headers
+RUN apk update && apk add git alpine-sdk linux-headers cargo
 
 # install boringtun userspace implementation of wireguard
 # 
-# - match versions of alpine & boringtun : 0.4.0 is now supported by bullseye with current system/cargo packages
-#   0.5.2 not yet supported
-# - glitch: alpine's apk cargo is too old vs boringtun's cargo packages dependencies, need to install
-#   up to date rust/cargo
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && . /root/.cargo/env && \
-    cargo install --locked --bin boringtun --version ~0.4.0 boringtun
+# - match versions of debian & boringtun : up to date 0.5.2 compiles ok for bullseye, but could not have it working
+#   Continue with 0.4.0
+RUN cargo install --locked --bin boringtun --version ~0.4.0 boringtun
 
 # install needed wireguard-tools
-ENV WITH_WGQUICK=yes
-RUN git clone https://git.zx2c4.com/wireguard-tools && \
-    make -C wireguard-tools/src && \
-    make -C wireguard-tools/src install
-
-
+RUN apk add wireguard-tools
 
 #
 # docker image for restful server
 #
-FROM python:3.9-alpine
+FROM python:3.10-alpine3.18
 ENV PYTHONUNBUFFERED 1
 
 ARG CONTAINER_GID

--- a/envs/vpn/docker/restful/build_files/bashrc_append
+++ b/envs/vpn/docker/restful/build_files/bashrc_append
@@ -4,9 +4,9 @@
 [ -f /config/config.env ] && source /config/config.env
 
 # needed to assign here `CONTAINER_{USER,GROUP,UID,GID}` values to handle the case where
-# - container is launched with `docker-compose up` (no value passed as in
-#  `CONTAINER_USER=myuser ... docker-compose up`)
-# - then doing a `docker-compose exec` : in this case `CONTAINER_{USER,GROUP,UID,GID}`
+# - container is launched with `docker compose up` (no value passed as in
+#  `CONTAINER_USER=myuser ... docker compose up`)
+# - then doing a `docker compose exec` : in this case `CONTAINER_{USER,GROUP,UID,GID}`
 #   use the (empty) values from the environment (see docker-compose.yml)
 #   that override values from the image (see Dockerfile)
 export CONTAINER_USER=${CONTAINER_USER:-${CONTAINER_BUILD_USER:-root}}

--- a/envs/vpn/docker/restful/build_files/requirements.txt
+++ b/envs/vpn/docker/restful/build_files/requirements.txt
@@ -1,4 +1,4 @@
-django==3.1.7
-djangorestframework==3.12.2
-django-cleanup
-gunicorn
+django>=4.1.7,<4.2.0
+djangorestframework>=3.14.0,<3.15.0
+django-cleanup~=7.0.0
+gunicorn~=20.1.0

--- a/envs/vpn/docker/restful/run_mounts/app/fedbiomed/urls.py
+++ b/envs/vpn/docker/restful/run_mounts/app/fedbiomed/urls.py
@@ -26,14 +26,14 @@ urlpatterns = [
 from django.conf import settings
 from django.conf.urls.static import static
 from django.views.static import serve
-from django.conf.urls import url
+from django.urls import re_path
 
 
 # Serve files in production
 if not settings.DEBUG:
     urlpatterns += [
-        url(r'^media/(?P<path>.*)$', serve, {'document_root': settings.MEDIA_ROOT}),
-        url(r'^static/(?P<path>.*)$', serve, {'document_root': settings.STATIC_ROOT}),
+        re_path(r'^media/(?P<path>.*)$', serve, {'document_root': settings.MEDIA_ROOT}),
+        re_path(r'^static/(?P<path>.*)$', serve, {'document_root': settings.STATIC_ROOT}),
     ]
 else:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/envs/vpn/docker/vpnserver/build_files/bashrc_append
+++ b/envs/vpn/docker/vpnserver/build_files/bashrc_append
@@ -4,9 +4,9 @@
 [ -f /config/config.env ] && source /config/config.env
 
 # needed to assign here `CONTAINER_{USER,GROUP,UID,GID}` values to handle the case where
-# - container is launched with `docker-compose up` (no value passed as in
-#  `CONTAINER_USER=myuser ... docker-compose up`)
-# - then doing a `docker-compose exec` : in this case `CONTAINER_{USER,GROUP,UID,GID}`
+# - container is launched with `docker compose up` (no value passed as in
+#  `CONTAINER_USER=myuser ... docker compose up`)
+# - then doing a `docker compose exec` : in this case `CONTAINER_{USER,GROUP,UID,GID}`
 #   use the (empty) values from the environment (see docker-compose.yml)
 #   that override values from the image (see Dockerfile)
 export CONTAINER_USER=${CONTAINER_USER:-${CONTAINER_BUILD_USER:-root}}

--- a/gui/ui/package.json
+++ b/gui/ui/package.json
@@ -4,44 +4,41 @@
   "private": true,
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
-    "@elastic/eui": "^66.0.0",
-    "@emotion/react": "^11.10.0",
-    "@testing-library/jest-dom": "^5.15.1",
-    "@testing-library/react": "^11.2.7",
-    "@testing-library/user-event": "^12.8.3",
-    "axios": "^0.24.0",
-    "bootstrap": "^5.1.3",
-    "http-proxy-middleware": "^2.0.1",
+    "@elastic/eui": "^81.0.0",
+    "@emotion/cache": "^11.11.0",
+    "@emotion/css": "^11.11.0",
+    "@emotion/react": "^11.11.0",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "axios": "^1.4.0",
+    "bootstrap": "^5.2.3",
+    "http-proxy-middleware": "^2.0.6",
     "install": "^0.13.0",
     "jwt-decode": "^3.1.2",
     "moment": "^2.29.4",
-    "npm": "^8.2.0",
+    "npm": "^9.6.7",
     "prop-types": "^15.8.1",
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0",
-    "react-jwt": "^1.1.6",
-    "react-moment": "^1.1.2",
-    "react-redux": "^7.2.6",
-    "react-router-dom": "^6.0.2",
-    "react-scripts": "^5.0.0",
-    "react-select": "^5.4.0",
+    "react": "^18.2.0",
+    "react-app": "^1.1.2",
+    "react-dom": "^18.2.0",
+    "react-jwt": "^1.1.8",
+    "react-moment": "^1.1.3",
+    "react-redux": "^8.0.5",
+    "react-router-dom": "^6.11.2",
+    "react-scripts": "^5.0.1",
+    "react-select": "^5.7.3",
     "react-syntax-highlighter": "^15.5.0",
-    "redux": "^4.1.2",
-    "redux-thunk": "^2.4.1",
+    "redux": "^4.2.1",
+    "redux-thunk": "^2.4.2",
     "thunk": "^0.0.1",
-    "web-vitals": "^1.1.2"
+    "web-vitals": "^3.3.1"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
   },
   "browserslist": {
     "production": [
@@ -54,5 +51,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "packageManager": "yarn@3.5.1",
+  "devDependencies": {
+    "yarn-upgrade-all": "^0.7.2"
   }
 }

--- a/scripts/choose_docker_compose
+++ b/scripts/choose_docker_compose
@@ -1,0 +1,18 @@
+
+#
+# Temporary utility function for smoothing `docker-compose` to `docker compose` migration
+# 
+
+docker_compose() {
+
+    if $(docker compose version >/dev/null 2>&1) ; then
+       DOCKER_COMPOSE='docker compose'
+    elif $(docker-compose version >/dev/null 2>&1) ; then
+      echo "[WARNING] docker-compose v1 is obsolete, please upgrade to docker-compose-plugin v2 !" >&2
+      DOCKER_COMPOSE='docker-compose'
+    else
+      echo '[ERROR] `docker compose` not found. It is a requirement for Fed-BioMed.' >&2
+      exit 1
+    fi
+
+}

--- a/scripts/configure_conda
+++ b/scripts/configure_conda
@@ -3,8 +3,14 @@
 # create all necessary environments
 #
 
-# list of env to find/intialise
+# List of available environemnts for Fed-BioMed
 fed_envs=(network node researcher gui)
+
+# Environments that are required to be installed for Fed-BioMed components
+# Note: network component is only necessary if restful module of network component  
+# is to be started locally rather than docker.
+fed_envs_auto_create=(node researcher gui)
+
 
 # detect how the file is run
 ([[ -n $ZSH_EVAL_CONTEXT && $ZSH_EVAL_CONTEXT =~ :file$ ]] ||
@@ -73,11 +79,13 @@ function activate_environment() {
     # pip may result into inconsistencies
 
     base=$basedir/envs/development/conda/$1
+    logfile=$1
 
     # check if alternate yaml file is available (OS dependent files usually)
     if [ -f "${base}-${ALTERNATE_YAML}.yaml" ]
     then
         file="${base}-${ALTERNATE_YAML}.yaml"
+        logfile=${logfile}-${ALTERNATE_YAML}
     else
         file="${base}.yaml"
     fi
@@ -88,7 +96,7 @@ function activate_environment() {
     then
         echo conda env update --file "$file"
     else
-        conda env update --file "$file" 2>/dev/null
+        conda env update --file "$file" 2>/tmp/${0##*/}_${logfile}.log
     fi
 
 }
@@ -186,7 +194,7 @@ esac
 # verify COMPONENTS
 if [ ${#COMPONENTS[@]} == 0 ]
 then
-    FINAL_COMPONENTS=("${fed_envs[@]}")
+    FINAL_COMPONENTS=("${fed_envs_auto_create[@]}")
 else
     # verify that given components are allowed
     for c in ${COMPONENTS[@]}

--- a/scripts/fedbiomed_environment
+++ b/scripts/fedbiomed_environment
@@ -108,6 +108,8 @@ activate_gui() {
 [[ -n "$ZSH_NAME" ]] && myname=${(%):-%x}
 basedir=$(cd $(dirname $myname)/.. || exit ; pwd)
 
+# temporary: `docker compose` migration
+source $basedir/scripts/choose_docker_compose
 
 # initialize development environment for....
 case $1 in
@@ -118,7 +120,9 @@ case $1 in
         activate_network
         echo "** Cleaning all caches / temporary files"
         # docker containers
-        (cd ${basedir}/envs/development/docker/ && docker-compose rm -sf &&  echo " * Docker cleaning" )
+        DOCKER_COMPOSE=$(docker_compose ; echo $DOCKER_COMPOSE) # dont call directly `docker_compose` or the calling process exists in case of error
+        # note: do as much cleaning as possible even if `docker compose` is not found
+        (cd ${basedir}/envs/development/docker/ && [ -n "$DOCKER_COMPOSE" ] && $DOCKER_COMPOSE rm -sf &&  echo " * Docker cleaning" )
 
         # network cleaner
         echo " * Network cleaning"
@@ -146,7 +150,14 @@ case $1 in
 
         # gui cleaning
         echo " * Node GUI cleaning"
-        gui_temp_paths='var/gui-build gui/ui/node_modules gui/ui/yarn.lock'
+        gui_temp_paths='
+            var/gui-build
+            gui/ui/node_modules
+            gui/ui/yarn.lock
+            gui/ui/.yarn
+            gui/ui/.pnp.cjs
+            gui/ui/.pnp.loader.mjs
+        '
         for p in $gui_temp_paths ; do
             if [ -e "${basedir}/$p" ] ; then
                 echo "[INFO] Removing directory ${basedir}/$p"

--- a/scripts/fedbiomed_run
+++ b/scripts/fedbiomed_run
@@ -233,22 +233,23 @@ case $1 in
         #
         case $2 in
             stop)
-                source ${basedir}/scripts/fedbiomed_environment network
                 docker-compose down
                 ;;
             help|-h|--help)
                 usage network
                 ;;
             *)
-                source ${basedir}/scripts/fedbiomed_environment network
+                source $basedir/scripts/choose_docker_compose
+                docker_compose
+
                 CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) \
                              CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') \
                              CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') \
-                             docker-compose build restful mqtt
+                             $DOCKER_COMPOSE build restful mqtt
                 CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) \
                              CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') \
                              CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') \
-                             docker-compose up -d restful mqtt
+                             $DOCKER_COMPOSE up -d restful mqtt
                 ;;
         esac
         ;;
@@ -445,7 +446,7 @@ case $1 in
                 # Windows WSL and others cannot handle using redirect file for securing notebook launch
                 # https://jupyter-notebook.readthedocs.io/en/stable/config.html (section NotebookApp.use_redirect_file)
                 NB_OPTS=
-                if [ -n "$(uname -r | egrep -i 'microsoft|wsl')" ]
+                if [ -n "$(uname -r | grep -E -i 'microsoft|wsl')" ]
                 # case if windows WSL is used
                 then
                     NB_OPTS='--NotebookApp.use_redirect_file=false'

--- a/scripts/fedbiomed_vpn
+++ b/scripts/fedbiomed_vpn
@@ -92,13 +92,18 @@ stop           stop and remove all containers
 check_prerequisite() {
     #
     # verify that every needed commands are installed
-    commands=( docker docker-compose )
+    source $basedir/scripts/choose_docker_compose
+    docker_compose
+
+    commands=( docker "$DOCKER_COMPOSE")
 
     ERROR=0
-    for i in ${commands[@]}
+    for i in "${commands[@]}"
     do
-        status=$(which $i)
-        [[ -z "$status" ]] && { echo "** ERROR: command not found: $i"; ERROR=1; }
+        #status=$(which $i)
+        $i >/dev/null 2>&1
+        status=$?
+        [[ "$status" -ne 0 ]] && { echo "** ERROR: command not found: $i"; ERROR=1; }
     done
     [[ $ERROR -eq 1 ]] && { echo "** Please install needed commands before running this script." ; exit 1; }
 }
@@ -123,14 +128,23 @@ internal_find_my_ip() {
             ;;
         4)
             # other cases using ifconfig command
-            _IP=$(ifconfig eth0 2> /dev/null| grep 'inet '| awk '{print $2}')
+            for i in $(seq -w 0 5); do
+                _IP=$(ifconfig eth$i 2> /dev/null| grep 'inet '| awk '{print $2}')
+                [ -n "$_IP" ] && break
+            done
             ;;
         5)
-            _IP=$(ifconfig en0 2> /dev/null| grep 'inet '| awk '{print $2}')
+            for i in $(seq -w 0 5); do
+                _IP=$(ifconfig en$i 2> /dev/null| grep 'inet '| awk '{print $2}')
+                [ -n "$_IP" ] && break
+            done
             ;;
         6)
             # check also wireless
-            _IP=$(ifconfig wlan0 2> /dev/null| grep 'inet '| awk '{print $2}')
+            for i in $(seq -w 0 5); do
+                _IP=$(ifconfig wlan$i 2> /dev/null| grep 'inet '| awk '{print $2}')
+                [ -n "$_IP" ] && break
+            done
             ;;
         #
         # you may add more heuristics here
@@ -142,7 +156,7 @@ internal_find_my_ip() {
     esac
 
     # verify that the result is an IPv4 adress
-    _IP=$(echo $_IP | egrep '([0-9]{1,3}[\.]){3}[0-9]{1,3}')
+    _IP=$(echo $_IP | grep -E '([0-9]{1,3}[\.]){3}[0-9]{1,3}')
 
     echo $_IP
 }
@@ -161,8 +175,8 @@ find_my_ip() {
 
     case $IP in
         127.*)
-            echo "** WARNING: 'vpnserver' will use the localhost IP address."
-            echo "            VPN may not work properly"
+            echo "** WARNING: 'vpnserver' will use the localhost IP address." >&2
+            echo "            VPN may not work properly" >&2
         ;;
     esac
 
@@ -204,7 +218,7 @@ containers_remove() {
     cd "$basedir/envs/vpn/docker"
     for i in ${ONLY_CONTAINERS[@]}
     do
-        docker-compose rm -sf $i >/dev/null
+        $DOCKER_COMPOSE rm -sf $i >/dev/null
     done
 }
 
@@ -221,7 +235,7 @@ containers_clean() {
 
     for i in base basenode
     do
-        docker-compose rm -sf $i >/dev/null
+        $DOCKER_COMPOSE rm -sf $i >/dev/null
     done
 
     #
@@ -308,7 +322,7 @@ containers_status() {
     do
         [[ "$i" = "gui" ]] || [[ "$i" = "gui2" ]] && { continue ; } # gui containers do not use wireguard
         echo -n "- pinging VPN server from container $i -> "
-        ping=$(docker-compose exec ${i} ping -n -c 3 -W 1 10.220.0.1 2>/dev/null | cat -v)
+        ping=$($DOCKER_COMPOSE exec ${i} ping -n -c 3 -W 1 10.220.0.1 2>/dev/null | cat -v)
 
         status=$(echo $ping|grep seq=)
         if [ -z "$status" ]; then
@@ -344,26 +358,26 @@ containers_build() {
         CONTAINER_UID=${CONTAINER_UID:-$(id -u)} CONTAINER_GID=${CONTAINER_GID:-$(id -g)} \
             CONTAINER_USER=${CONTAINER_USER:-$(id -un | sed 's/[^[:alnum:]]/_/g')} \
             CONTAINER_GROUP=${CONTAINER_GROUP:-$(id -gn | sed 's/[^[:alnum:]]/_/g')} \
-            docker-compose build base
+            $DOCKER_COMPOSE build base
     fi
     if [ $BUILD_NODEBASE -eq 1 ]; then
         echo "- building 'basenode' container"
         CONTAINER_UID=${CONTAINER_UID:-$(id -u)} CONTAINER_GID=${CONTAINER_GID:-$(id -g)} \
             CONTAINER_USER=${CONTAINER_USER:-$(id -un | sed 's/[^[:alnum:]]/_/g')} \
             CONTAINER_GROUP=${CONTAINER_GROUP:-$(id -gn | sed 's/[^[:alnum:]]/_/g')} \
-            docker-compose build basenode
+            $DOCKER_COMPOSE build basenode
     fi
 
     for i in ${ONLY_CONTAINERS[@]}
     do
         echo "- stopping '$i' container"
-        docker-compose rm -sf $i >/dev/null
+        $DOCKER_COMPOSE rm -sf $i >/dev/null
         echo "- building '$i' container"
         MPSPDZ_URL=$MPSPDZ_URL MPSPDZ_COMMIT=$MPSPDZ_COMMIT \
             CONTAINER_UID=${CONTAINER_UID:-$(id -u)} CONTAINER_GID=${CONTAINER_GID:-$(id -g)} \
             CONTAINER_USER=${CONTAINER_USER:-$(id -un | sed 's/[^[:alnum:]]/_/g')} \
             CONTAINER_GROUP=${CONTAINER_GROUP:-$(id -gn | sed 's/[^[:alnum:]]/_/g')} \
-            docker-compose build $i
+            $DOCKER_COMPOSE build $i
     done
 }
 
@@ -381,7 +395,7 @@ single_container_configure() {
     IP=$(find_my_ip)
 
     /bin/rm -fr ./vpnserver/run_mounts/config/config_peers/${category}/${container}
-    docker-compose exec vpnserver bash -c -i "python ./vpn/bin/configure_peer.py genconf ${category} ${container}"
+    $DOCKER_COMPOSE exec vpnserver bash -c -i "python ./vpn/bin/configure_peer.py genconf ${category} ${container}"
     sleep 1
 
     /bin/rm -fr ./${container}/run_mounts/config/wireguard    2> /dev/null
@@ -407,7 +421,7 @@ containers_configure() {
     CONTAINER_UID=${CONTAINER_UID:-$(id -u)} CONTAINER_GID=${CONTAINER_GID:-$(id -g)} \
         CONTAINER_USER=${CONTAINER_USER:-$(id -un | sed 's/[^[:alnum:]]/_/g')} \
         CONTAINER_GROUP=${CONTAINER_GROUP:-$(id -gn | sed 's/[^[:alnum:]]/_/g')} \
-        docker-compose up -d vpnserver
+        $DOCKER_COMPOSE up -d vpnserver
 
     for i in ${ONLY_CONTAINERS[@]}
     do
@@ -440,14 +454,14 @@ containers_start() {
 
 
     # Use CONTAINER_UID variable again when starting container(s) because
-    # if image is not build `docker-compose up ` will automatically build it
+    # if image is not build `docker compose up ` will automatically build it
 
     # start vpnserver first
     MPSPDZ_URL=$MPSPDZ_URL MPSPDZ_COMMIT=$MPSPDZ_COMMIT \
         CONTAINER_UID=${CONTAINER_UID:-$(id -u)} CONTAINER_GID=${CONTAINER_GID:-$(id -g)} \
         CONTAINER_USER=${CONTAINER_USER:-$(id -un | sed 's/[^[:alnum:]]/_/g')} \
         CONTAINER_GROUP=${CONTAINER_GROUP:-$(id -gn | sed 's/[^[:alnum:]]/_/g')} \
-        docker-compose up -d vpnserver
+        $DOCKER_COMPOSE up -d vpnserver
 
     # start other container(s)
     for i in ${ONLY_CONTAINERS[@]}
@@ -465,37 +479,37 @@ containers_start() {
         esac
 
         echo "- starting $i container"
-        docker-compose rm -sf $CONTAINER >/dev/null
+        $DOCKER_COMPOSE rm -sf $CONTAINER >/dev/null
         MPSPDZ_URL=$MPSPDZ_URL MPSPDZ_COMMIT=$MPSPDZ_COMMIT \
             CONTAINER_UID=${CONTAINER_UID:-$(id -u)} CONTAINER_GID=${CONTAINER_GID:-$(id -g)} \
             CONTAINER_USER=${CONTAINER_USER:-$(id -un | sed 's/[^[:alnum:]]/_/g')} \
             CONTAINER_GROUP=${CONTAINER_GROUP:-$(id -gn | sed 's/[^[:alnum:]]/_/g')} \
-            docker-compose up -d $CONTAINER
+            $DOCKER_COMPOSE up -d $CONTAINER
 
         case $i in
             mqtt|restful)
-                pubkey=$(docker-compose exec "$i" wg show wg0 public-key | tr -d '\r')
+                pubkey=$($DOCKER_COMPOSE exec "$i" wg show wg0 public-key | tr -d '\r')
                 # Remove key to avoid protocol error if keys are same
-                docker-compose exec vpnserver python ./vpn/bin/configure_peer.py remove management "$i"
-                docker-compose exec vpnserver python ./vpn/bin/configure_peer.py add management "$i" "$pubkey"
+                $DOCKER_COMPOSE exec vpnserver python ./vpn/bin/configure_peer.py remove management "$i"
+                $DOCKER_COMPOSE exec vpnserver python ./vpn/bin/configure_peer.py add management "$i" "$pubkey"
                 ;;
             researcher)
-                pubkey=$(docker-compose exec researcher wg show wg0 public-key | tr -d '\r')
+                pubkey=$($DOCKER_COMPOSE exec researcher wg show wg0 public-key | tr -d '\r')
                 # Remove key to avoid protocol error if keys are same
-                docker-compose exec vpnserver python ./vpn/bin/configure_peer.py remove researcher researcher1
-                docker-compose exec vpnserver python ./vpn/bin/configure_peer.py add researcher researcher1 $pubkey
+                $DOCKER_COMPOSE exec vpnserver python ./vpn/bin/configure_peer.py remove researcher researcher1
+                $DOCKER_COMPOSE exec vpnserver python ./vpn/bin/configure_peer.py add researcher researcher1 $pubkey
                 ;;
             node)
-                pubkey=$(docker-compose exec node wg show wg0 public-key | tr -d '\r')
+                pubkey=$($DOCKER_COMPOSE exec node wg show wg0 public-key | tr -d '\r')
                 # Remove key to avoid protocol error if keys are same
-                docker-compose exec vpnserver python ./vpn/bin/configure_peer.py remove node NODETAG
-                docker-compose exec vpnserver python ./vpn/bin/configure_peer.py add node NODETAG $pubkey
+                $DOCKER_COMPOSE exec vpnserver python ./vpn/bin/configure_peer.py remove node NODETAG
+                $DOCKER_COMPOSE exec vpnserver python ./vpn/bin/configure_peer.py add node NODETAG $pubkey
                 ;;
             node2)
-                pubkey=$(docker-compose exec node2 wg show wg0 public-key | tr -d '\r')
+                pubkey=$($DOCKER_COMPOSE exec node2 wg show wg0 public-key | tr -d '\r')
                 # Remove key to avoid protocol error if keys are same
-                docker-compose exec vpnserver python ./vpn/bin/configure_peer.py remove node NODE2TAG
-                docker-compose exec vpnserver python ./vpn/bin/configure_peer.py add node NODE2TAG $pubkey
+                $DOCKER_COMPOSE exec vpnserver python ./vpn/bin/configure_peer.py remove node NODE2TAG
+                $DOCKER_COMPOSE exec vpnserver python ./vpn/bin/configure_peer.py add node NODE2TAG $pubkey
                 ;;
             *)
                 ;;
@@ -514,12 +528,12 @@ run() {
     cd "$basedir/envs/vpn/docker"
 
     # find @IP of mqtt and restful inside the VPN
-    status=$(docker-compose ps restful | wc -l)
+    status=$($DOCKER_COMPOSE ps restful | wc -l)
     [[ $? ]] || {
         echo "** ERROR: restful container not running"
         exit 1
     }
-    restful_IP=$(docker-compose exec restful ip route | tr -d '\r' | grep ^10.220 | awk '{print $NF}')
+    restful_IP=$($DOCKER_COMPOSE exec restful ip route | tr -d '\r' | grep ^10.220 | awk '{print $NF}')
     echo "- restful IP is: $restful_IP"
     [[ -z "$restful_IP" ]] && {
         echo "** ERROR: cannot find IP address of restful server" ;
@@ -528,12 +542,12 @@ run() {
     }
 
     #
-    status=$(docker-compose ps mqtt | wc -l)
+    status=$($DOCKER_COMPOSE ps mqtt | wc -l)
     [[ $? ]] || {
         echo "** ERROR: mqtt container not running"
         exit 1
     }
-    mqtt_IP=$(docker-compose exec mqtt ip route | tr -d '\r' | grep ^10.220 | awk '{print $NF}')
+    mqtt_IP=$($DOCKER_COMPOSE exec mqtt ip route | tr -d '\r' | grep ^10.220 | awk '{print $NF}')
     echo "- mqtt    IP is: $mqtt_IP"
     [[ -z "$mqtt_IP" ]] && {
         echo "** ERROR: cannot find IP address of mqtt server" ;
@@ -544,7 +558,7 @@ run() {
     CMD="export MQTT_BROKER=$mqtt_IP && export MQTT_BROKER_PORT=1883 && export UPLOADS_URL=http://${restful_IP}:8000/upload/ &&
     export UPLOADS_IP=${restful_IP} && export FEDBIOMED_NO_RESET=1 && ./scripts/fedbiomed_run $container ${RUN_ARGS}"
 
-    docker-compose exec -u ${CONTAINER_UID:-$(id -u)} $container bash -c "$CMD"
+    $DOCKER_COMPOSE exec -u ${CONTAINER_UID:-$(id -u)} $container bash -c "$CMD"
 
 
 

--- a/scripts/run_integration_test
+++ b/scripts/run_integration_test
@@ -205,7 +205,8 @@ cleaning() {
     fi
 
     # kill the docker containers
-    ( cd $basedir/envs/development/docker ; docker-compose down )
+    ( cd $basedir/envs/development/docker ; source $basedir/scripts/choose_docker_compose ; \
+        docker_compose ; $DOCKER_COMPOSE down  )
 
     #
     # clean all datasets from nodes

--- a/scripts/run_test_mnist
+++ b/scripts/run_test_mnist
@@ -79,7 +79,8 @@ conda deactivate
 ##clean running processes and datasets
 echo "INFO: killing kpids=$kpids"
 kill -9 $kpids
-( cd $basedir/envs/development/docker ; docker-compose down )
+( cd $basedir/envs/development/docker ; source $basedir/scripts/choose_docker_compose ; \
+    docker_compose ; $DOCKER_COMPOSE down )
 source $basedir/scripts/fedbiomed_environment node
 $basedir/scripts/fedbiomed_run node --delete-mnist
 $basedir/scripts/fedbiomed_run node config config-n1.ini --delete-mnist

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -26,6 +26,7 @@ from fedbiomed.researcher.environ import environ
 from fedbiomed.researcher.job import Job
 from fedbiomed.researcher.requests import Requests
 from fedbiomed.researcher.responses import Responses
+import fedbiomed.researcher.job # needed for specific mocking
 
 
 
@@ -189,18 +190,18 @@ class TestJob(ResearcherTestCase):
             mock_logger_critical.assert_called_once()
 
     @patch('fedbiomed.common.logger.logger.critical')
-    @patch('inspect.isclass')
+
     def test_job_06_init_isclass_raises_error(self,
-                                              mock_isclass,
                                               mock_logger_critical):
         """ Test initialization when inspect.isclass raises NameError"""
 
-        mock_isclass.side_effect = NameError
-        with self.assertRaises(NameError):
-            _ = Job(training_plan_class='FakeModel',
-                    training_args=TrainingArgs({"batch_size": 12}, only_required=False),
-                    data=self.fds)
-            mock_logger_critical.assert_called_once()
+        with patch.object(fedbiomed.researcher.job, 'inspect') as mock_inspect:
+            mock_inspect.isclass.side_effect = NameError
+            with self.assertRaises(NameError):
+                _ = Job(training_plan_class='FakeModel',
+                        training_args=TrainingArgs({"batch_size": 12}, only_required=False),
+                        data=self.fds)
+                mock_logger_critical.assert_called_once()
 
     @patch('fedbiomed.common.logger.logger.error')
     def test_job_07_initialization_raising_exception_save_and_save_code(self,


### PR DESCRIPTION
Fixes #820 and #821 

This hotfix pulls the latests build scripts, Dockerfiles, conda environments, and gui packages from develop. 

This is needed because our current VPN containers cannot build or run due to outdated or misconfigured packages (see #820 , #821 ). 
Essentially, we aim to bring v4.4 up to date with the changes introduced in PR #802  (related to issue #448).
