### PR TITLE
Provide a method to access Model class from training plan

### DIFF
--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -55,8 +55,8 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         testing_data_loader: Data loader used in the validation routine.
     """
 
-    _model: Model
-    _optimizer: BaseOptimizer
+    _model: Optional[Model]
+    _optimizer: Optional[BaseOptimizer]
 
     def __init__(self) -> None:
         """Construct the base training plan."""

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -81,6 +81,17 @@ class BaseTrainingPlan(metaclass=ABCMeta):
     def model(self):
         """Gets model instance of the training plan"""
 
+    # FIXME: re-implement Model as a subclass of Torch.nn.module, SGDClassifier, etc.
+    # to avoid having a distinct getter for the class, see #1049
+
+    def get_model_wrapper_class(self) -> Model:
+        """Gets training plan's model wrapper class.
+
+        Returns:
+            the wrapper class for the model
+        """
+        return self._model
+
     @property
     def dependencies(self):
             return self._dependencies

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -84,11 +84,12 @@ class BaseTrainingPlan(metaclass=ABCMeta):
     # FIXME: re-implement Model as a subclass of Torch.nn.module, SGDClassifier, etc.
     # to avoid having a distinct getter for the class, see #1049
 
-    def get_model_wrapper_class(self) -> Model:
+    def get_model_wrapper_class(self) -> Optional[Model]:
         """Gets training plan's model wrapper class.
 
         Returns:
-            the wrapper class for the model
+            the wrapper class for the model, or None
+            if model is not instantiated.
         """
         return self._model
 

--- a/fedbiomed/researcher/aggregators/aggregator.py
+++ b/fedbiomed/researcher/aggregators/aggregator.py
@@ -81,8 +81,7 @@ class Aggregator:
         aggregated_params = aggregate(params=params)
 
         # Convert model params
-        model = training_plan._model
-
+        model = training_plan.get_model_wrapper_class()
         model_params = model.unflatten(aggregated_params)
 
         return model_params

--- a/fedbiomed/researcher/federated_workflows/_experiment.py
+++ b/fedbiomed/researcher/federated_workflows/_experiment.py
@@ -850,11 +850,13 @@ class Experiment(TrainingPlanWorkflow):
                 encryption_factors=encryption_factors,
                 total_sample_size=total_sample_size,
                 model_params=model_params,
-                num_expected_params=len(self.training_plan()._model.flatten(exclude_buffers = not self.training_args()['share_persistent_buffers']))
+                num_expected_params=len(self.training_plan().get_model_wrapper_class().flatten(
+                    exclude_buffers = not self.training_args()['share_persistent_buffers']))
             )
             # FIXME: Access TorchModel through non-private getter once it is implemented
             aggregated_params: Dict[str, Union[torch.tensor, np.ndarray]] = (
-                self.training_plan()._model.unflatten(flatten_params, exclude_buffers = not self.training_args()['share_persistent_buffers'])
+                self.training_plan().get_model_wrapper_class().unflatten(
+                    flatten_params, exclude_buffers = not self.training_args()['share_persistent_buffers'])
             )
 
         else:

--- a/fedbiomed/researcher/federated_workflows/_training_plan_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_training_plan_workflow.py
@@ -427,7 +427,8 @@ class TrainingPlanWorkflow(FederatedWorkflow, ABC):
             os.path.join('..', os.path.basename(training_plan_file))
         )
         params_path = os.path.join(breakpoint_path, f"model_params_{uuid.uuid4()}.mpk")
-        Serializer.dump(self.training_plan()._model.get_weights(only_trainable = False, exclude_buffers = False), params_path)
+        Serializer.dump(self.training_plan().get_model_wrapper_class().get_weights(
+            only_trainable = False, exclude_buffers = False), params_path)
         state['model_weights_path'] = params_path
 
         super().breakpoint(state, bkpt_number)
@@ -474,7 +475,7 @@ class TrainingPlanWorkflow(FederatedWorkflow, ABC):
             raise FedbiomedExperimentError(msg)
         param_path = saved_state['model_weights_path']
         params = Serializer.load(param_path)
-        loaded_exp.training_plan()._model.set_weights(params)
+        loaded_exp.training_plan().get_model_wrapper_class().set_weights(params)
 
         return loaded_exp, saved_state
 

--- a/tests/test_training_plan_workflow.py
+++ b/tests/test_training_plan_workflow.py
@@ -199,7 +199,7 @@ class TestTrainingPlanWorkflow(ResearcherTestCase, MockRequestModule):
                                    f'model_params_{mock_uuid.return_value}.mpk'
                                    )
         mock_serializer_dump.assert_called_once_with(
-            self.mock_tp._model.get_weights.return_value,
+            self.mock_tp.get_model_wrapper_class.return_value.get_weights.return_value,
             params_path
         )
         # This also validates the breakpoint scheme: if this fails, please consider updating the breakpoints version
@@ -250,7 +250,7 @@ class TestTrainingPlanWorkflow(ResearcherTestCase, MockRequestModule):
         self.assertIsInstance(exp.training_plan(), FakeTorchTrainingPlan)
         self.assertDictEqual(exp.model_args(), {'breakpoint-model': 'args'})
         # Test if set_weights is called with the right arguments
-        exp.training_plan()._model.set_weights.assert_called_once_with(
+        exp.training_plan().get_model_wrapper_class.return_value.set_weights.assert_called_once_with(
             mock_serializer_load.return_value
         )
 


### PR DESCRIPTION
**PR description**

Closes #1049

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`