### PR TITLE
Fix for declearn optimizer not able save breakpoint

### DIFF
--- a/fedbiomed/researcher/job.py
+++ b/fedbiomed/researcher/job.py
@@ -227,7 +227,6 @@ class Job:
         """
 
         self._training_replies[round_] = {}
-        print("REPLY", replies)
 
         # Loops over errors
         for node_id, error in errors.items():
@@ -414,14 +413,13 @@ class Job:
             node_id = reply["node_id"]
             node_av = reply.get("optim_aux_var", {})
             for module, params in node_av.items():
-                print("PROCESS", module, params)
                 aux_var.setdefault(module, {})[node_id] = params
             # save optimizer auxiliary variables in a file
             # FIXME: should we keep them for advanced optimizer/strategies?
-            aux_vars_path = os.path.join(self._keep_files_dir, f"auxilary_var_replies_{node_id}.mpk")
+            aux_vars_path = os.path.join(self._keep_files_dir, f"auxilary_var_replies_{round_id}_{node_id}.mpk")
             Serializer.dump(reply["optim_aux_var"], aux_vars_path)
             reply["optim_aux_var"] = aux_vars_path
-            #reply.pop("optim_aux_var")
+
         return aux_var
 
     def _get_model_params(self) -> Dict[str, Any]:
@@ -595,7 +593,6 @@ class Job:
                 reply.pop('params', None)
 
             converted_training_replies.append(training_reply)
-        print("TP", converted_training_replies)
 
         return converted_training_replies
 

--- a/fedbiomed/researcher/job.py
+++ b/fedbiomed/researcher/job.py
@@ -416,9 +416,10 @@ class Job:
                 aux_var.setdefault(module, {})[node_id] = params
             # save optimizer auxiliary variables in a file
             # FIXME: should we keep them for advanced optimizer/strategies?
-            aux_vars_path = os.path.join(self._keep_files_dir, f"auxilary_var_replies_{round_id}_{node_id}.mpk")
-            Serializer.dump(reply["optim_aux_var"], aux_vars_path)
-            reply["optim_aux_var"] = aux_vars_path
+            if node_av:
+                aux_vars_path = os.path.join(self._keep_files_dir, f"auxilary_var_replies_{round_id}_{node_id}.mpk")
+                Serializer.dump(reply["optim_aux_var"], aux_vars_path)
+                reply["optim_aux_var"] = aux_vars_path
 
         return aux_var
 

--- a/fedbiomed/researcher/job.py
+++ b/fedbiomed/researcher/job.py
@@ -424,8 +424,9 @@ class Job:
             if node_av:
                 nodes_optim_aux_vars.update({node_id: node_av})
                 if aux_vars_path is None:
-                    aux_vars_path = os.path.join(self._keep_files_dir, f"auxilary_var_replies_{round_id}.mpk")
-                
+                    aux_vars_path = os.path.join(
+                        self._keep_files_dir, f"auxiliary_var_replies_{round_id}_{uuid.uuid4()}.mpk")
+
                 reply["optim_aux_var"] = aux_vars_path
         if nodes_optim_aux_vars:
             Serializer.dump(nodes_optim_aux_vars, aux_vars_path)


### PR DESCRIPTION
**PR description**

Proposes a fix for the bug described in #992 

`TrainingReplies` are saved in breakpoints, keeping copies of what is sent back by Nodes. However, they may contain auxiliary_variables parameters received from `Nodes` that are non JSON serializable.
This fix proposes to save these auxiliary variables and non JSON serializable parameters into files, so we keep consistency with the notion of `TrainingReplies`.

-  There is one file for node auxiliary variable parameters at each `Round`: we may to optimize the way they are saved in order to reduce the number of files we have
 - the auxiliary variable parameters are converted into a file during the auxiliary variable data extraction process. This might not be suitable with the purpose of the method (which is bsically to extract data, not to transform data)
 - auxiliary variable data are converted when processing data on the `Researcher` side, decreasing the amount of data stored in the memory (a path is stored instead of a Tensor)

*Example*:  optim_aux_var are converted and saved at each `Round` in this format:
```
{'NODE_1234': {'scaffold': {'state': TorchVector with 8 coefs:
       ... }},
 'NODE_4321'': {'scaffold': {'state': TorchVector with 8 coefs:
       ...}}
}
``` 

We might decide at some point whether or not we keep or not these pieces of information in the `TrainingReplies`
There is no test for this bug, since a complete refactor is coming soon, but please advise and ask me to implement one if needed. Also, I was wondering if we needed a method to revert back optimizer auxiliary variables (not implemented yet)

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`