### PR TITLE
Correctly import all training plan dependencies on researcher side while initializing Job

### DIFF
--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -165,7 +165,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         """
         return []
 
-    def _configure_dependencies(self) -> None:
+    def configure_dependencies(self) -> None:
         """ Configures dependencies """
         init_dep_spec = get_method_spec(self.init_dependencies)
         if len(init_dep_spec.keys()) > 0:

--- a/fedbiomed/common/training_plans/_sklearn_training_plan.py
+++ b/fedbiomed/common/training_plans/_sklearn_training_plan.py
@@ -96,7 +96,7 @@ class SKLearnTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         self._batch_maxnum = self._training_args.get('batch_maxnum', self._batch_maxnum)
 
         # Add dependencies
-        self._configure_dependencies()
+        self.configure_dependencies()
 
         # configure optimizer (if provided in the TrainingPlan)
         self._configure_optimizer()

--- a/fedbiomed/common/training_plans/_torchnn.py
+++ b/fedbiomed/common/training_plans/_torchnn.py
@@ -148,7 +148,7 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         # Optionally set up differential privacy.
         self._dp_controller = DPController(training_args.dp_arguments() or None)
         # Add dependencies
-        self._configure_dependencies()
+        self.configure_dependencies()
         # Configure aggregator-related arguments
         # TODO: put fedprox mu inside strategy_args
         self._fedprox_mu = self._training_args.get('fedprox_mu')

--- a/fedbiomed/researcher/job.py
+++ b/fedbiomed/researcher/job.py
@@ -142,7 +142,7 @@ class Job:
 
         else:
             self._training_plan = self._training_plan_class
-        self._training_plan._configure_dependencies()
+        self._training_plan.configure_dependencies()
 
         # find the name of the class in any case
         # (it is `model` only in the case where `model` is not an instance)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -832,8 +832,9 @@ class TestExperiment(ResearcherTestCase):
         self.test_exp.set_training_plan_class(TestExperiment.FakeModelTorch)  # required for set_job below
         with patch('fedbiomed.researcher.job.Repository', new=MagicMock()) as patched_repo, \
              patch('fedbiomed.researcher.job.Job.update_parameters', return_value=None) as patched_update_params, \
-             patch('fedbiomed.researcher.job.Job.validate_minimal_arguments', return_value=None) as patched_validate:
-            self.test_exp.set_job()  # create an actual Job inside the experiment
+             patch('fedbiomed.researcher.job.Job.validate_minimal_arguments', return_value=None) as patched_validate, \
+             patch('fedbiomed.researcher.job.Job._load_training_plan_from_file') as patched_load_tp:
+                        self.test_exp.set_job()  # create an actual Job inside the experiment
         # First, make sure that the training_args are the same as above
         self.assertSubDictInDict(ma_expected_3, train_args_3)
         new_args = {'loader_args': {'batch_size': 42}}

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -83,7 +83,6 @@ class TestJob(ResearcherTestCase):
         self.patcher4 = patch('fedbiomed.common.message.ResearcherMessages.format_outgoing_message')
         self.patcher5 = patch('fedbiomed.researcher.job.atexit')
 
-
         self.mock_request = self.patcher1.start()
         self.mock_upload_file = self.patcher2.start()
         self.mock_download_file = self.patcher3.start()
@@ -1034,6 +1033,28 @@ class TestJob(ResearcherTestCase):
         # Call the method and verify that it returns an empty dict.
         aux_var = self.job.extract_received_optimizer_aux_var_from_round(round_id=1)
         self.assertDictEqual(aux_var, {})
+
+    def test_job_27_name_error_bug_864(self):
+        class ShouldNotRaiseNameErrorTrainingPlan(BaseTrainingPlan):
+            def post_init(self, model_args=None, training_args=None, aggregator_args=None):
+                d = defaultdict()
+            def init_dependencies(self):
+                return ['from collections import defaultdict']
+            def model(self):
+                pass
+            def training_routine(self):
+                pass
+            def init_optimizer(self):
+                pass
+
+        j = Job(reqs=MagicMock(),
+                nodes=None,
+                training_plan_class=ShouldNotRaiseNameErrorTrainingPlan,
+                training_plan_path=None,
+                training_args={},
+                model_args={},
+                data=None,
+                keep_files_dir='some/path')
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -82,12 +82,17 @@ class TestJob(ResearcherTestCase):
                               return_value=(True, environ['TMP_DIR']))
         self.patcher4 = patch('fedbiomed.common.message.ResearcherMessages.format_outgoing_message')
         self.patcher5 = patch('fedbiomed.researcher.job.atexit')
+        # We also patch the function for loading from a file, because below we mock the training plan class
+        # used in the job. This has the effect that `save_code` actually does not save any code, therefore we cannot
+        # load anything.
+        self.patch_tp_load_from_file = patch('fedbiomed.researcher.job.Job._load_training_plan_from_file')
 
         self.mock_request = self.patcher1.start()
         self.mock_upload_file = self.patcher2.start()
         self.mock_download_file = self.patcher3.start()
         self.mock_request_create = self.patcher4.start()
         self.mock_atexit = self.patcher5.start()
+        self.mock_tp_load_from_file = self.patch_tp_load_from_file.start()
 
         # Globally create mock for Model and FederatedDataset
         self.model = create_autospec(BaseTrainingPlan, instance=False)
@@ -95,6 +100,7 @@ class TestJob(ResearcherTestCase):
 
         self.fds.data = MagicMock(return_value={})
         self.mock_request_create.side_effect = TestJob.msg_side_effect
+        self.mock_tp_load_from_file.return_value = self.model
 
         # Build Global Job that will be used in most of the tests
         self.job = Job(
@@ -110,6 +116,7 @@ class TestJob(ResearcherTestCase):
         self.patcher3.stop()
         self.patcher4.stop()
         self.patcher5.stop()
+        self.patch_tp_load_from_file.stop()
 
         # shutil.rmtree(os.path.join(VAR_DIR, "breakpoints"))
         # (above) remove files created during these unit tests
@@ -152,15 +159,24 @@ class TestJob(ResearcherTestCase):
         self.assertEqual(j._reqs, reqs, 'Job did not initialize provided Request object')
 
     def test_job_04_init_building_model_from_path(self):
-        """ Test model is passed as static python file with training_plan_path """
+        """ Test model is passed as static python file with training_plan_path
+
+        Note about patching the function to load from file:
+        In this specific case we cannot rely on the basic mock from above because we would end up testing whether the
+        mocked return value is indeed what we expect. But since we set the mock return value in the first place, this
+        would not be a very significant test. Instead, we turn off the mocking and rely on the fact that, differently
+        from the other test cases, here we will actually save the training plan's code.
+        """
 
         # Get source of the model and save in tmp directory for just test purposes
         tmp_dir_model = TestJob.create_fake_model('fake_model.py')
         self.mock_upload_file.reset_mock()
 
+        self.patch_tp_load_from_file.stop()
         j = Job(training_plan_path=tmp_dir_model,
                 training_args=training_args_for_testing,
                 training_plan_class='FakeModel')
+        self.patch_tp_load_from_file.start()
 
         self.assertEqual(j.training_plan.__class__.__name__, FakeModel.__name__,
                          'Provided model and model instance of Job do not match, '
@@ -1047,6 +1063,7 @@ class TestJob(ResearcherTestCase):
             def init_optimizer(self):
                 pass
 
+        self.patch_tp_load_from_file.stop()
         j = Job(reqs=MagicMock(),
                 nodes=None,
                 training_plan_class=ShouldNotRaiseNameErrorTrainingPlan,
@@ -1055,6 +1072,7 @@ class TestJob(ResearcherTestCase):
                 model_args={},
                 data=None,
                 keep_files_dir='some/path')
+        self.patch_tp_load_from_file.start()
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/tests/test_torchnn.py
+++ b/tests/test_torchnn.py
@@ -157,7 +157,7 @@ class TestTorchnn(unittest.TestCase):
         self.assertTrue(os.path.isfile(file))
         os.remove(file)
 
-    @patch("fedbiomed.common.training_plans.TorchTrainingPlan._configure_dependencies")
+    @patch("fedbiomed.common.training_plans.TorchTrainingPlan.configure_dependencies")
     @patch("fedbiomed.common.training_plans.TorchTrainingPlan._configure_model_and_optimizer")
     def test_torch_training_plan_02_post_init(self, conf_optimizer_model, conf_deps):
 
@@ -183,7 +183,7 @@ class TestTorchnn(unittest.TestCase):
         # Test default init dependencies
         tp = TorchTrainingPlan()
         add_dependency.reset_mock()
-        tp._configure_dependencies()
+        tp.configure_dependencies()
         add_dependency.assert_called_once()
 
         # Wrong 1 -----------------------------------------------------------------
@@ -193,7 +193,7 @@ class TestTorchnn(unittest.TestCase):
 
         tp = FakeWrongTP()
         with self.assertRaises(FedbiomedTrainingPlanError):
-            tp._configure_dependencies()
+            tp.configure_dependencies()
 
         # Wrong 2 -----------------------------------------------------------------
         class FakeWrongTP(BaseFakeTrainingPlan):
@@ -202,7 +202,7 @@ class TestTorchnn(unittest.TestCase):
 
         tp = FakeWrongTP()
         with self.assertRaises(FedbiomedTrainingPlanError):
-            tp._configure_dependencies()
+            tp.configure_dependencies()
 
     def test_torch_training_plan_04_configure_model_and_optimizer_1(self):
         """Tests method for configuring model and optimizer """

--- a/tests/testsupport/base_fake_training_plan.py
+++ b/tests/testsupport/base_fake_training_plan.py
@@ -24,3 +24,10 @@ class BaseFakeTrainingPlan(TorchTrainingPlan):
 
     def training_step(self):
         pass
+
+    def init_dependencies(self):
+        return [
+            'from typing import Any, Dict, Optional',
+            'from fedbiomed.common.training_args import TrainingArgs',
+            'from fedbiomed.common.training_plans import TorchTrainingPlan',
+        ]

--- a/tests/testsupport/fake_training_plan.py
+++ b/tests/testsupport/fake_training_plan.py
@@ -74,6 +74,19 @@ class FakeModel(BaseTrainingPlan):
     def optimizer(self):
         return self._optimizer
 
+    def init_dependencies(self):
+        return ['from fedbiomed.common.training_plans import BaseTrainingPlan',
+                'from typing import Any, Dict, Optional',
+                'from unittest import mock',
+                'import time',
+                'from fedbiomed.common.constants import TrainingPlans',
+                'import torch',
+                'from torch.utils.data import Dataset, DataLoader',
+                'from fedbiomed.common.models import Model',
+                'from fedbiomed.common.optimizers import BaseOptimizer',
+                'from fedbiomed.common.data import DataManager',
+        ]
+
     def save(self, filename: str, results: Dict[str, Any] = None):
         """
         Fakes `save` method of TrainingPlan classes, originally used for
@@ -95,6 +108,7 @@ class FakeModel(BaseTrainingPlan):
         Args:
             path (str): saving path
         """
+        super().save_code(path)
 
     def set_dataset_path(self, path: str):
         """Fakes `set_dataset` method of TrainingPlan classes. Originally


### PR DESCRIPTION
Fix #864.

This PR introduces the following change:
- **Before**: inside Job init, we instantiated a training plan class but it was "unusable" (i.e. `post_init` could fail) because we never imported the necessary modules
- **Now**: we import the modules necessary to enable the training plan class instance to actually execute `post_init`

Details:
1. The modules are imported in the same way that we do on the node, i.e. by saving a training plan file with the necessary import statements and then importing that file
2. inside job init, we need to instantiate the training plan class twice: the first time is just to be able to save the code. In this case, the instance is still in an "unusable" state. The second time is actually the good one with the correctly imported modules

