### PR TITLE
fix 969 fedbiomed_vpn time race issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Fed-BioMed changelog
 
+## 2024-01-18 version 5.0.1
+
+- fix `fedbiomed_vpn` failure due to time race under certain circumstance
+
 ## 2023-12-21 version 5.0.0
 
 - introduce new communication architecture based on gRPC

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,7 @@ git pull --prune
 - check that the CI for `develop` builds correctly (github checks)
 - set the release version tag for the release (or use this tag directly in commands)
 ```bash
-export RELEASE_TAG=v5.0.0
+export RELEASE_TAG=v5.1.0
 ```
 - fork a `release/$RELEASE_TAG` branch from `develop`, and checkout the `release/$RELEASE_TAG` branch
 ```bash
@@ -122,10 +122,10 @@ Release principle: follow the [gitflow](https://www.atlassian.com/git/tutorials/
   export HOTFIX_NAME=521-short-description
   ```
 
-- set the hotfix version tag for the release (or use this tag directly in commands).For example, if the previous version was `v5.0.0`, it becomes `v5.0.1`.
+- set the hotfix version tag for the release (or use this tag directly in commands).For example, if the previous version was `v5.0.1`, it becomes `v5.0.2`.
 
   ```bash
-  export HOTFIX_TAG=v5.0.1
+  export HOTFIX_TAG=v5.0.2
   ```
 
 - fork a `hotfix/$HOTFIX_NAME` branch from `master`, and checkout the `hotfix/$HOTFIX_NAME` branch

--- a/fedbiomed/common/constants.py
+++ b/fedbiomed/common/constants.py
@@ -58,7 +58,7 @@ SERVER_certificate_prefix = "server_certificate"
 # 2. bump the version below: if your change breaks backward compatibility you must increase the
 # major version, else the minor version. Micro versions are supported but their use is currently discouraged.
 
-__version__ = FBM_Component_Version('5.0.0')  # Fed-BioMed software version
+__version__ = FBM_Component_Version('5.0.1')  # Fed-BioMed software version
 __researcher_config_version__ = FBM_Component_Version('2')  # researcher config file version
 __node_config_version__ = FBM_Component_Version('2')  # node config file version
 __node_state_version__ = FBM_Component_Version('1')  # node state version

--- a/scripts/fedbiomed_vpn
+++ b/scripts/fedbiomed_vpn
@@ -415,6 +415,7 @@ containers_configure() {
         CONTAINER_USER=${CONTAINER_USER:-$(id -un | sed 's/[^[:alnum:]]/_/g')} \
         CONTAINER_GROUP=${CONTAINER_GROUP:-$(id -gn | sed 's/[^[:alnum:]]/_/g')} \
         $DOCKER_COMPOSE up -d vpnserver
+    sleep 1 # give time to container to initialize
 
     for i in ${ONLY_CONTAINERS[@]}
     do
@@ -453,6 +454,7 @@ containers_start() {
         CONTAINER_USER=${CONTAINER_USER:-$(id -un | sed 's/[^[:alnum:]]/_/g')} \
         CONTAINER_GROUP=${CONTAINER_GROUP:-$(id -gn | sed 's/[^[:alnum:]]/_/g')} \
         $DOCKER_COMPOSE up -d vpnserver
+    sleep 1 # give time to container to initialize
 
     # start other container(s)
     for i in ${ONLY_CONTAINERS[@]}
@@ -476,6 +478,7 @@ containers_start() {
             CONTAINER_USER=${CONTAINER_USER:-$(id -un | sed 's/[^[:alnum:]]/_/g')} \
             CONTAINER_GROUP=${CONTAINER_GROUP:-$(id -gn | sed 's/[^[:alnum:]]/_/g')} \
             $DOCKER_COMPOSE up -d $CONTAINER
+        sleep 1 # give time to container to initialize
 
         case $i in
             researcher)


### PR DESCRIPTION
**PR description**

Fix #969 in v5.0.1

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`