### PR TITLE
changing declearn optimizer learning rate

### DIFF
--- a/notebooks/declearn-with-pytorch.ipynb
+++ b/notebooks/declearn-with-pytorch.ipynb
@@ -62,7 +62,7 @@
     "    \n",
     "    # Defines and return a declearn optimizer\n",
     "    def init_optimizer(self, optimizer_args):\n",
-    "        return Optimizer(lr=.1 ,modules=[AdamModule()], regularizers=[FedProxRegularizer()])\n",
+    "        return Optimizer(lr=optimizer_args[\"lr\"] ,modules=[AdamModule()], regularizers=[FedProxRegularizer()])\n",
     "    \n",
     "    # Declares and return dependencies\n",
     "    def init_dependencies(self):\n",
@@ -181,6 +181,7 @@
     "                 aggregator=FedAverage(),\n",
     "                 node_selection_strategy=None,\n",
     "                tensorboard=True)\n",
+    "\n",
     "exp.set_test_ratio(0.1)\n",
     "exp.set_test_on_local_updates(True)\n",
     "exp.set_test_on_global_updates(True)"
@@ -319,7 +320,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "fedbiomed-node",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
**PR description**
Related to issue #909 

Changed the learning rate to the same we have in `101-getting-started` notebook

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`