### PR TITLE
Feature896/1012 unit tests job classes

### DIFF
--- a/fedbiomed/common/message.py
+++ b/fedbiomed/common/message.py
@@ -331,7 +331,7 @@ class ApprovalRequest(RequestReply, RequiresProtocolVersion):
     Attributes:
         researcher_id: id of the researcher that sends the request
         description: description of the training plan
-        training_plan_url: URL where TrainingPlan is available
+        training_plan: The training plan that is going to be checked for approval
         command: request command string
 
     Raises:
@@ -350,9 +350,11 @@ class ApprovalReply(RequestReply, RequiresProtocolVersion):
 
     Attributes:
         researcher_id: Id of the researcher that will receive the reply
+        message: currently unused (empty string)
         node_id: Node id that replys the request
-        status: status code received after uploading the training plan (usually HTTP status)
+        status: status code for the request (obsolete, always 0)
         command: Reply command string
+        success: Request was successfully sumbitted to node (not yet approved)
 
     Raises:
         FedbiomedMessageError: triggered if message's fields validation failed
@@ -445,7 +447,7 @@ class TrainingPlanStatusRequest(RequestReply, RequiresProtocolVersion):
     Attributes:
         researcher_id: Id of the researcher that sends the request
         experiment_id: ID related to the experiment.
-        training_plan_url: The training plan that is going to be checked for approval
+        training_plan: The training plan that is going to be checked for approval
         command: Request command string
 
     Raises:
@@ -471,9 +473,9 @@ class TrainingPlanStatusReply(RequestReply, RequiresProtocolVersion):
             if any exception occurs
         approval_obligation : Approval mode for node. True, if training plan approval is enabled/required
             in the node for training.
-        is_approved: True, if the requested training plan is one of the approved training plan by the node
+        status: a `TrainingPlanApprovalStatus` value describing the approval status 
         msg: Message from node based on state of the reply
-        training_plan_url: The training plan that has been checked for approval
+        training_plan: The training plan that has been checked for approval
         command: Reply command string
 
     Raises:

--- a/fedbiomed/researcher/federated_workflows/jobs/_job.py
+++ b/fedbiomed/researcher/federated_workflows/jobs/_job.py
@@ -67,10 +67,10 @@ class Job(ABC):
         ```
         nodes = ['node_1', 'node_2']
         job = Job(nodes, file)
-        with job._timer():
+        with job._timer() as my_timer:
             # ... send some request
 
-        job._timer.get_timer()
+        my_timer
         # {node_1: 2.22, node_2: 2.21} # request time for each Node in second
         ```
         """
@@ -91,8 +91,6 @@ class Job(ABC):
             self._timer.update({node_id: time.perf_counter() - self._timer[node_id] for node_id in self._timer.keys()})
             return self._timer
 
-        def get_timer(self) -> Dict:
-            return self._timer
 
     @abstractmethod
     def execute(self) -> Any:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -57,6 +57,7 @@ class TestJob(ResearcherTestCase, MockRequestModule):
         job = MinimalJob(nodes=nodes, keep_files_dir=files_dir)
         self.assertIsNotNone(job._keep_files_dir)  # must be initialized by Job
         self.assertTrue(isinstance(job._nodes, list) and len(job._nodes) == 0)  # nodes must be empty list by default
+
         # Job can take nodes and keep_files_dir as arguments
         mynodes = ['first-node', 'second-node']
         job = MinimalJob(
@@ -65,6 +66,24 @@ class TestJob(ResearcherTestCase, MockRequestModule):
         )
         self.assertEqual(job._keep_files_dir, 'keep_files_dir')
         self.assertTrue(all(x == y for x, y in zip(job._nodes, mynodes)))
+
+        # use and check timer
+        with job.RequestTimer(mynodes) as t1:
+            pass
+
+        for node in mynodes:
+            self.assertTrue(node in t1)
+            self.assertTrue(isinstance(t1[node], float))
+            self.assertAlmostEqual(t1[node], 0, delta=10**-3)
+
+        # use and check getters
+        n = job.nodes
+        self.assertEqual(n, mynodes)
+
+        r = job.requests
+        # need to access the private member
+        self.assertEqual(r, job._reqs)
+
 
     @patch('fedbiomed.researcher.federated_workflows._training_plan_workflow.uuid.uuid4', return_value='UUID')
     def test_job_02_training_job_successful(self, mock_uuid):


### PR DESCRIPTION
**PR description**

Partial #1012 
- add 100% unit test coverage for job classes (Job, TrainingJob, TrainingPlanApproveJob, TrainingPlanCheckJob)
- misc: remove Job.RequestTimer.get_timer which seems useless (value is returned by `__exit__`)

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`