### PR TITLE
Hotfix/1003 fix after training params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Fed-BioMed changelog
 
+## 2024-02-23 version 5.1.1
+
+- fix missing layers when using BatchNorm and other persistent buffers with SecAgg
+
 ## 2024-02-19 version 5.1.0
 
 - multiple fixes and improvements for gRPC communications stability

--- a/fedbiomed/common/constants.py
+++ b/fedbiomed/common/constants.py
@@ -58,7 +58,7 @@ SERVER_certificate_prefix = "server_certificate"
 # 2. bump the version below: if your change breaks backward compatibility you must increase the
 # major version, else the minor version. Micro versions are supported but their use is currently discouraged.
 
-__version__ = FBM_Component_Version('5.1.0')  # Fed-BioMed software version
+__version__ = FBM_Component_Version('5.1.1')  # Fed-BioMed software version
 __researcher_config_version__ = FBM_Component_Version('2')  # researcher config file version
 __node_config_version__ = FBM_Component_Version('2')  # node config file version
 __node_state_version__ = FBM_Component_Version('1')  # node state version

--- a/fedbiomed/common/models/_model.py
+++ b/fedbiomed/common/models/_model.py
@@ -126,7 +126,7 @@ class Model(Generic[_MT, DT], metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def flatten(self) -> List[float]:
+    def flatten(self, params: Dict[str, Any]) -> List[float]:
         """Flattens model weights
 
         Returns:
@@ -177,12 +177,15 @@ class Model(Generic[_MT, DT], metaclass=ABCMeta):
     @abstractmethod
     def unflatten(
             self,
-            weights_vector: List[float]
+            weights_vector: List[float],
+            model_params: Dict[str, Any]
     ) -> None:
         """Revert flatten model weights back model-dict form.
 
         Args:
             weights_vector: Vectorized model weights to convert dict
+            model_params: Dictionary of model parameters in the format {param name: param value}. This is used only
+                to infer the format of the parameters (names and shapes).
 
         Returns:
             Model dictionary
@@ -191,4 +194,8 @@ class Model(Generic[_MT, DT], metaclass=ABCMeta):
         if not isinstance(weights_vector, list) or not all([isinstance(w, float) for w in weights_vector]):
             raise FedbiomedModelError(
                 f"{ErrorNumbers.FB622} `weights_vector should be 1D list of float containing flatten model parameters`"
+            )
+        if not isinstance(model_params, dict):
+            raise FedbiomedModelError(
+                f"{ErrorNumbers.FB622} `model_params` should be a dict of the form {{param name: param value}}"
             )

--- a/fedbiomed/common/models/_sklearn.py
+++ b/fedbiomed/common/models/_sklearn.py
@@ -137,16 +137,15 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
             ) from err
         return weights
 
-    def flatten(self) -> List[float]:
+    def flatten(self, params: Dict[str, Any]) -> List[float]:
         """Gets weights as flatten vector
 
         Returns:
             to_list: Convert np.ndarray to a list if it is True.
         """
 
-        weights = self.get_weights()
         flatten = []
-        for _, w in weights.items():
+        for _, w in params.items():
             w_: List[float] = list(w.flatten().astype(float))
             flatten.extend(w_)
 
@@ -154,25 +153,27 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
 
     def unflatten(
             self,
-            weights_vector: List[float]
+            weights_vector: List[float],
+            model_params: Dict[str, Any]
     ) -> Dict[str, np.ndarray]:
         """Unflatten vectorized model weights
 
         Args:
             weights_vector: Vectorized model weights to convert dict
+            model_params: Dictionary of model parameters in the format {param name: param value}. This is used only
+                to infer the format of the parameters (names and shapes)
 
         Returns:
             Model dictionary
         """
 
-        super().unflatten(weights_vector)
+        super().unflatten(weights_vector, model_params)
 
         weights_vector = np.array(weights_vector)
-        weights = self.get_weights()
         pointer = 0
 
         params = {}
