### PR TITLE
fix message display in wrong cell

### DIFF
--- a/fedbiomed/common/ipython.py
+++ b/fedbiomed/common/ipython.py
@@ -1,0 +1,21 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
+
+def is_ipython() -> bool:
+    """
+    Function that checks whether the codes (function itself) is executed in ipython kernel or not
+
+    Returns:
+        True, if python interpreter is IPython
+    """
+
+    ipython_shells = ['ZMQInteractiveShell', 'TerminalInteractiveShell']
+    try:
+        shell = get_ipython().__class__.__name__
+        if shell in ipython_shells:
+            return True
+        else:
+            return False
+    except NameError:
+        return False

--- a/fedbiomed/common/logger.py
+++ b/fedbiomed/common/logger.py
@@ -49,6 +49,7 @@ import logging.handlers
 from typing import Callable, Any
 
 from fedbiomed.common.singleton import SingletonMeta
+from fedbiomed.common.ipython import is_ipython
 
 # default values
 DEFAULT_LOG_FILE = 'mylog.log'
@@ -123,6 +124,21 @@ class _GrpcHandler(logging.Handler):
             except Exception:
                 logging.error("Not able to send log message to remote party")
 
+
+class _IpythonConsoleHandler(logging.Handler):
+    """Logger handler for Ipython consoles.
+
+    Do not use in other contexts.
+    """
+    def emit(self, record: logging.LogRecord):
+        """Emits the logged record
+
+        Args:
+            record: message emitted by the logger
+        """
+
+        # `display` is defined in Ipython context
+        display(record.getMessage())
 
 
 class FedLogger(metaclass=SingletonMeta):
@@ -271,8 +287,10 @@ class FedLogger(metaclass=SingletonMeta):
             format: the format string of the logger
             level: initial level of the logger for this handler (optional) if not given, the default level is set
         """
-
-        handler = logging.StreamHandler()
+        if is_ipython():
+            handler = _IpythonConsoleHandler()
+        else:
+            handler = logging.StreamHandler()
 
         handler.setLevel(self._internal_level_translator(level))
 

--- a/fedbiomed/common/logger.py
+++ b/fedbiomed/common/logger.py
@@ -138,7 +138,7 @@ class _IpythonConsoleHandler(logging.Handler):
         """
 
         # `display` is defined in Ipython context
-        display(record.getMessage())
+        display({'text/plain': record.getMessage() }, raw=True)
 
 
 class FedLogger(metaclass=SingletonMeta):

--- a/fedbiomed/common/logger.py
+++ b/fedbiomed/common/logger.py
@@ -138,7 +138,7 @@ class _IpythonConsoleHandler(logging.Handler):
         """
 
         # `display` is defined in Ipython context
-        display({'text/plain': record.getMessage() }, raw=True)
+        display({'text/plain': self.format(record)}, raw=True)
 
 
 class FedLogger(metaclass=SingletonMeta):

--- a/fedbiomed/common/utils/__init__.py
+++ b/fedbiomed/common/utils/__init__.py
@@ -4,7 +4,6 @@
 from ._utils import (
     read_file,
     get_class_source,
-    is_ipython,
     import_class_from_spec,
     import_class_object_from_file,
     import_class_from_file,
@@ -47,7 +46,6 @@ __all__ = [
     # _utils
     "read_file",
     "get_class_source",
-    "is_ipython",
     "import_class_object_from_file"
     "import_class_from_spec",
     "get_ipython_class_file",

--- a/fedbiomed/common/utils/_utils.py
+++ b/fedbiomed/common/utils/_utils.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from fedbiomed.common.constants import ErrorNumbers
 from fedbiomed.common.exceptions import FedbiomedError
+from fedbiomed.common.ipython import is_ipython
 
 
 def read_file(path):
@@ -70,24 +71,6 @@ def get_class_source(cls: Callable) -> str:
     else:
         return inspect.getsource(cls)
 
-
-def is_ipython() -> bool:
-    """
-    Function that checks whether the codes (function itself) is executed in ipython kernel or not
-
-    Returns:
-        True, if python interpreter is IPython
-    """
-
-    ipython_shells = ['ZMQInteractiveShell', 'TerminalInteractiveShell']
-    try:
-        shell = get_ipython().__class__.__name__
-        if shell in ipython_shells:
-            return True
-        else:
-            return False
-    except NameError:
-        return False
 
 def import_class_object_from_file(module_path: str, class_name: str) -> Tuple[Any, Any]:
     """Import a module from a file and create an instance of a specified class of the module.

--- a/fedbiomed/researcher/experiment.py
+++ b/fedbiomed/researcher/experiment.py
@@ -30,8 +30,8 @@ from fedbiomed.common.optimizers import Optimizer
 from fedbiomed.common.serializer import Serializer
 from fedbiomed.common.training_args import TrainingArgs
 from fedbiomed.common.training_plans import BaseTrainingPlan, TorchTrainingPlan, SKLearnTrainingPlan
