### PR TITLE
fix gRPC communication instabilities

### DIFF
--- a/fedbiomed/common/constants.py
+++ b/fedbiomed/common/constants.py
@@ -69,8 +69,10 @@ __messaging_protocol_version__ = FBM_Component_Version('2')  # format of gRPC me
 
 
 # Max message length as bytes
-MAX_MESSAGE_BYTES_LENGTH = 4000000 - sys.getsizeof(bytes("", encoding="UTF-8")) # 4MB 
+MAX_MESSAGE_BYTES_LENGTH = 4000000 - sys.getsizeof(bytes("", encoding="UTF-8"))  # 4MB
 
+# Max number of retries for sending message (node and researcher side)
+MAX_SEND_RETRIES = 5
 
 
 class _BaseEnum(Enum):

--- a/fedbiomed/transport/client.py
+++ b/fedbiomed/transport/client.py
@@ -531,7 +531,7 @@ class Sender(Listener):
             except GeneratorExit as exp:
                 await self._on_status_change(ClientStatus.FAILED)
                 raise FedbiomedCommunicationError(
-                    f"{ErrorNumbers.FB628}: Sender has stopped due to unexpected gRPC abort: {exp}") from exp    
+                    f"{ErrorNumbers.FB628}: Sender has stopped due to unexpected gRPC abort: {exp}") from exp
 
 
     async def _get(self, callback: Optional[Callable] = None) -> None:

--- a/fedbiomed/transport/client.py
+++ b/fedbiomed/transport/client.py
@@ -514,6 +514,7 @@ class Sender(Listener):
             if self._retry_count > 5:
                 logger.warning("Message can not be sent to researcher after 5 retries")
                 self._queue.task_done()
+                self._retry_count = 0
 
             msg = await self._queue.get()
 

--- a/fedbiomed/transport/client.py
+++ b/fedbiomed/transport/client.py
@@ -528,6 +528,11 @@ class Sender(Listener):
                 raise FedbiomedCommunicationError(
                     f"{ErrorNumbers.FB628}: Sender has stopped due to unknown reason: {exp}") from exp
 
+            except GeneratorExit as exp:
+                await self._on_status_change(ClientStatus.FAILED)
+                raise FedbiomedCommunicationError(
+                    f"{ErrorNumbers.FB628}: Sender has stopped due to unexpected gRPC abort: {exp}") from exp    
+
 
     async def _get(self, callback: Optional[Callable] = None) -> None:
         """Gets task result from the queue.

--- a/fedbiomed/transport/client.py
+++ b/fedbiomed/transport/client.py
@@ -15,7 +15,7 @@ from fedbiomed.transport.protocols.researcher_pb2_grpc import ResearcherServiceS
 from fedbiomed.common.logger import logger
 from fedbiomed.common.serializer import Serializer
 from fedbiomed.common.message import Message, TaskRequest, TaskResult, FeedbackMessage
-from fedbiomed.common.constants import MAX_MESSAGE_BYTES_LENGTH, ErrorNumbers
+from fedbiomed.common.constants import MAX_MESSAGE_BYTES_LENGTH, MAX_SEND_RETRIES, ErrorNumbers
 from fedbiomed.common.exceptions import FedbiomedCommunicationError
 
 
@@ -545,8 +545,9 @@ class Sender(Listener):
             # initialize in case of early failure
             self._stub_type = _StubType.NO_STUB
 
-            if self._retry_count > 5:
-                logger.warning("Message can not be sent to researcher after 5 retries")
+            if self._retry_count > MAX_SEND_RETRIES:
+                logger.warning(
+                    f"Message can not be sent to researcher after {MAX_SEND_RETRIES} retries. Discard message.")
                 self._queue.task_done()
                 self._retry_count = 0
 

--- a/fedbiomed/transport/client.py
+++ b/fedbiomed/transport/client.py
@@ -592,7 +592,6 @@ class Sender(Listener):
 
             self._queue.task_done()
             self._retry_count = 0
-            self._retry_msg = None
 
 
     def _stream_reply(self, message: Message) -> Iterable:

--- a/fedbiomed/transport/client.py
+++ b/fedbiomed/transport/client.py
@@ -174,14 +174,14 @@ class GrpcClient:
         self,
         node_id: str,
         researcher: ResearcherCredentials,
-        update_id_map: Callable
+        update_id_map: Awaitable
     ) -> None:
         """Class constructor
 
         Args:
             node_id: unique ID of this node (connection client)
             researcher: the researcher to which the node connects (connection server)
