### PR TITLE
Adding error message when using `import_model` and `export_model`  while model hasnot been instantiated

### DIFF
--- a/docs/user-guide/researcher/training-plan.md
+++ b/docs/user-guide/researcher/training-plan.md
@@ -364,25 +364,26 @@ to control the training process by changing these arguments. Modifying the train
 ```
 
 
-## Exporting and importing model 
+## Exporting and importing model
 
 Each training plan provides export and import functionality.
 
 - Export facility is used for saving model parameters to a file after training the model in Fed-BioMed, so it can be used in another software (eg for inference).
 - Import facility is used for loading model parameters from a file, for example to specialize with Fed-BioMed a model pre-trained with another software (transfer learning) or a previous Fed-BioMed run.
 
+**Exports** and **imports** are handled through the [`Experiment`](../../researcher/experiment) interface. [`Experiment`](../../researcher/experiment) interface will initialize the model for you, by calling internally `Training Plan` methods `init_method` and `post_init`.
 
 To save model to file `/path/to/file` use:
 
-```
-MyTrainingPlan().export_model('/path/to_file')
+```python
+exp.training_plan().export_model('/path/to_file')
 ```
 
 
 To load model from file `/path/to/file` use:
 
-```
-MyTrainingPlan().import_model('/path/to_file')
+```python
+exp.training_plan().import_model('/path/to_file')
 ```
 
 Of course, loaded model needs to be identical to the training plan's model.
@@ -390,7 +391,7 @@ Of course, loaded model needs to be identical to the training plan's model.
 
 After loading model in an [Experiment](../../researcher/experiment) it is needed to also update the model in `Job()` class. For example for an `Experiment` named `exp` use:
 
-```
+```python
 exp.training_plan().import_model('/path/to/file')
 exp.job().update_parameters(exp.training_plan().get_model_params())
 ```
