### PR TITLE
Add section in user guide for buffers

### DIFF
--- a/docs/user-guide/researcher/experiment.md
+++ b/docs/user-guide/researcher/experiment.md
@@ -338,6 +338,13 @@ training_args = {
     'dry_run': False,
 }
 ```
+
+#### Sharing persistent buffers
+
+In Pytorch experiments, you may include the argument `share_persistent_buffers`. When set to `True` (default), nodes will share the full `state_dict()` of the Pytorch module, which contains both the learnable parameters and the persistent buffers (defined as invariant in the network, like batchnorm’s `running_mean` and `running_var`). When set to `False`, nodes will only share learnable parameters.
+
+This argument will be ignored for scikit-learn experiments, as the notion of persistent buffers is specific to Pytorch.
+
 ### Aggregator
 
 An aggregator is one of the required arguments for the experiment. It is used on the researcher for aggregating model parameters that are received from the nodes after


### PR DESCRIPTION
**PR description**

This PR refers to issue #1042 :

- add a section in the User Guide / Researcher / Experiment to describe the new argument share_persistent_buffers in the training arguments

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`