### PR TITLE
tune queue size

### DIFF
--- a/fedbiomed/common/tasks_queue.py
+++ b/fedbiomed/common/tasks_queue.py
@@ -26,7 +26,8 @@ class TasksQueue:
             tmp_dir: indicates where temporary files should be stored.
         """
         try:
-            self.queue = persistqueue.Queue(messages_queue_dir, tempdir=tmp_dir)
+            # small chunksize to limit un-needed use of disk space
+            self.queue = persistqueue.Queue(messages_queue_dir, tempdir=tmp_dir, chunksize=1)
         except ValueError as e:
             msg = ErrorNumbers.FB603.value + ": cannot create queue (" + str(e) + ")"
             logger.critical(msg)


### PR DESCRIPTION
**PR description**

Tune filesystem persistent queue `chunk_size`.

Rationale:
- `chunk_size` defines the number of queue items stored per file, default is 100
- this space is used even when queue element won't be re-used (`task_done()` was run)
- the default value is probably oriented for small items, optimized for performance
- in our case, we use few queue items potentially very big (include model weights)
- for example in a test with 100 rounds, 10 nodes, model params ~50 MB it results in 50GB disk used for queues

Note: no associated issue.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`