-            update_id_map: function to call when updating the researcher ID, needs proper prototype
+            update_id_map: awaitable to call when updating the researcher ID, needs proper prototype
         """
         self._id = None
         self._researcher = researcher
@@ -524,14 +524,14 @@ class Sender(Listener):
             elif isinstance(msg["stub"], grpc.aio.StreamUnaryMultiCallable):
                 stream_call = msg["stub"]()
 
-                if isinstance(callback, Callable):
-                    # we could check the callback prototype
-                    callback(msg["message"])
-
                 for reply in self._stream_reply(msg["message"]):
                     await stream_call.write(reply)
 
                 await stream_call.done_writing()
+
+                if isinstance(callback, Callable):
+                    # we could check the callback prototype
+                    callback(msg["message"])
 
             else:
                 raise FedbiomedCommunicationError(

--- a/fedbiomed/transport/client.py
+++ b/fedbiomed/transport/client.py
@@ -45,7 +45,7 @@ class _StubType(Enum):
 GRPC_CLIENT_CONN_RETRY_TIMEOUT = 2
 
 # timeout in seconds of a request to the server for a task (payload) to run on the node
-GRPC_CLIENT_TASK_REQUEST_TIMEOUT = 60
+GRPC_CLIENT_TASK_REQUEST_TIMEOUT = 3600
 
 
 def is_server_alive(host: str, port: str):
@@ -168,8 +168,8 @@ class Channels:
             # https://www.evanjones.ca/grpc-is-tricky.html
             # https://www.evanjones.ca/tcp-connection-timeouts.html
             # Be sure to keep client-server configuration coherent
-            ("grpc.keepalive_time_ms", GRPC_CLIENT_CONN_RETRY_TIMEOUT * 1000),
-            ("grpc.keepalive_timeout_ms", 1000),
+            ("grpc.keepalive_time_ms", 30 * GRPC_CLIENT_CONN_RETRY_TIMEOUT * 1000),
+            ("grpc.keepalive_timeout_ms", 2 * 1000),
             ("grpc.http2.max_pings_without_data", 0),
             ("grpc.keepalive_permit_without_calls", 1),
             #

--- a/fedbiomed/transport/node_agent.py
+++ b/fedbiomed/transport/node_agent.py
@@ -151,7 +151,9 @@ class NodeAgentAsync:
 
         # Updates replies
         async with self._replies_lock:
-            if message.request_id:
+            # update replies only for (1) request-response messages
+            # (2) that are not yet registered as pending request
+            if message.request_id and message.request_id not in self._replies:
                 self._replies.update({
                     message.request_id: {'callback': on_reply, 'reply': None}
                 })

--- a/fedbiomed/transport/node_agent.py
+++ b/fedbiomed/transport/node_agent.py
@@ -9,7 +9,7 @@ from fedbiomed.common.message import Message, ResearcherMessages
 from fedbiomed.common.logger import logger
 
 # timeout in seconds for server to wait for a new task request from node before assuming node is disconnected
-GPRC_SERVER_TASK_WAIT_TIMEOUT = 10
+GRPC_SERVER_TASK_WAIT_TIMEOUT = 10
 
 
 class NodeActiveStatus(Enum):
@@ -193,12 +193,12 @@ class NodeAgentAsync:
     async def _change_node_status_disconnected(self) -> None:
         """Task coroutine to change node status as `DISCONNECTED` after a delay
 
-        Node becomes DISCONNECTED if it doesn't become ACTIVE in GPRC_SERVER_TASK_WAIT_TIMEOUT seconds,
+        Node becomes DISCONNECTED if it doesn't become ACTIVE in GRPC_SERVER_TASK_WAIT_TIMEOUT seconds,
         which cancels this task
         """
 
-        # Sleep at least GPRC_SERVER_TASK_WAIT_TIMEOUT seconds in WAITING
-        await asyncio.sleep(GPRC_SERVER_TASK_WAIT_TIMEOUT)
+        # Sleep at least GRPC_SERVER_TASK_WAIT_TIMEOUT seconds in WAITING
+        await asyncio.sleep(GRPC_SERVER_TASK_WAIT_TIMEOUT)
 
         # If the status still WAITING set status to DISCONNECTED
         async with self._status_lock:

--- a/fedbiomed/transport/node_agent.py
+++ b/fedbiomed/transport/node_agent.py
@@ -1,8 +1,6 @@
 from enum import Enum
 from typing import Optional, Dict, Callable
-from datetime import datetime
 import copy
-from threading import Event
 
 import asyncio
 import grpc
@@ -46,7 +44,6 @@ class NodeAgentAsync:
             loop: event loop
         """
         self._id: str = id
