### PR TITLE
Added buffers in breakpoints for secagg

### DIFF
--- a/fedbiomed/common/models/_model.py
+++ b/fedbiomed/common/models/_model.py
@@ -188,12 +188,19 @@ class Model(Generic[_MT, DT], metaclass=ABCMeta):
     @abstractmethod
     def unflatten(
             self,
-            weights_vector: List[float]
+            weights_vector: List[float],
+            only_trainable: bool = False,
+            exclude_buffers: bool = True
     ) -> None:
         """Revert flatten model weights back model-dict form.
 
         Args:
             weights_vector: Vectorized model weights to convert dict
+            only_trainable: Whether to ignore non-trainable model parameters
+                from outputs (e.g. frozen neural network layers' parameters),
+                or include all model parameters (the default).
+            exclude_buffers: Whether to ignore buffers (the default), or 
+                include them.
 
         Returns:
             Model dictionary

--- a/fedbiomed/common/models/_sklearn.py
+++ b/fedbiomed/common/models/_sklearn.py
@@ -182,7 +182,7 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
             Model dictionary
         """
 
-        super().unflatten(weights_vector)
+        super().unflatten(weights_vector, only_trainable, exclude_buffers)
 
         weights_vector = np.array(weights_vector)
         weights = self.get_weights()

--- a/fedbiomed/common/models/_sklearn.py
+++ b/fedbiomed/common/models/_sklearn.py
@@ -173,6 +173,10 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
 
         Args:
             weights_vector: Vectorized model weights to convert dict
+            only_trainable: Unused for scikit-learn models. (Whether to ignore
+                non-trainable model parameters.)
+            exclude_buffers: Unused for scikit-learn models. (Whether to ignore
+                buffers.)
 
         Returns:
             Model dictionary

--- a/fedbiomed/common/models/_sklearn.py
+++ b/fedbiomed/common/models/_sklearn.py
@@ -165,7 +165,9 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
 
     def unflatten(
             self,
-            weights_vector: List[float]
+            weights_vector: List[float],
+            only_trainable: bool = False,
+            exclude_buffers: bool = True
     ) -> Dict[str, np.ndarray]:
         """Unflatten vectorized model weights
 

--- a/fedbiomed/common/models/_torch.py
+++ b/fedbiomed/common/models/_torch.py
@@ -114,6 +114,11 @@ class TorchModel(Model):
 
         Args:
             weights_vector: Vectorized model weights to convert dict
+            only_trainable: Whether to ignore non-trainable model parameters
+                from outputs (e.g. frozen neural network layers' parameters),
+                or include all model parameters (the default).
+            exclude_buffers: Whether to ignore buffers (the default), or 
+                include them.
 
         Returns:
             Model dictionary

--- a/fedbiomed/common/models/_torch.py
+++ b/fedbiomed/common/models/_torch.py
@@ -96,7 +96,6 @@ class TorchModel(Model):
         Returns:
             to_list: Convert np.ndarray to a list if it is True.
         """
-
         params: List[float] = torch.nn.utils.parameters_to_vector(
             self.get_weights(only_trainable=only_trainable, exclude_buffers=exclude_buffers).values()
         ).tolist()
@@ -105,7 +104,9 @@ class TorchModel(Model):
 
     def unflatten(
             self,
-            weights_vector: List[float]
+            weights_vector: List[float],
+            only_trainable: bool = False,
+            exclude_buffers: bool = True
     ) -> Dict[str, torch.Tensor]:
         """Unflatten vectorized model weights using [`vector_to_parameters`][torch.nn.utils.vector_to_parameters]
 
@@ -121,18 +122,18 @@ class TorchModel(Model):
         super().unflatten(weights_vector)
 
         # Copy model to make sure global model parameters won't be overwritten
-        model = copy.deepcopy(self.model)
+        model = copy.deepcopy(self)
         vector = torch.as_tensor(weights_vector).type(torch.DoubleTensor)
+        weights = model.get_weights(only_trainable=only_trainable, exclude_buffers=exclude_buffers)
 
         # Following operation updates model parameters of copied model object
         try:
-            torch.nn.utils.vector_to_parameters(vector, model.parameters())
+            torch.nn.utils.vector_to_parameters(vector, weights.values())
         except TypeError as e:
             FedbiomedModelError(
                 f"{ErrorNumbers.FB622.value} Can not unflatten model parameters. {e}"
             )
-
-        return TorchModel(model).get_weights()
+        return weights
 
     def set_weights(
         self,

--- a/fedbiomed/common/models/_torch.py
+++ b/fedbiomed/common/models/_torch.py
@@ -124,7 +124,7 @@ class TorchModel(Model):
             Model dictionary
         """
 
