### PR TITLE
Fix cleaning of node side temporary dirs

### DIFF
--- a/fedbiomed/node/node.py
+++ b/fedbiomed/node/node.py
@@ -342,6 +342,10 @@ class Node:
                             )
                             msg.request_id = item.request_id
                             self._grpc_client.send(msg)
+
+                            # clean out `Round` objects (eg temporary files)
+                            # don't wait for garbage collection
+                            del round
                     except Exception as e:
                         # send an error message back to network if something
                         # wrong occured

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -5,7 +5,6 @@
 implementation of Round class of the node component
 '''
 
-import atexit
 import tempfile
 import shutil
 import os
@@ -116,8 +115,11 @@ class Round:
         self._node_state_manager: NodeStateManager = NodeStateManager(environ['DB_PATH'])
 
         self._keep_files_dir = tempfile.mkdtemp(prefix=environ['TMP_DIR'])
-        atexit.register(lambda: shutil.rmtree(self._keep_files_dir))  # remove directory
 
+    def __del__(self):
+        """Class destructor"""
+        # remove temporary files directory
+        shutil.rmtree(self._keep_files_dir)
 
     def _initialize_validate_training_arguments(self) -> Optional[Dict[str, Any]]:
         """Initialize and validate requested experiment/training arguments.

--- a/tests/test_round.py
+++ b/tests/test_round.py
@@ -76,9 +76,6 @@ class TestRound(NodeTestCase):
         # logs messages
         history_monitor = MagicMock()
 
-        self.atexit_patcher = patch('fedbiomed.node.round.atexit')
-        self.atexit_mock = self.atexit_patcher.start()
-
         self.state_manager_patch = patch('fedbiomed.node.round.NodeStateManager')
         self.ic_from_spec_patch = patch("fedbiomed.node.round.utils.import_class_from_spec")
         self.ic_from_file_patch = patch("fedbiomed.node.round.utils.import_class_object_from_file")
@@ -135,7 +132,6 @@ class TestRound(NodeTestCase):
         self.r2.history_monitor = dummy_monitor
 
     def tearDown(self):
-        self.atexit_patcher.stop() 
         self.ic_from_file_patch.stop()
         self.ic_from_spec_patch.stop()
         self.state_manager_patch.stop()


### PR DESCRIPTION
**PR description**
Fix cleaning of node side temporary dirs (no issue associated).

How to test:
- launch 1 or 2 nodes, add MNIST dataset
- count files and list last files in `$FEDBIOMED_DIR/var`
  ```
  ls -lart ./var | wc -l
  ls -lart ./var | tail -20
  ```
- run `101-getting-started.ipynb` notebook
- count again files and list last files in `$FEDBIOMED_DIR/var`
- check that there are no more files in the directory (at least no temporary dir)

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`