### PR TITLE
Fixes dataset delete from CLI

### DIFF
--- a/fedbiomed/common/constants.py
+++ b/fedbiomed/common/constants.py
@@ -243,7 +243,7 @@ class ErrorNumbers(_BaseEnum):
     FB319 = "FB319: Command not found error"
     FB320 = "FB320: bad model type"
     FB321 = "FB321: Secure aggregation delete error"
-    FB322 = "FB322: Dataset registration error"
+    FB322 = "FB322: Dataset manager error"
     # application error on researcher
 
     FB400 = "FB400: undetermined application error"

--- a/fedbiomed/node/cli_utils/_database.py
+++ b/fedbiomed/node/cli_utils/_database.py
@@ -219,18 +219,17 @@ def delete_database(interactive: bool = True):
                 opt_idx = int(input(msg)) - 1
                 assert opt_idx in range(len(my_data))
 
-                tags = my_data[opt_idx]['tags']
+                d_id = my_data[opt_idx]['dataset_id']
             else:
-                tags = ''
                 for ds in my_data:
                     if ds['name'] == 'MNIST':
-                        tags = ds['tags']
+                        d_id = ds['dataset_id']
                         break
 
-            if not tags:
+            if not d_id:
                 logger.warning('No matching dataset to delete')
                 return
-            dataset_manager.remove_database(tags)
+            dataset_manager.remove_database(d_id)
             logger.info('Dataset removed. Here your available datasets')
             dataset_manager.list_my_data()
             return

--- a/fedbiomed/node/cli_utils/_database.py
+++ b/fedbiomed/node/cli_utils/_database.py
@@ -249,8 +249,8 @@ def delete_all_database():
         return
 
     for ds in my_data:
-        tags = ds['tags']
-        dataset_manager.remove_database(tags)
-        logger.info('Dataset removed for tags:' + str(tags))
+        d_id = ds['dataset_id']
+        dataset_manager.remove_database(d_id)
+        logger.info('Dataset removed for dataset_id:' + str(d_id))
 
     return

--- a/fedbiomed/node/dataset_manager.py
+++ b/fedbiomed/node/dataset_manager.py
@@ -527,20 +527,23 @@ class DatasetManager:
             raise FedbiomedDatasetManagerError(_msg)
 
     def remove_database(self, dataset_id: str):
-        """Removes datasets from database.
+        """Removes a dataset from database.
 
-        Only datasets matching the `tags` should be removed.
+        Only the dataset matching the `dataset_id` should be removed.
 
         Args:
-            tags: Dataset description tags.
+            dataset_id: Dataset unique ID.
         """
+        # TODO: check that there is no more than one dataset with `dataset_id` (consistency, should not happen)
         _, dataset_document = self._dataset_table.get(self._database.dataset_id == dataset_id, add_docs=True)
 
         if dataset_document:
             self._dataset_table.remove(doc_ids=[dataset_document.doc_id])
         else:
-            logger.debug(f"No dataset found with id {dataset_id}")
-            
+            _msg = ErrorNumbers.FB322.value + f": No dataset found with id {dataset_id}"
+            logger.error(_msg)
+            raise FedbiomedDatasetManagerError(_msg)
+
     def modify_database_info(self,
                              dataset_id: str,
                              modified_dataset: dict):

--- a/fedbiomed/node/dataset_manager.py
+++ b/fedbiomed/node/dataset_manager.py
@@ -526,7 +526,7 @@ class DatasetManager:
             logger.error(_msg)
             raise FedbiomedDatasetManagerError(_msg)
 
-    def remove_database(self, tags: Union[tuple, list]):
+    def remove_database(self, dataset_id: str):
         """Removes datasets from database.
 
         Only datasets matching the `tags` should be removed.
@@ -534,9 +534,13 @@ class DatasetManager:
         Args:
             tags: Dataset description tags.
         """
-        doc_ids = [doc.doc_id for doc in self.search_by_tags(tags)]
-        self._dataset_table.remove(doc_ids=doc_ids)
+        _, dataset_document = self._dataset_table.get(self._database.dataset_id == dataset_id, add_docs=True)
 
+        if dataset_document:
+            self._dataset_table.remove(doc_ids=[dataset_document.doc_id])
+        else:
+            logger.debug(f"No dataset found with id {dataset_id}")
+            
     def modify_database_info(self,
                              dataset_id: str,
                              modified_dataset: dict):

--- a/tests/test_dataset_manager.py
+++ b/tests/test_dataset_manager.py
@@ -574,6 +574,8 @@ class TestDatasetManager(NodeTestCase):
             for doc_id in doc_ids:
                 self.fake_database.pop(str(doc_id))
 
+        # case 1 : existing dataset id
+
         # patchers
         get.return_value = get_result
         db_remove_patch.side_effect = db_remove_side_effect
@@ -585,8 +587,14 @@ class TestDatasetManager(NodeTestCase):
         db_remove_patch.assert_called_once_with(doc_ids=[1])
         self.assertFalse(self.fake_database.get('1', False))
 
+        # case 2 : non existing dataset id
+
+        # patchers
         get.return_value = None, None
-        self.dataset_manager.remove_database(dataset_id)
+
+        # action + check
+        with self.assertRaises(FedbiomedDatasetManagerError):
+            self.dataset_manager.remove_database(dataset_id)
 
 
     @patch('fedbiomed.node.dataset_manager.DatasetManager.search_conflicting_tags')

--- a/tests/test_dataset_manager.py
+++ b/tests/test_dataset_manager.py
@@ -547,9 +547,9 @@ class TestDatasetManager(NodeTestCase):
 
 
     @patch('tinydb.table.Table.remove')
-    @patch('fedbiomed.node.dataset_manager.DatasetManager.search_by_tags')
+    @patch('fedbiomed.common.db.DBTable.get')
     def test_dataset_manager_19_remove_database(self,
-                                             search_by_tags_patch,
+                                             get,
                                              db_remove_patch):
         """
         Tests `remove_database` method by simulating the removal of a database
@@ -560,8 +560,8 @@ class TestDatasetManager(NodeTestCase):
         # (usually, datasets are added with an integer from 1 to the number of datasets
         # contained in the database)
 
-        dataset_tags = ['some', 'tags']
-        search_result = [doc1]
+        dataset_id= 'some-id'
+        get_result = ({}, doc1)
 
 
         def db_remove_side_effect(doc_ids: List[int]):
@@ -575,16 +575,18 @@ class TestDatasetManager(NodeTestCase):
                 self.fake_database.pop(str(doc_id))
 
         # patchers
-        search_by_tags_patch.return_value = search_result
+        get.return_value = get_result
         db_remove_patch.side_effect = db_remove_side_effect
 
         # action
-        self.dataset_manager.remove_database(dataset_tags)
+        self.dataset_manager.remove_database(dataset_id)
 
         # checks
-        search_by_tags_patch.assert_called_once_with(dataset_tags)
         db_remove_patch.assert_called_once_with(doc_ids=[1])
         self.assertFalse(self.fake_database.get('1', False))
+
+        get.return_value = None, None
+        self.dataset_manager.remove_database(dataset_id)
 
 
     @patch('fedbiomed.node.dataset_manager.DatasetManager.search_conflicting_tags')


### PR DESCRIPTION
**PR description**

This PR updates `cli.py` and `dataset_manager.remove_database` to use `dataset_id`  for deleting a dataset instead of  `tags`.


**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state`/`load_state` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`