-        super().unflatten(weights_vector)
+        super().unflatten(weights_vector, only_trainable, exclude_buffers)
 
         # Copy model to make sure global model parameters won't be overwritten
         model = copy.deepcopy(self)

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -613,7 +613,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         Returns:
             The trained parameters to aggregate.
         """
-        exclude_buffers=not self._training_args['share_persistent_buffers']
+        exclude_buffers = not self._training_args['share_persistent_buffers']
         if flatten:
             return self._model.flatten(exclude_buffers=exclude_buffers)
         return self.get_model_params(exclude_buffers=exclude_buffers)

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -613,7 +613,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         Returns:
             The trained parameters to aggregate.
         """
-        exclude_buffers=self._training_args['share_persistent_buffers']
+        exclude_buffers=not self._training_args['share_persistent_buffers']
         if flatten:
             return self._model.flatten(exclude_buffers=exclude_buffers)
         return self.get_model_params(exclude_buffers=exclude_buffers)

--- a/fedbiomed/common/training_plans/_torchnn.py
+++ b/fedbiomed/common/training_plans/_torchnn.py
@@ -617,7 +617,7 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         # Run (optional) DP controller adjustments as well.
         params = self._dp_controller.after_training(params)
         if flatten:
-            params = self._model.flatten()
+            params = self._model.flatten(exclude_buffers=not self._share_persistent_buffers)
         return params
 
     def __norm_l2(self) -> float:

