### PR TITLE
Makes `save_aggregated_params` a public method

### DIFF
--- a/fedbiomed/researcher/federated_workflows/_experiment.py
+++ b/fedbiomed/researcher/federated_workflows/_experiment.py
@@ -1149,7 +1149,7 @@ class Experiment(TrainingPlanWorkflow):
             'aggregator': agg_bkpt,
             'agg_optimizer': agg_optim_bkpt,
             'node_selection_strategy': strategy_bkpt,
-            'aggregated_params': self._save_aggregated_params(
+            'aggregated_params': self.save_aggregated_params(
                 self._aggregated_params, breakpoint_path),
             'training_replies': training_replies_bkpt,
         }
@@ -1204,7 +1204,7 @@ class Experiment(TrainingPlanWorkflow):
 
     @staticmethod
     @exp_exceptions
-    def _save_aggregated_params(aggregated_params_init: dict, breakpoint_path: str) -> Dict[int, dict]:
+    def save_aggregated_params(aggregated_params_init: dict, breakpoint_path: str) -> Dict[int, dict]:
         """Extract and format fields from aggregated_params that need to be saved in breakpoint.
 
         Creates link to the params file from the `breakpoint_path` and use them to reference the params files.

--- a/fedbiomed/researcher/federated_workflows/_experiment.py
+++ b/fedbiomed/researcher/federated_workflows/_experiment.py
@@ -1210,8 +1210,11 @@ class Experiment(TrainingPlanWorkflow):
         Creates link to the params file from the `breakpoint_path` and use them to reference the params files.
 
         Args:
-            aggregated_params_init (dict): ???
-            breakpoint_path: path to the directory where breakpoints files and links will be saved
+            aggregated_params_init: initial aggregated parameters to be saved inside the breakpoint. This
+                argument won't be modified in-place.
+            breakpoint_path: path to the directory where breakpoints files and links will be saved,
+                in a `*.mpk` file. Aggregated parameters are saved in a file named `aggregated_params_xxx.mpk`,
+                inside the breakpoint_path folder.
 
         Returns:
             Extract from `aggregated_params`

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -399,7 +399,7 @@ class TestExperiment(ResearcherTestCase, MockRequestModule):
         )
         exp._set_round_current(2)
 
-        with patch.object(exp, '_save_aggregated_params', return_value={'agg_params': 'bkpt'}) as mock_agg_param_save,\
+        with patch.object(exp, 'save_aggregated_params', return_value={'agg_params': 'bkpt'}) as mock_agg_param_save,\
                 patch.object(exp, 'save_training_replies', return_value={'replies': 'bkpt'}) as mock_save_replies, \
                 patch.object(exp, 'training_plan') as mock_tp:
             exp.breakpoint()


### PR DESCRIPTION
**PR description**

- Tested by running breakpoint save and resume notebook
**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`