-        self._last_request: Optional[datetime] = None
         self._replies = Replies()
         self._stopped_request_ids = []
         # Node should be active when it is first instantiated
@@ -56,7 +53,7 @@ class NodeAgentAsync:
         self._loop = loop
         self._status_task : Optional[asyncio.Task] = None
 
-        # protect read/write operations on self._status + self._status_task + self._last_request)
+        # protect read/write operations on self._status + self._status_task)
         self._status_lock = asyncio.Lock()
         self._replies_lock = asyncio.Lock()
         self._stopped_request_ids_lock = asyncio.Lock()
@@ -171,7 +168,6 @@ class NodeAgentAsync:
                 logger.info(f"Node {self._id} is back online!")
 
             self._status = NodeActiveStatus.ACTIVE
-            self._last_request = datetime.now()
 
             # Cancel status task if there is any running
             if self._status_task:

--- a/fedbiomed/transport/server.py
+++ b/fedbiomed/transport/server.py
@@ -25,7 +25,7 @@ from fedbiomed.common.constants import MessageType, MAX_MESSAGE_BYTES_LENGTH
 
 server_setup_timeout = int(os.getenv('GRPC_SERVER_SETUP_TIMEOUT', 1))
 
-GPRC_SERVER_SETUP_TIMEOUT = GRPC_CLIENT_CONN_RETRY_TIMEOUT + server_setup_timeout
+GRPC_SERVER_SETUP_TIMEOUT = GRPC_CLIENT_CONN_RETRY_TIMEOUT + server_setup_timeout
 MAX_GRPC_SERVER_SETUP_TIMEOUT = 20 * server_setup_timeout
 
 
@@ -343,18 +343,18 @@ class GrpcServer(_GrpcAsyncServer):
         logger.info("Starting researcher service...")
 
 
-        logger.info(f'Waiting {GPRC_SERVER_SETUP_TIMEOUT}s for nodes to connect...')
-        time.sleep(GPRC_SERVER_SETUP_TIMEOUT)
+        logger.info(f'Waiting {GRPC_SERVER_SETUP_TIMEOUT}s for nodes to connect...')
+        time.sleep(GRPC_SERVER_SETUP_TIMEOUT)
 
         sleep_ = 0
         while len(self.get_all_nodes()) == 0:
 
             if sleep_ == 0:
                 logger.info(f"No nodes found, server will wait "
-                            f"{MAX_GRPC_SERVER_SETUP_TIMEOUT - GPRC_SERVER_SETUP_TIMEOUT} "
+                            f"{MAX_GRPC_SERVER_SETUP_TIMEOUT - GRPC_SERVER_SETUP_TIMEOUT} "
                             "more seconds until a node creates connection.")
 
-            if sleep_ > MAX_GRPC_SERVER_SETUP_TIMEOUT - GPRC_SERVER_SETUP_TIMEOUT:
+            if sleep_ > MAX_GRPC_SERVER_SETUP_TIMEOUT - GRPC_SERVER_SETUP_TIMEOUT:
                 if len(self.get_all_nodes()) == 0:
                     logger.warning("Server has not received connection from any remote nodes in "
                                    f"MAX_GRPC_SERVER_SETUP_TIMEOUT: {MAX_GRPC_SERVER_SETUP_TIMEOUT} "

--- a/fedbiomed/transport/server.py
+++ b/fedbiomed/transport/server.py
@@ -103,6 +103,9 @@ class ResearcherServicer(researcher_pb2_grpc.ResearcherServiceServicer):
                     ).to_proto()
                 except GeneratorExit:
                     # schedule resend if task sending could not be completed