+from fedbiomed.common.ipython import is_ipython
 from fedbiomed.common.utils import (
-    is_ipython,
     raise_for_version_compatibility,
     __default_version__,
     import_class_from_file

--- a/tests/test_ipython.py
+++ b/tests/test_ipython.py
@@ -1,0 +1,56 @@
+import unittest
+import fedbiomed.common.ipython as fb_ipython
+import fedbiomed.common.ipython
+
+from unittest.mock import patch
+
+
+class TestIpython(unittest.TestCase):
+    class ZMQInteractiveShell:
+        """ Fake ZMQInteractiveShell class to mock get_ipython function.
+            Function returns this class, so the exceptions can be raised
+            as they are running on IPython kernel
+        """
+
+        def __call__(self):
+            pass
+
+    class ZMQInteractiveShellNone:
+        """ Fake ZMQInteractiveShellNone class to mock get_ipython function.
+            It return class name as `ZMQInteractiveShellNone` so tests
+            can get into condition where the functions get runs on IPython kernel
+            but not in ZMQInteractiveShell
+        """
+
+        def __call__(self):
+            pass
+
+    def setUp(self):
+        pass
+
+    def tearDown(self) -> None:
+        pass
+
+    def test_utils_01_is_ipython(self):
+        """ Test the function is_ipython """
+
+        with patch.object(fedbiomed.common.ipython, 'get_ipython', create=True) as mock_get_ipython:
+            mock_get_ipython.side_effect = TestIpython.ZMQInteractiveShell
+            result = fb_ipython.is_ipython()
+            self.assertTrue(result, f'`is_python` has returned {result}, while the expected is `True`')
+
+            mock_get_ipython.side_effect = TestIpython.ZMQInteractiveShell
+            result = fb_ipython.is_ipython()
+            self.assertTrue(result, f'`is_python` has returned {result}, while the expected is `True`')
+
+            mock_get_ipython.side_effect = TestIpython.ZMQInteractiveShellNone
+            result = fb_ipython.is_ipython()
+            self.assertFalse(result, f'`is_python` has returned {result}, while the expected is `False`')
+
+            mock_get_ipython.side_effect = NameError
+            result = fb_ipython.is_ipython()
+            self.assertFalse(result, f'`is_python` has returned {result}, while the expected is `False`')
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,41 +17,13 @@ class TestClass:
 
 
 class TestUtils(unittest.TestCase):
-    class ZMQInteractiveShell:
-        """ Fake ZMQInteractiveShell class to mock get_ipython function.
-            Function returns this class, so the exceptions can be raised
-            as they are running on IPython kernel
-        """
-
-        def __call__(self):
-            pass
-
-    class ZMQInteractiveShell:
-        """ Fake TerminalInteractiveShell class to mock get_ipython function.
-            Function returns this class, so the exceptions can be raised
-            as they are running on IPython kernel
-        """
-
-        def __call__(self):
-            pass
-
-    class ZMQInteractiveShellNone:
-        """ Fake ZMQInteractiveShellNone class to mock get_ipython function.
-            It return class name as `ZMQInteractiveShellNone` so tests
-            can get into condition where the functions get runs on IPython kernel
-            but not in ZMQInteractiveShell
-        """
-
-        def __call__(self):
-            pass
-
     def setUp(self):
         pass
 
     def tearDown(self) -> None:
         pass
 
-    @patch('fedbiomed.common.utils.is_ipython')
+    @patch('fedbiomed.common.utils._utils.is_ipython')
     @patch('fedbiomed.common.utils.get_ipython_class_file')
     @patch('inspect.linecache.getlines')
     def test_utils_01_get_class_source(self,
@@ -86,27 +58,7 @@ class TestUtils(unittest.TestCase):
         with self.assertRaises(FedbiomedError):
             fed_utils.get_class_source(obj)
 
-    def test_utils_02_is_ipython(self):
-        """ Test the function is_ipython """
-
-        with patch.object(fedbiomed.common.utils._utils, 'get_ipython', create=True) as mock_get_ipython:
-            mock_get_ipython.side_effect = TestUtils.ZMQInteractiveShell
-            result = fed_utils.is_ipython()
-            self.assertTrue(result, f'`is_python` has returned {result}, while the expected is `True`')
-
-            mock_get_ipython.side_effect = TestUtils.ZMQInteractiveShell
-            result = fed_utils.is_ipython()
-            self.assertTrue(result, f'`is_python` has returned {result}, while the expected is `True`')
-
-            mock_get_ipython.side_effect = TestUtils.ZMQInteractiveShellNone
-            result = fed_utils.is_ipython()
-            self.assertFalse(result, f'`is_python` has returned {result}, while the expected is `False`')
-
-            mock_get_ipython.side_effect = NameError
-            result = fed_utils.is_ipython()
-            self.assertFalse(result, f'`is_python` has returned {result}, while the expected is `False`')
-
-    def test_utils_03_get_ipython_class_file(self):
+    def test_utils_02_get_ipython_class_file(self):
         """ Testing function that gets class source from ipython kernel"""
 
         # Test normal case


### PR DESCRIPTION
**PR description**

Fix #975 

Changes the display style of output ...

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`