-        for key, w in weights.items():
+        for key, w in model_params.items():
             num_param = w.size
             params[key] = weights_vector[pointer: pointer + num_param].reshape(w.shape)
 

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -610,7 +610,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
             The trained parameters to aggregate.
         """
         if flatten:
-            return self._model.flatten()
+            return self._model.flatten(params=self.get_model_params())
         return self.get_model_params()
 
     def export_model(self, filename: str) -> None:

--- a/fedbiomed/common/training_plans/_torchnn.py
+++ b/fedbiomed/common/training_plans/_torchnn.py
@@ -604,12 +604,12 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         if self._share_persistent_buffers:
             params = dict(self._model.model.state_dict())
         else:
-            params = super().after_training_params()
+            params = super().after_training_params(flatten=False)
         # Check whether postprocess method exists, and use it.
         if hasattr(self, 'postprocess'):
             logger.debug("running model.postprocess() method")
             try:
-                params = self.postprocess(self._model.model.state_dict())  # Post process
+                params = self.postprocess(params)  # Post process
             except Exception as e:
                 raise FedbiomedTrainingPlanError(f"{ErrorNumbers.FB605.value}: Error while running post-process "
                                                  f"{e}") from e
@@ -617,7 +617,7 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         # Run (optional) DP controller adjustments as well.
         params = self._dp_controller.after_training(params)
         if flatten:
-            params = self._model.flatten()
+            params = self._model.flatten(params)
         return params
 
     def __norm_l2(self) -> float:

--- a/fedbiomed/researcher/aggregators/aggregator.py
+++ b/fedbiomed/researcher/aggregators/aggregator.py
@@ -83,7 +83,8 @@ class Aggregator:
         # Convert model params
         model = training_plan._model
 
-        model_params = model.unflatten(aggregated_params)
+        model_params = model.unflatten(weights_vector=aggregated_params,
+                                       model_params=training_plan.after_training_params())
 
         return model_params
 

--- a/fedbiomed/researcher/aggregators/scaffold.py
+++ b/fedbiomed/researcher/aggregators/scaffold.py
@@ -373,7 +373,7 @@ class Scaffold(Aggregator):
                 the number of layers contained in the model (in Pytroch, each layer can have a specific learning rate).
         """
 
-        n_model_layers = len(training_plan.get_model_params())
+        n_model_layers = len(training_plan.get_model_params(only_trainable=True))
         for node_id in self._fds.node_ids():
             lrs: Dict[str, float] = {}
 

--- a/fedbiomed/researcher/experiment.py
+++ b/fedbiomed/researcher/experiment.py
@@ -1506,7 +1506,9 @@ class Experiment:
             )
             # FIXME: Access TorchModel through non-private getter once it is implemented
             aggregated_params: Dict[str, Union[torch.tensor, np.ndarray]] = (
-                self._job.training_plan._model.unflatten(flatten_params)
+                self._job.training_plan._model.unflatten(weights_vector=flatten_params,
+                                                         model_params=self.training_plan().after_training_params(
+                                                             flatten=False))
             )
 
         else:

--- a/fedbiomed/researcher/job.py
+++ b/fedbiomed/researcher/job.py
@@ -294,7 +294,7 @@ class Job:
             'round': round_,
             'training_plan': self._training_plan.source(),
             'training_plan_class': self._training_plan_class.__name__,
-            'params': self._get_model_params(),
+            'params': self._get_model_params(only_trainable=not self._training_args.dict()['share_persistent_buffers']),
             'secagg_servkey_id': secagg_arguments.get('secagg_servkey_id'),
             'secagg_biprime_id': secagg_arguments.get('secagg_biprime_id'),
             'secagg_random': secagg_arguments.get('secagg_random'),
@@ -432,13 +432,17 @@ class Job:
             Serializer.dump(nodes_optim_aux_vars, aux_vars_path)
         return aux_var
 
-    def _get_model_params(self) -> Dict[str, Any]:
+    def _get_model_params(self,
+                          only_trainable: bool = False) -> Dict[str, Any]:
         """Gets model parameters form the training plan.
+
+        Arguments:
+            only_trainable: switch to include only the trainable parameters (default: False)
 
         Returns:
             Model weights, as a dictionary mapping parameters' names to their value.
         """
