### PR TITLE
Implementing fix for  loading Node state while testing

### DIFF
--- a/fedbiomed/node/node.py
+++ b/fedbiomed/node/node.py
@@ -305,7 +305,8 @@ class Node:
                 aux_var_urls=aux_var_urls,
             )
             # the round raises an error if it cannot initialize
-            round.initialize_node_state_manager(state_id)  # initialize node state manager
+            #round.initialize_node_state_manager(state_id)  # initialize node state manager
+            round.initialize_arguments(state_id)
 
         return round
 

--- a/fedbiomed/node/node_state_manager.py
+++ b/fedbiomed/node/node_state_manager.py
@@ -182,7 +182,7 @@ class NodeStateManager:
             raise FedbiomedNodeStateManagerError(f"{ErrorNumbers.FB323.value}: failing to "
                                                  "save node state into DataBase") from e
 
-    def initialize(self, previous_state_id: Optional[str] = None) -> None:
+    def initialize(self, previous_state_id: Optional[str] = None, testing: Optional[bool] = False) -> None:
         """Initializes NodeStateManager, by cerating folder that will contains Node state folders.
 
         Args:
@@ -190,15 +190,16 @@ class NodeStateManager:
         """
 
         self._previous_state_id = previous_state_id
-        self._generate_new_state_id()
+        if not testing:
+            self._generate_new_state_id()
 
-        self._node_state_base_dir = os.path.join(environ["VAR_DIR"], "node_state_%s" % environ["NODE_ID"])
-        # Always create the base folder for saving states for this node
-        try:
-            os.makedirs(self._node_state_base_dir, exist_ok=True)
-        except Exception as e:
-            raise FedbiomedNodeStateManagerError(f"{ErrorNumbers.FB323.value}: Failing to create"
-                                                 f" directories {self._node_state_base_dir}") from e
+            self._node_state_base_dir = os.path.join(environ["VAR_DIR"], "node_state_%s" % environ["NODE_ID"])
+            # Always create the base folder for saving states for this node
+            try:
+                os.makedirs(self._node_state_base_dir, exist_ok=True)
+            except Exception as e:
+                raise FedbiomedNodeStateManagerError(f"{ErrorNumbers.FB323.value}: Failing to create"
+                                                    f" directories {self._node_state_base_dir}") from e
 
     def get_node_state_base_dir(self) -> Optional[str]:
         """Returns `Node` State base directory path, in which are saved Node state files and other contents

--- a/fedbiomed/researcher/job.py
+++ b/fedbiomed/researcher/job.py
@@ -415,8 +415,9 @@ class Job:
         msg = {**headers, **self._repository_args}
         time_start = {}
 
-        # update node states when used node list has changed from one round to another
-        self._update_nodes_states_agent()
+        if do_training:
+            # update node states when used node list has changed from one round to another
+            self._update_nodes_states_agent()
 
         # pass heavy aggregator params through file exchange system
         self.upload_aggregator_args(aggregator_args_thr_msg, aggregator_args_thr_files)
@@ -540,9 +541,9 @@ class Job:
                     'timing': timing,
                 })
                 self._training_replies[round_].append(response)
-
-        # update node states with node answers + when used node list has changed during the round
-        self._update_nodes_states_agent(before_training=False)
+        if do_training:
+            # update node states with node answers + when used node list has changed during the round
+            self._update_nodes_states_agent(before_training=False)
 
         # return the list of nodes which answered because nodes in error have been removed
         return self._nodes


### PR DESCRIPTION
**PR description**

A bug has been spotted regarding Node state saving facility:
it was no more possible to use validation feature on Node state.

The bug was due to the fact that each time a TrainRequest is issued, node state is saved.
However, testing on local updates is a specific TrainRequest, and doing such test updates  the NodeStateManager with a new `state_id`.

This fix intents to fix this bug by checking if :
- a training is done
- NodeStateAgent is not updated when performing testing on local updates

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`