+                    # => retry send as long as (1) send not successful (2) node is connected
+                    # (no max retries)
+                    # => discard if node is disconnected
                     await node_agent.send_async(task)
                     await node_agent.change_node_status_after_task()
                     # need return here to avoid RuntimeError

--- a/fedbiomed/transport/server.py
+++ b/fedbiomed/transport/server.py
@@ -250,11 +250,11 @@ class _GrpcAsyncServer:
         self._is_started.set()
         try:
             if self._debug:
-                logger.debug("Waiting for termination")
+                logger.debug("Waiting for gRPC server termination")
             await self._server.wait_for_termination()
         finally:
             if self._debug:
-                logger.debug("Done starting the server")
+                logger.debug("gRPC server has stopped")
 
 
     async def send(self, message: Message, node_id: str) -> None:

--- a/fedbiomed/transport/server.py
+++ b/fedbiomed/transport/server.py
@@ -75,14 +75,10 @@ class ResearcherServicer(researcher_pb2_grpc.ResearcherServiceServicer):
             request: RPC request
             context: RPC peer context
         """
-
         task_request = TaskRequest.from_proto(request).get_dict()
         logger.debug(f"Node: {task_request.get('node')} polling for the tasks")
 
-        node_agent = await self._agent_store.retrieve(
-            node_id=task_request["node"],
-            context=context
-        )
+        node_agent = await self._agent_store.retrieve(node_id=task_request["node"])
 
         # Update node active status as active
         await node_agent.set_active()
@@ -102,6 +98,8 @@ class ResearcherServicer(researcher_pb2_grpc.ResearcherServiceServicer):
 
         # Choice: mark task as de-queued as soon only if really sent
         node_agent.task_done()
+
+        await node_agent.change_node_status_after_task()
 
 
 

--- a/fedbiomed/transport/server.py
+++ b/fedbiomed/transport/server.py
@@ -88,10 +88,6 @@ class ResearcherServicer(researcher_pb2_grpc.ResearcherServiceServicer):
         await node_agent.set_active()
 
         task = await node_agent.get_task()
-
-        # Choice: be simple, mark task as de-queued as soon as retrieved
-        node_agent.task_done()
-
         task = Serializer.dumps(task.get_dict())
 
         chunk_range = range(0, len(task), MAX_MESSAGE_BYTES_LENGTH)
@@ -103,6 +99,10 @@ class ResearcherServicer(researcher_pb2_grpc.ResearcherServiceServicer):
                 iteration=iter_,
                 bytes_=task[start:stop]
             ).to_proto()
+
+        # Choice: mark task as de-queued as soon only if really sent
+        node_agent.task_done()
+
 
 
     async def ReplyTask(

--- a/fedbiomed/transport/server.py
+++ b/fedbiomed/transport/server.py
@@ -225,10 +225,10 @@ class _GrpcAsyncServer:
                 # https://www.evanjones.ca/grpc-is-tricky.html
                 # https://www.evanjones.ca/tcp-connection-timeouts.html
                 # Be sure to keep client-server configuration coherent
-                ("grpc.keepalive_time_ms", GRPC_CLIENT_CONN_RETRY_TIMEOUT * 1000),
-                ("grpc.keepalive_timeout_ms", 1000),
+                ("grpc.keepalive_time_ms", 30 * GRPC_CLIENT_CONN_RETRY_TIMEOUT * 1000),
+                ("grpc.keepalive_timeout_ms", 2 * 1000),
                 ("grpc.http2.min_ping_interval_without_data_ms", 0.9 * GRPC_CLIENT_CONN_RETRY_TIMEOUT * 1000),
-                ("grpc.max_connection_idle_ms", (GRPC_CLIENT_TASK_REQUEST_TIMEOUT + 1) * 1000),
+                ("grpc.max_connection_idle_ms", (GRPC_CLIENT_TASK_REQUEST_TIMEOUT + 2) * 1000),
                 ("grpc.max_connection_age_ms", (GRPC_CLIENT_TASK_REQUEST_TIMEOUT + 5) * 1000),
                 ("grpc.max_connection_age_grace_ms", 2 * 1000),
                 ("grpc.http2.max_pings_without_data", 0),

--- a/fedbiomed/transport/server.py
+++ b/fedbiomed/transport/server.py
@@ -104,7 +104,9 @@ class ResearcherServicer(researcher_pb2_grpc.ResearcherServiceServicer):
                 except GeneratorExit:
                     # schedule resend if task sending could not be completed
                     await node_agent.send_async(task)
-                    logger.debug(f"Re-schedule unfinished task response")
+                    await node_agent.change_node_status_after_task()
+                    # need return here to avoid RuntimeError
+                    return
         except asyncio.CancelledError:
             if task is not None:
                 # schedule resend if task was pulled from queue

--- a/tests/test_transport_client.py
+++ b/tests/test_transport_client.py
@@ -70,7 +70,7 @@ class TestGrpcClient(unittest.IsolatedAsyncioTestCase):
 
     async def test_grpc_client_03_on_status_change(self):
 
-        self.client._on_status_change(ClientStatus.CONNECTED)
+        await self.client._on_status_change(ClientStatus.CONNECTED)
         self.assertEqual(self.client._status, ClientStatus.CONNECTED)
 
     async def test_grpc_client_05__update_id(self):

--- a/tests/test_transport_node_agent.py
+++ b/tests/test_transport_node_agent.py
@@ -55,24 +55,17 @@ class TestNodeAgent(unittest.IsolatedAsyncioTestCase):
         self.node_agent._status = NodeActiveStatus.WAITING
         r = await self.node_agent.send_async(message=message)
         item = await self.node_agent._queue.get()
-        self.assertEqual(item, message) 
+        self.assertEqual(item[0], message)
 
         self.node_agent._status = NodeActiveStatus.ACTIVE
         r = await self.node_agent.send_async(message=message)
         item = await self.node_agent._queue.get()
-        self.assertEqual(item, message) 
+        self.assertEqual(item[0], message)
 
         with patch('fedbiomed.transport.node_agent.asyncio.Queue.put') as put:
             put.side_effect = Exception
             with self.assertRaises(Exception):
                 await self.node_agent.send_async(message=message)
-
-
-    async def test_node_agent_05_set_context(self):
-
-        context = MagicMock()
-        self.node_agent.set_context(context)
-        context.add_done_callback.assert_called_once_with(self.node_agent._on_get_task_request_done)
 
     async def test_node_agent_06_get_task(self):
 
@@ -86,31 +79,17 @@ class TestNodeAgent(unittest.IsolatedAsyncioTestCase):
             self.node_agent.task_done()
             task_done.assert_called_once()
 
-
-    async def test_node_agent_08_private_on_get_task_request_done(self):
-
-        context = MagicMock()
-
-        with patch('fedbiomed.transport.node_agent.NodeAgent._change_node_status_after_task', AsyncMock()) as cns:
-            self.node_agent._on_get_task_request_done(context)
-            self.assertTrue(self.node_agent._is_waiting.is_set())
-            cns.assert_called_once()
-
-    async def test_node_agent_09_private_change_node_status_after_task(self):
+    async def test_node_agent_09_change_node_status_after_task(self):
         """ Tests two methods 
 