-        return self._training_plan.get_model_params()
+        return self._training_plan.get_model_params(only_trainable=only_trainable)
 
     def _load_and_set_model_params_from_file(self, path: str) -> None:
         """Loads model parameters from given path

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 import copy
+from collections import OrderedDict
 import logging
 import unittest
 import urllib.request
@@ -377,19 +378,19 @@ class TestSkLearnModel(unittest.TestCase):
             model.model.partial_fit(inputs, target)
             coef = model.model.coef_.astype(float).flatten()
             intercepts = model.model.intercept_.astype(float).flatten()
-            flatten = model.flatten()
+            flatten = model.flatten(model.get_weights())
 
             self.assertListEqual(flatten, [*intercepts, *coef])
 
-            unflatten = model.unflatten(flatten)
+            unflatten = model.unflatten(flatten, model_params=model.get_weights())
             self.assertListEqual(unflatten["coef_"].tolist(), model.model.coef_.tolist())
             self.assertListEqual(unflatten["intercept_"].tolist(), model.model.intercept_.tolist())
 
             with self.assertRaises(FedbiomedModelError):
-                model.unflatten({"un-sported-type": "oopps"})
+                model.unflatten({"un-sported-type": "oopps"}, model_params={})
 
             with self.assertRaises(FedbiomedModelError):
-                model.unflatten(["not-float-list"])
+                model.unflatten(["not-float-list"], model_params={})
 
     def test_sklearnmodel_11_set_weights(self):
         """Test that 'SkLearnModel.set_weights' works properly."""
@@ -698,7 +699,7 @@ class TestTorchModel(unittest.TestCase):
         """Tests flatten and unflatten methods of Sklearn methods"""
 
         # Flatten model parameters
-        flatten = self.model.flatten()
+        flatten = self.model.flatten(self.model.get_weights())
 
         weights = self.model.get_weights()
 
@@ -706,16 +707,19 @@ class TestTorchModel(unittest.TestCase):
         b = weights["bias"].flatten().tolist()
         self.assertListEqual(flatten, [*w, *b])
 
-        unflatten = dict(self.model.unflatten(flatten))
+        unflatten = dict(self.model.unflatten(flatten, model_params=self.model.get_weights()))
         self.assertListEqual(unflatten["weight"].tolist(), weights["weight"].tolist())
         self.assertListEqual(unflatten["bias"].tolist(), weights["bias"].tolist())
 
         # Test invalid argument types
         with self.assertRaises(FedbiomedModelError):
-            self.model.unflatten({"un-sported-type": "oopps"})
+            self.model.unflatten({"un-sported-type": "oopps"}, model_params={})
 
         with self.assertRaises(FedbiomedModelError):
-            self.model.unflatten(["not-float-list"])
+            self.model.unflatten(["not-float-list"], model_params={})
+
+        with self.assertRaises(FedbiomedModelError):
+            self.model.unflatten([0.1], model_params='not a dict')
 
     def test_torchmodel_09_export(self):
         """Test that 'TorchModel.export' works properly."""

--- a/tests/test_torchnn.py
+++ b/tests/test_torchnn.py
@@ -815,6 +815,19 @@ class TestTorchnn(unittest.TestCase):
         with self.assertRaises(FedbiomedTrainingPlanError):
             tp.export_model(temp)
 
+    def test_after_training_params(self):
+        model = nn.Linear(1,1)
+        tp = self.run_model_initialization(model=model)
+        params = tp.after_training_params()
+        self.assertDictEqual(model.state_dict(), params)
+
+        tp.postprocess = lambda x: x
+        params = tp.after_training_params()
+        self.assertDictEqual(model.state_dict(), params)
+
+        params = tp.after_training_params(flatten=True)
+        self.assertListEqual(list(model.state_dict().values()), params)
+
 
 class TestSendToDevice(unittest.TestCase):
 
@@ -980,6 +993,7 @@ class TestTorchNNTrainingRoutineDataloaderTypes(unittest.TestCase):
         tp.training_step.assert_called_once_with({'key': torch.Tensor([0])}, {'key': torch.Tensor([1])})
         patch_tensor_backward.assert_called_once()
         #tp._optimizer.step.assert_called()
+
 
 
 if __name__ == '__main__':  # pragma: no cover


### PR DESCRIPTION
Fix #1003.

This PR fixes an issue that I encountered whereby some layers were missing from the breakpoints when using SecAgg. 

While working on this, I noticed several inconsistencies in the way that we handle model parameters: we have multiple "entry points" to obtain them (e.g. `after_training_params`, `get_weights`), as well as modifiers that the user can apply (e.g. `share_persistent_buffers`). 

I do not claim that I fixed all these inconsistencies in an elegant way, but my goal was to get the code into a working state, since I plan to review and improve all of this in PR #943 . 

The main changes that I tried to introduce are: 
1. the `share_persistent_buffers` training argument is now taken into account also in `Job._get_model_params`, even though the implementation is slightly misleading. 
2. the `flatten` method (used in SecAgg) now takes as inputs the parameters to be flattened
3. the `unflatten` method (used in SecAgg) now takes as inputs the dictionary of model parameters, to be used as template for reconstructing the parameter shapes and names from the flat vector
4. the `TorchTrainingPlan.after_training_params` method has been fixed to correctly re-use the partial results that are computed within the method itself


