### PR TITLE
Feature896/update function inconsistencies

### DIFF
--- a/fedbiomed/common/optimizers/generic_optimizers.py
+++ b/fedbiomed/common/optimizers/generic_optimizers.py
@@ -162,7 +162,10 @@ class DeclearnOptimizer(BaseOptimizer):
         # Therefore, it is necessary to disable the sklearn internal optimizer beforehand
         # otherwise, computation will be incorrect
         grad = declearn.model.api.Vector.build(self._model.get_gradients())
-        weights = declearn.model.api.Vector.build(self._model.get_weights())
+        weights = declearn.model.api.Vector.build(self._model.get_weights(
+            only_trainable=False,
+            exclude_buffers=True
+        ))
         updates = self.optimizer.step(grad, weights)
         self._model.apply_updates(updates.coefs)
 

--- a/fedbiomed/researcher/aggregators/scaffold.py
+++ b/fedbiomed/researcher/aggregators/scaffold.py
@@ -365,7 +365,10 @@ class Scaffold(Aggregator):
                 the number of layers contained in the model (in Pytroch, each layer can have a specific learning rate).
         """
 
-        n_model_layers = len(training_plan.get_model_params())
+        n_model_layers = len(training_plan.get_model_params(
+            only_trainable=False,
+            exclude_buffers=True)
+        )
         for node_id in self._fds.node_ids():
             lrs: Dict[str, float] = {}
 

--- a/fedbiomed/researcher/datasets.py
+++ b/fedbiomed/researcher/datasets.py
@@ -108,10 +108,3 @@ class FederatedDataSet:
             shapes_dict[node_id] = node_data_size
 
         return shapes_dict
-
-    def fiter_nodes_from_ids(self,
-                             nodes_to_keep: List[str]) -> List[str]:
-        """Removes nodes that are not in nodes_to_keep from data and returns new list of node ids"""
-        self._data = {node_id: metadata for node_id, metadata in self._data if node_id in nodes_to_keep}
-        return self.node_ids()
-


### PR DESCRIPTION
**PR description**

Addresses one of the tasks listed in #896 
> cross check code for functions inconsistencies
> -    clean code from unused code/functions
> -    update/remove references to refactored methods that changed signature or were removed

Specifically we found the following points:

- re-introduced `TrainingPlanWorkflow.training_plan_file()` that was removed during refactoring, but may be useful. For example it is mentioned in training plan approval tutorials in `docs/tutorials`

- renamed `_reset_training_plan`

- converted in `TrainingPlanWorklow` variable `self.__training_plan` to `self._training_plan` (single _ ). Same for `self._training_plan_class`

- removed unused `FederatedDataSet.fiter_nodes_from_ids`

- misc: explicitely added default parameters to some calls of `BaseTrainingPlan.get_model_parameters()` => `get_model_parameters(only_trainable=False, exclude_buffers=True)` + same for `Model.get_weights()`.
The reason is: as this code existed before changing these methods' signature for handling the case of frozen layers and buffers, we want to make it clear for developpers that these calls were re-assessed after this change


**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`