--- a/fedbiomed/common/training_plans/_torchnn.py
+++ b/fedbiomed/common/training_plans/_torchnn.py
@@ -601,10 +601,7 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         """
         # Either include non-parameter buffers to the outputs or not.
         # Note: this is mostly about sharing statistics from BatchNorm layers.
-        if self._share_persistent_buffers:
-            params = dict(self._model.model.state_dict())
-        else:
-            params = super().after_training_params()
+        params = super().after_training_params()
         # Check whether postprocess method exists, and use it.
         if hasattr(self, 'postprocess'):
             logger.debug("running model.postprocess() method")

--- a/fedbiomed/researcher/federated_workflows/_experiment.py
+++ b/fedbiomed/researcher/federated_workflows/_experiment.py
@@ -852,11 +852,11 @@ class Experiment(TrainingPlanWorkflow):
                 encryption_factors=encryption_factors,
                 total_sample_size=total_sample_size,
                 model_params=model_params,
-                num_expected_params=len(self.training_plan()._model.flatten())
+                num_expected_params=len(self.training_plan()._model.flatten(exclude_buffers = not self.training_args()['share_persistent_buffers']))
             )
             # FIXME: Access TorchModel through non-private getter once it is implemented
             aggregated_params: Dict[str, Union[torch.tensor, np.ndarray]] = (
-                self.training_plan()._model.unflatten(flatten_params)
+                self.training_plan()._model.unflatten(flatten_params, exclude_buffers = not self.training_args()['share_persistent_buffers'])
             )
 
         else:

--- a/fedbiomed/researcher/federated_workflows/_experiment.py
+++ b/fedbiomed/researcher/federated_workflows/_experiment.py
@@ -1183,7 +1183,7 @@ class Experiment(TrainingPlanWorkflow):
         loaded_exp, saved_state = super().load_breakpoint()
         # retrieve breakpoint sampling strategy
         bkpt_sampling_strategy_args = saved_state.get("node_selection_strategy")
-        bkpt_sampling_strategy = cls._create_object(bkpt_sampling_strategy_args, data=loaded_exp.training_data())
+        bkpt_sampling_strategy = cls._create_object(bkpt_sampling_strategy_args)
         loaded_exp.set_strategy(bkpt_sampling_strategy)
         # retrieve breakpoint researcher optimizer
         bkpt_optim = Experiment._load_optimizer(saved_state.get("agg_optimizer"))

--- a/fedbiomed/researcher/federated_workflows/_training_plan_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_training_plan_workflow.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Type, TypeVar, Union, Optional, Tuple
 from fedbiomed.common.constants import ErrorNumbers
 from fedbiomed.common.exceptions import FedbiomedExperimentError, FedbiomedJobError
 from fedbiomed.common.logger import logger
+from fedbiomed.common.serializer import Serializer
 from fedbiomed.common.training_args import TrainingArgs
 from fedbiomed.common.training_plans import TorchTrainingPlan, SKLearnTrainingPlan
 from fedbiomed.common.utils import import_class_from_file
@@ -367,6 +368,9 @@ class TrainingPlanWorkflow(FederatedWorkflow, ABC):
             # experiment in a different tree
             os.path.join('..', os.path.basename(training_plan_file))
         )
+        params_path = os.path.join(breakpoint_path, f"model_params_{uuid.uuid4()}.mpk")
+        Serializer.dump(self.training_plan()._model.get_weights(only_trainable = False, exclude_buffers = False), params_path)
+        state['model_weights_path'] = params_path
 
         super().breakpoint(state, bkpt_number)
 
@@ -407,6 +411,9 @@ class TrainingPlanWorkflow(FederatedWorkflow, ABC):
                   'breakpoint file seems corrupted, `training_plan` is None'
             logger.critical(msg)
             raise FedbiomedExperimentError(msg)
+        param_path = saved_state['model_weights_path']
+        params = Serializer.load(param_path)
+        loaded_exp.training_plan()._model.set_weights(params)
 
         return loaded_exp, saved_state
 

--- a/tests/test_training_plan_workflow.py
+++ b/tests/test_training_plan_workflow.py
@@ -215,7 +215,7 @@ class TestTrainingPlanWorkflow(ResearcherTestCase, MockRequestModule):
             1
         )
 
-    @patch('fedbiomed.common.serializer.Serializer.load')
+    @patch('fedbiomed.common.serializer.Serializer.load', return_value={"coefs": [1, 2, 3]})
     @patch(
         'fedbiomed.researcher.federated_workflows.'
         '_training_plan_workflow.import_class_from_file',
@@ -247,6 +247,11 @@ class TestTrainingPlanWorkflow(ResearcherTestCase, MockRequestModule):
         self.assertEqual(exp.training_plan_class(), FakeTorchTrainingPlan)
         self.assertIsInstance(exp.training_plan(), FakeTorchTrainingPlan)
         self.assertDictEqual(exp.model_args(), {'breakpoint-model': 'args'})
+        # Test if set_weights is called with the right arguments
+        print('ICI', type(exp.training_plan()._model.set_weights))
+        exp.training_plan()._model.set_weights.assert_called_once_with(
+            mock_serializer_load.return_value
+        )
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/tests/test_training_plan_workflow.py
+++ b/tests/test_training_plan_workflow.py
@@ -248,7 +248,6 @@ class TestTrainingPlanWorkflow(ResearcherTestCase, MockRequestModule):
         self.assertIsInstance(exp.training_plan(), FakeTorchTrainingPlan)
         self.assertDictEqual(exp.model_args(), {'breakpoint-model': 'args'})
         # Test if set_weights is called with the right arguments
-        print('ICI', type(exp.training_plan()._model.set_weights))
         exp.training_plan()._model.set_weights.assert_called_once_with(
             mock_serializer_load.return_value
         )

--- a/tests/test_training_plan_workflow.py
+++ b/tests/test_training_plan_workflow.py
@@ -176,11 +176,13 @@ class TestTrainingPlanWorkflow(ResearcherTestCase, MockRequestModule):
         status = exp.check_training_plan_status()
         mock_approval_job.execute.assert_called_once_with()
 
+    @patch('fedbiomed.common.serializer.Serializer.dump')
     @patch('fedbiomed.researcher.federated_workflows._training_plan_workflow.FederatedWorkflow.breakpoint')
     @patch('fedbiomed.researcher.federated_workflows._training_plan_workflow.uuid.uuid4', return_value='UUID')
     def test_federated_workflow_06_breakpoint(self,
                                               mock_uuid,
                                               mock_super_breakpoint,
+                                              mock_serializer_dump
                                               ):
         # define attributes that will be saved in breakpoint
         exp = TrainingPlanWorkflow(
@@ -188,6 +190,16 @@ class TestTrainingPlanWorkflow(ResearcherTestCase, MockRequestModule):
             model_args={'breakpoint-model': 'args'}
         )
         exp.breakpoint(state={}, bkpt_number=1)
+        # Test if the Serializer.dump is called once with the good arguments
+        params_path = os.path.join(environ['EXPERIMENTS_DIR'],
+                                   exp.experimentation_folder(),
+                                   'breakpoint_0000',
+                                   f'model_params_{mock_uuid.return_value}.mpk'
+                                   )
+        mock_serializer_dump.assert_called_once_with(
+            self.mock_tp._model.get_weights.return_value,
+            params_path
+        )
         # This also validates the breakpoint scheme: if this fails, please consider updating the breakpoints version
         mock_super_breakpoint.assert_called_once_with(
             {
@@ -198,10 +210,12 @@ class TestTrainingPlanWorkflow(ResearcherTestCase, MockRequestModule):
                                                    'breakpoint_0000',
                                                    'model_0000.py'
                                                    ),
+                'model_weights_path': params_path
             },
             1
         )
 
+    @patch('fedbiomed.common.serializer.Serializer.load')
     @patch(
         'fedbiomed.researcher.federated_workflows.'
         '_training_plan_workflow.import_class_from_file',
@@ -211,18 +225,25 @@ class TestTrainingPlanWorkflow(ResearcherTestCase, MockRequestModule):
         '_training_plan_workflow.FederatedWorkflow.load_breakpoint')
     def test_federated_workflow_07_load_breakpoint(self,
                                                    mock_super_load,
-                                                   mock_import_class
+                                                   mock_import_class,
+                                                   mock_serializer_load
                                                    ):
+        model_weights_path = 'some-path-for-model-weights'
         mock_super_load.return_value = (
             TrainingPlanWorkflow(),
             {
                 'model_args': {'breakpoint-model': 'args'},
                 'training_plan_class_name': 'FakeTorchTrainingPlan',
-                'training_plan_path': 'some-path'
+                'training_plan_path': 'some-path',
+                'model_weights_path': model_weights_path
             }
         )
 
         exp, saved_state = TrainingPlanWorkflow.load_breakpoint()
+        # Test if Serializer.load is called once with the good arguments
+        mock_serializer_load.assert_called_once_with(
+            model_weights_path
+        )
         self.assertEqual(exp.training_plan_class(), FakeTorchTrainingPlan)
         self.assertIsInstance(exp.training_plan(), FakeTorchTrainingPlan)
         self.assertDictEqual(exp.model_args(), {'breakpoint-model': 'args'})

--- a/tests/testsupport/fake_training_plan.py
+++ b/tests/testsupport/fake_training_plan.py
@@ -138,9 +138,9 @@ class FakeModel(BaseTrainingPlan):
     def testing_routine(self, metric, history_monitor, before_train: bool):
         pass
 
-
 class FakeTorchTrainingPlan(FakeModel, TorchTrainingPlan):
 
+    _model = mock.create_autospec(Model, instance=True)
 
     def init_model(self):
         pass


### PR DESCRIPTION
**PR description**

#1003 
This PR introduces persistent buffers parameters in breakpoints during secure aggregation. 
It also fixes some issues with model weight API, (#1010 ) by adding the only_trainable and exclude_buffers boolean in flatten and unflatten functions.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`