-        - _change_node_status_after_task
+        - change_node_status_after_task
         - _change_node_status_disconnected
 
         """
         with patch('fedbiomed.transport.node_agent.asyncio.sleep') as sleep:
-            self.node_agent._is_waiting.set()
-            await self.node_agent._change_node_status_after_task()
-            self.node_agent._status = NodeActiveStatus.WAITING
+            await self.node_agent.change_node_status_after_task()
             await self.node_agent._status_task
             self.assertEqual(self.node_agent._status, NodeActiveStatus.DISCONNECTED)
-
-
 
 
 class TestAgentStore(unittest.IsolatedAsyncioTestCase):
@@ -123,18 +102,16 @@ class TestAgentStore(unittest.IsolatedAsyncioTestCase):
         )
 
     async def test_agent_store_01_retrieve(self):
-        mock = MagicMock()
-        node_agent = await self.agent_store.retrieve(node_id='node-id', context=mock)
+        node_agent = await self.agent_store.retrieve(node_id='node-id')
         self.assertTrue('node-id' in self.agent_store._node_agents)
         self.assertIsInstance(node_agent, NodeAgent)
 
 
     async def test_agent_store_02_get_all(self):
-        
-        mock = MagicMock()
+
         # Register node agents
-        await self.agent_store.retrieve(node_id='node-id-1', context=mock)
-        await self.agent_store.retrieve(node_id='node-id-2', context=mock)
+        await self.agent_store.retrieve(node_id='node-id-1')
+        await self.agent_store.retrieve(node_id='node-id-2')
 
         all_ = await self.agent_store.get_all()
 
@@ -143,14 +120,14 @@ class TestAgentStore(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(self.agent_store._node_agents['node-id-2'] == True)
 
     async def test_agent_store_03_get(self):
-        
-        mock = MagicMock()
+
         # Register node agents
-        await self.agent_store.retrieve(node_id='node-id-1', context=mock)
-        await self.agent_store.retrieve(node_id='node-id-2', context=mock)
+        await self.agent_store.retrieve(node_id='node-id-1')
+        await self.agent_store.retrieve(node_id='node-id-2')
 
         result = await self.agent_store.get('node-id-1')
         self.assertEqual(result.id, 'node-id-1')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_transport_server.py
+++ b/tests/test_transport_server.py
@@ -58,7 +58,6 @@ class TestResearcherServicer(unittest.IsolatedAsyncioTestCase):
     async def test_researcher_servicer_01_GetTaskUnary(self):
 
         node_agent = AsyncMock()
-        node_agent.set_context = MagicMock()
         node_agent.task_done = MagicMock()
         node_agent.get_task.return_value = [example_task, 0 , time.time()]
 

--- a/tests/test_transport_server.py
+++ b/tests/test_transport_server.py
@@ -1,6 +1,6 @@
 import unittest
 import asyncio 
-
+import time
 
 
 from unittest.mock import patch, MagicMock, AsyncMock, PropertyMock
@@ -60,7 +60,7 @@ class TestResearcherServicer(unittest.IsolatedAsyncioTestCase):
         node_agent = AsyncMock()
         node_agent.set_context = MagicMock()
         node_agent.task_done = MagicMock()
-        node_agent.get_task.return_value = example_task
+        node_agent.get_task.return_value = [example_task, 0 , time.time()]
 
         self.agent_store.retrieve.return_value = node_agent
         async for r in self.servicer.GetTaskUnary(request=self.request, context=self.context):

--- a/tests/test_transport_server.py
+++ b/tests/test_transport_server.py
@@ -3,7 +3,7 @@ import asyncio
 import time
 
 
-from unittest.mock import patch, MagicMock, AsyncMock, PropertyMock
+from unittest.mock import patch, MagicMock, AsyncMock, PropertyMock, Mock
 
 
 from fedbiomed.transport.node_agent import AgentStore
@@ -98,6 +98,23 @@ class TestResearcherServicer(unittest.IsolatedAsyncioTestCase):
         result = await self.servicer.Feedback(request=request, unused_context=self.context)
         self.on_message.assert_called_once()
         self.assertEqual(result, Empty())
+
+
+    @patch('fedbiomed.transport.server.TaskResponse')
+    async def test_researcher_servicer_04_GetTaskUnary_exceptions(self, task_response):
+
+        for exception in [GeneratorExit, asyncio.CancelledError]:
+            node_agent = AsyncMock()
+            node_agent.task_done = MagicMock()
+            node_agent.send_async = AsyncMock()
+            self.agent_store.retrieve.return_value = node_agent
+
+            node_agent.get_task.return_value = [example_task, 0 , time.time()]
+            task_response.side_effect = exception
+
+            async for r in self.servicer.GetTaskUnary(request=self.request, context=self.context):
+                self.assertEqual(r, None)
+            node_agent.send_async.assert_called_once()
 
 
 class TestGrpcAsyncServer(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
**PR description**

Fix #980 #981

Review is mostly doing stability checks with some heavy tests (rather than code review)
- [x] @mvesin long tests on setup that revealed the issue (101 notebook + 2 nodes + 60 rounds, no batch_maxnum) x 8 runs
- [x] @mvesin long tests on setup that revealed the issue (101 notebook + 3 nodes + 60 rounds, no batch_maxnum) x 4 runs
- [x] @mvesin long tests on setup that revealed the issue (secagg notebook + 3 nodes + 30 rounds, no batch_maxnum, no breakpoints) x 10 runs
- [x] @sharkovsky long test on MacOS (101 notebook + 2 nodes + 30 rounds, no batch_maxnum) 1 or several runs depending on speed

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`