### PR TITLE
Fix notebook failing when using `batch_maxnum`

### DIFF
--- a/fedbiomed/common/training_plans/_training_iterations.py
+++ b/fedbiomed/common/training_plans/_training_iterations.py
@@ -164,7 +164,7 @@ class MiniBatchTrainingIterationsAccountant:
         # override number of batches per epoch if researcher specified batch_maxnum
         if self._training_plan.training_args()['batch_maxnum'] is not None and \
                 self._training_plan.training_args()['batch_maxnum'] > 0:
-            num_batches_per_epoch = self._training_plan.training_args()['batch_maxnum']
+            num_batches_per_epoch = min(num_batches_per_epoch, self._training_plan.training_args()['batch_maxnum'])
         # first scenario: researcher specified epochs
         if self._training_plan.training_args()['num_updates'] is None:
             if self._training_plan.training_args()['epochs'] is not None:


### PR DESCRIPTION
**PR description**

Fix #945

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`