### PR TITLE
Fix secagg failures with 4+ nodes

### DIFF
--- a/fedbiomed/common/secagg/_jls.py
+++ b/fedbiomed/common/secagg/_jls.py
@@ -124,8 +124,8 @@ def divide(xs: List[int], k: int) -> List[int]:
     # CAVEAT: `dtype` must to allow bigger values than each nodes's weighted value
     # This implementation allows at most 2**32 nodes (as weighted value uses uint32)
     max_val = np.iinfo(np.uint64).max
-    if any([v > max_val for v in xs]):
-        raise FedbiomedSecaggCrypterError(f"{ErrorNumbers.FB624.value}: Cannot divide, values exceed maximum number")
+    if any([v > max_val or v < 0 for v in xs]):
+        raise FedbiomedSecaggCrypterError(f"{ErrorNumbers.FB624.value}: Cannot divide, values outside of bounds")
 
     xs = np.array(xs, dtype=np.uint64)
     return (xs / k).tolist()
@@ -152,7 +152,7 @@ def reverse_quantize(
 
     # CAVEAT: there should not be any weight received that does not fit in `uint64`
     max_val = np.iinfo(np.uint64).max
-    if any([v > max_val for v in weights]):
+    if any([v > max_val or v < 0 for v in weights]):
         raise FedbiomedSecaggCrypterError(
             f"{ErrorNumbers.FB624.value}: Cannot reverse quantize, received values exceed maximum number"
         )

--- a/fedbiomed/common/secagg/_jls.py
+++ b/fedbiomed/common/secagg/_jls.py
@@ -28,8 +28,9 @@ import gmpy2
 from gmpy2 import mpz, gcd
 import numpy as np
 
-from fedbiomed.common.constants import VEParameters
+from fedbiomed.common.constants import VEParameters, ErrorNumbers
 from fedbiomed.common.logger import logger
+from fedbiomed.common.exceptions import FedbiomedSecaggCrypterError
 
 
 def _check_clipping_range(
@@ -117,7 +118,15 @@ def divide(xs: List[int], k: int) -> List[int]:
     Returns:
         List of divided integers
     """
-    xs = np.array(xs, dtype=np.uint32)
+
+    # CAVEAT: `dtype` must to allow bigger values than each nodes's weighted value
+    # This implementation allows at most 2**32 nodes (as weighted value uses uint32)
+    max_val = np.iinfo(np.uint64).max
+    if any([v > max_val for v in xs]):
+        # TODO RAISE ERROR
+        raise FedbiomedSecaggCrypterError(f"{ErrorNumbers.FB624.value}: Cannot divide, values exceed maximum number")
+
+    xs = np.array(xs, dtype=np.uint64)
     return (xs / k).tolist()
 
 

--- a/fedbiomed/common/secagg/_jls.py
+++ b/fedbiomed/common/secagg/_jls.py
@@ -105,8 +105,8 @@ def multiply(xs: List[int], k: int) -> List[int]:
     Returns:
         List of multiplied integers
     """
-    xs = np.array(xs, dtype=np.uint32)
-    return (xs * k).tolist()
+    # Quicker than converting to/from numpy
+    return [e * k for e in xs]
 
 
 def divide(xs: List[int], k: int) -> List[int]:
@@ -120,15 +120,8 @@ def divide(xs: List[int], k: int) -> List[int]:
     Returns:
         List of divided integers
     """
-
-    # CAVEAT: `dtype` must to allow bigger values than each nodes's weighted value
-    # This implementation allows at most 2**32 nodes (as weighted value uses uint32)
-    max_val = np.iinfo(np.uint64).max
-    if any([v > max_val or v < 0 for v in xs]):
-        raise FedbiomedSecaggCrypterError(f"{ErrorNumbers.FB624.value}: Cannot divide, values outside of bounds")
-
-    xs = np.array(xs, dtype=np.uint64)
-    return (xs / k).tolist()
+    # Quicker than converting to/from numpy
+    return [e / k for e in xs]
 
 
 def reverse_quantize(

--- a/fedbiomed/common/secagg/_secagg_crypter.py
+++ b/fedbiomed/common/secagg/_secagg_crypter.py
@@ -4,7 +4,7 @@
 
 import time
 
-from typing import List, Union
+from typing import List, Union, Optional
 from gmpy2 import mpz
 
 from fedbiomed.common.exceptions import FedbiomedSecaggCrypterError
@@ -62,7 +62,7 @@ class SecaggCrypter:
             key: int,
             biprime: int,
             clipping_range: Union[int, None] = None,
-            weight: int = None,
+            weight: Optional[int] = None,
     ) -> List[int]:
         """Encrypts model parameters.
 
@@ -107,7 +107,8 @@ class SecaggCrypter:
         params = quantize(weights=params,
                           clipping_range=clipping_range)
 
-        # we multiply the parameters with the weight, and we get params in the range [0, 2^(VEParameters.TARGET_RANGE + VEParameters.MAX_WEIGHT_RANGE)]
+        # we multiply the parameters with the weight, and we get params in
+        # the range [0, 2^(VEParameters.TARGET_RANGE + VEParameters.MAX_WEIGHT_RANGE)]
         # check if weight if num_bits of weight is less than VEParameters.WEIGHT_RANGE
         if weight is not None:
             if 2**weight.bit_length() > VEParameters.WEIGHT_RANGE:
@@ -206,7 +207,6 @@ class SecaggCrypter:
             raise FedbiomedSecaggCrypterError(f"{ErrorNumbers.FB624.value}: The aggregation of encrypted parameters "
                                               f"is not successful: {e}")
 
-        # TODO implement weighted averaging here or in `self._jls.aggregate`
         # Reverse quantize and division (averaging)
         logger.info(f"Aggregating {len(params)} parameters from {num_nodes} nodes.")
         aggregated_params = self._apply_average(sum_of_weights, total_sample_size)

--- a/tests/test_secagg_crypter.py
+++ b/tests/test_secagg_crypter.py
@@ -50,11 +50,23 @@ class TestSecaggCrypter(unittest.TestCase):
     def test_secagg_crypter_03_apply_average(self):
         """Tests quantized divide"""
 
+        # Test successful division
+
         vector = [4, 8, 12]
         result = self.secagg_crypter._apply_average(vector, 2)
 
-        # Test division
         self.assertListEqual(result, [v / 2 for v in vector])
+
+        # Test division with overflow
+
+        vectors = [
+            [-1],
+            [2**64],
+        ]
+        for vector in vectors:
+            with self.assertRaises(FedbiomedSecaggCrypterError):
+                self.secagg_crypter._apply_average(vector, 2)
+
 
     def test_secagg_crypter_03_encrypt(self):
         """Tests encryption"""

--- a/tests/test_secagg_crypter.py
+++ b/tests/test_secagg_crypter.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from gmpy2 import mpz
 
+from fedbiomed.common.constants import VEParameters
 from fedbiomed.common.secagg import SecaggCrypter, EncryptedNumber
 from fedbiomed.common.secagg._jls import PublicParam
 from fedbiomed.common.exceptions import FedbiomedSecaggCrypterError
@@ -61,12 +62,39 @@ class TestSecaggCrypter(unittest.TestCase):
 
         vectors = [
             [-1],
-            [2**64],
+            [1, 1, -1],
+            [-1, 1, 1],
+            [1, -1, 1],
         ]
         for vector in vectors:
             with self.assertRaises(FedbiomedSecaggCrypterError):
                 self.secagg_crypter._apply_average(vector, 2)
 
+    def test_secagg_crypter_04_apply_weighing(self):
+        """Tests quantized multiply"""
+
+        # Test successful multiply
+
+        vector = [4, 8, 12]
+        result = self.secagg_crypter._apply_weighing(vector, 2)
+
+        self.assertListEqual(result, [v * 2 for v in vector])
+
+        # Test multiply with overflow
+
+        vectors = [
+            [-1],
+            [1, 1, -1],
+            [-1, 1, 1],
+            [1, -1, 1],
+            [VEParameters.TARGET_RANGE],
+            [2 * VEParameters.TARGET_RANGE],
+            [0, VEParameters.TARGET_RANGE, 0],
+            [0, 0, VEParameters.TARGET_RANGE],
+        ]
+        for vector in vectors:
+            with self.assertRaises(FedbiomedSecaggCrypterError):
+                self.secagg_crypter._apply_weighing(vector, 2)
 
     def test_secagg_crypter_03_encrypt(self):
         """Tests encryption"""


### PR DESCRIPTION
**PR description**

- address issue #1056 in `divide()` by using `uint64` to avoid overflow when summing several `uint32`. Problem was introduced by weighted average.

- misc robustify for
  * `divide()` by raising an error if data would be lost by converting from `int` to `uint64` (which should not happen with < 2**32 nodes with current weighting function, but will avoid similar bug in the future)
  * `quantize()` by making all type conversions of weight explicit, so it is clear the maximum supported `target_range` is 2**64
  * `reverse_quantize()` by also making explicit the weight type conversions, plus raising an error if encoded weights values are outside of bounds, which would result in information loss (or means we have faulty input)

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`