@@ -406,6 +407,6 @@ exp.job().update_parameters(exp.training_plan().get_model_params())
 
     In both PyTorch and scikit-learn, the model saving and loading facility are based on [pickle](https://docs.python.org/3/library/pickle.html). While it is the recommended way of saving models in these frameworks, a malicious pickle model can execute arbitrary code on your machine when loaded. Thus make sure you are loading a model from a reliable source.
 
-
-
-
+!!! warning "Usage through `Experiment`"
+    Both **exports** and **imports** must be used through [Experiment](../../researcher/experiment) interface. Indeed, `Experiment` class has methods to load Training Plans and for initializing Model. Once the Model is initialized, you can
+    use both `export_model` and `import_model` for saving model into a file and respectively load it from a file.

--- a/docs/user-guide/researcher/training-plan.md
+++ b/docs/user-guide/researcher/training-plan.md
@@ -371,7 +371,7 @@ Each training plan provides export and import functionality.
 - Export facility is used for saving model parameters to a file after training the model in Fed-BioMed, so it can be used in another software (eg for inference).
 - Import facility is used for loading model parameters from a file, for example to specialize with Fed-BioMed a model pre-trained with another software (transfer learning) or a previous Fed-BioMed run.
 
-**Exports** and **imports** are handled through the [`Experiment`](../../researcher/experiment) interface. [`Experiment`](../../researcher/experiment) interface will initialize the model for you, by calling internally `Training Plan` methods `init_method` and `post_init`.
+**Exports** and **imports** are handled through the [`Experiment`](../../researcher/experiment) interface. [`Experiment`](../../researcher/experiment) interface will initialize the model for you, by calling internally `Training Plan` methods `init_method` and `post_init`. See example below for an instantiated `Experiment` object named `exp`.
 
 To save model to file `/path/to/file` use:
 
@@ -389,7 +389,7 @@ exp.training_plan().import_model('/path/to_file')
 Of course, loaded model needs to be identical to the training plan's model.
 
 
-After loading model in an [Experiment](../../researcher/experiment) it is needed to also update the model in `Job()` class. For example for an `Experiment` named `exp` use:
+After loading model in an [Experiment](../../researcher/experiment) it is needed to also update the model in `Job()` class:
 
 ```python
 exp.training_plan().import_model('/path/to/file')

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -72,6 +72,10 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         self._optimizer_args: Dict[str, Any] = None
         self._loader_args: Dict[str, Any] = None
         self._training_args: Dict[str, Any] = None
+        
+        self._error_msg_import_model: str = f"{ErrorNumbers.FB605.value}: Training Plan's Model is not initialized.\n" +\
+                                            "To %s a model, you should do it through `fedbiomed.researcher.experiment.Experiment`'s interface" +\
+                                            " and not directly from Training Plan"
 
     @abstractmethod
     def model(self):
@@ -614,6 +618,11 @@ class BaseTrainingPlan(metaclass=ABCMeta):
 
         Args:
             filename: path to the file where the model will be saved.
+        
+        Raises:
+            TrainingPlanError: raised if model has not be initialized through the 
+            `post_init` method. If you need to export the model, you must do it through
+            [`Experiment`][`fedbiomed.researcher.experiment.Experiment`]'s interface.
 
         !!! info "Notes":
             This method is designed to save the model to a local dump
@@ -627,6 +636,8 @@ class BaseTrainingPlan(metaclass=ABCMeta):
             outside of a training context) and export results using
             [`Serializer`][fedbiomed.common.serializer.Serializer].
         """
+        if self._model is None:
+            raise FedbiomedTrainingPlanError(self._error_msg_import_model % "export")
         self._model.export(filename)
 
     def import_model(self, filename: str) -> None:
@@ -634,6 +645,12 @@ class BaseTrainingPlan(metaclass=ABCMeta):
 
         Args:
             filename: path to the file where the model has been exported.
+
+        Raises:
+            TrainingPlanError: raised if model has not be initialized through the 
+            `post_init` method. If you need to export the model, you must do it through
+            [`Experiment`][`fedbiomed.researcher.experiment.Experiment`]'s interface.
+
 
         !!! info "Notes":
             This method is designed to load the model from a local dump
@@ -646,6 +663,8 @@ class BaseTrainingPlan(metaclass=ABCMeta):
             network-exchanged file, and the `set_model_params` method to assign
             the loaded values into the wrapped model.
         """
+        if self._model is None:
+            raise FedbiomedTrainingPlanError(self._error_msg_import_model % "import")
         try:
             self._model.reload(filename)
         except FedbiomedModelError as exc:

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -651,8 +651,6 @@ class BaseTrainingPlan(metaclass=ABCMeta):
             `post_init` method. If you need to export the model from the Training Plan, you
             must do it through [`Experiment`][`fedbiomed.researcher.experiment.Experiment`]'s
             interface.
-            FedbiomedModelError: raised if model cannot be reloaded with the pointed file.
-
 
         !!! info "Notes":
             This method is designed to load the model from a local dump

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -620,7 +620,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
             filename: path to the file where the model will be saved.
         
         Raises:
-            TrainingPlanError: raised if model has not be initialized through the 
+            FedBiomedTrainingPlanError: raised if model has not be initialized through the 
             `post_init` method. If you need to export the model, you must do it through
             [`Experiment`][`fedbiomed.researcher.experiment.Experiment`]'s interface.
 
@@ -647,9 +647,11 @@ class BaseTrainingPlan(metaclass=ABCMeta):
             filename: path to the file where the model has been exported.
 
         Raises:
-            TrainingPlanError: raised if model has not be initialized through the 
-            `post_init` method. If you need to export the model, you must do it through
-            [`Experiment`][`fedbiomed.researcher.experiment.Experiment`]'s interface.
+            FedBiomedTrainingPlanError: raised if model has not be initialized through the 
+            `post_init` method. If you need to export the model from the Training Plan, you
+            must do it through [`Experiment`][`fedbiomed.researcher.experiment.Experiment`]'s
+            interface.
+            FedbiomedModelError: raised if model cannot be reloaded with the pointed file.
 
 
         !!! info "Notes":

--- a/tests/test_fedbiosklearn.py
+++ b/tests/test_fedbiosklearn.py
@@ -131,15 +131,29 @@ class TestSklearnTrainingPlanBasicInheritance(unittest.TestCase):
 
     def test_sklearntrainingplanbasicinheritance_03_export_model(self):
         training_plan = SKLearnTrainingPlan()
+
+        # first test export_model when model hasnot been created
+
+        with self.assertRaises(FedbiomedTrainingPlanError):
+            training_plan.import_model('model_file.pt')
+
+        # then test when modle has been created (eg through Experiment)
         training_plan._model = create_autospec(spec=fedbiomed.common.models._sklearn.BaseSkLearnModel,
                                                instance=True)
-       
+
         training_plan.export_model('filename')
         training_plan._model.export.assert_called_once_with('filename')
 
 
     def test_sklearntrainingplanbasicinheritance_04_import_model(self):
         training_plan = SKLearnTrainingPlan()
+
+        # first test import_model when model hasnot been created
+        temp = tempfile.mkdtemp()  # creating file to load model from
+        with self.assertRaises(FedbiomedTrainingPlanError):
+            training_plan.import_model(temp)
+
+        # then test when modle has been created (eg through Experiment)
         training_plan._model = SGDClassifierSKLearnModel(SGDClassifier())
 
         # Saved object is not of the correct type


### PR DESCRIPTION
**PR description**
Related to issue #952 : the newly implemented methods `export_model` and `import_model` of the training plan cannot be used directly through the `Tranining Plan`, and only once the Training plan has been loaded in the `Experiment`. 

This proposed fix adds:
1.  error messages when one call either `export_model` or `import_model` from the `TrainingPlan`
2. updates for documentation

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`