### PR TITLE
Fix 833/525 display incorrect round number after breakpoint load

### DIFF
--- a/fedbiomed/researcher/experiment.py
+++ b/fedbiomed/researcher/experiment.py
@@ -298,7 +298,7 @@ class Experiment:
         #     # TODO: confirm placement for finishing monitoring - should be at the end of the experiment
         #     self._reqs.remove_monitor_callback()
 
-        if self._monitor is not None and self._monitor is not False and self._monitor is not True:
+        if isinstance(self._monitor, Monitor):
             self._monitor.close_writer()
 
     @property
@@ -1069,6 +1069,10 @@ class Experiment:
 
         # everything is OK
         self._round_current = round_current
+
+        # `Monitor` is not yet declared during object initialization
+        if isinstance(self._monitor, Monitor):
+            self._monitor.set_round(self._round_current + 1)
 
         # at this point self._round_current is an int
         return self._round_current


### PR DESCRIPTION
- misc remove useless test for self._monitor

**PR description**

Fixes 833 (duplicate from 525)

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state`/`load_state` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`