### PR TITLE
Fix docker `gui` container build with new CLI syntax

### DIFF
--- a/envs/vpn/docker/gui/build_files/Dockerfile
+++ b/envs/vpn/docker/gui/build_files/Dockerfile
@@ -76,7 +76,7 @@ RUN conda env update --file ./envs/vpn/conda/fedbiomed-gui.yaml && \
 # need clean/purge to be in the same command line to shrink image
  
 # `data-folder` and `config` are not used when doing `install-only`
-RUN ./scripts/fedbiomed_run node gui data-folder /data config DUMMY install-only start
+RUN ./scripts/fedbiomed_run gui data-folder /data config DUMMY install-only start
 
 # transmit build-time values to running container
 ENV CONTAINER_BUILD_USER=${CONTAINER_USER}

--- a/envs/vpn/docker/gui/build_files/Dockerfile
+++ b/envs/vpn/docker/gui/build_files/Dockerfile
@@ -76,7 +76,7 @@ RUN conda env update --file ./envs/vpn/conda/fedbiomed-gui.yaml && \
 # need clean/purge to be in the same command line to shrink image
  
 # `data-folder` and `config` are not used when doing `install-only`
-RUN ./scripts/fedbiomed_run gui data-folder /data config DUMMY install-only start
+RUN ./scripts/fedbiomed_gui data-folder /data config DUMMY install-only start
 
 # transmit build-time values to running container
 ENV CONTAINER_BUILD_USER=${CONTAINER_USER}

--- a/scripts/fedbiomed_run
+++ b/scripts/fedbiomed_run
@@ -110,7 +110,7 @@ EOF
             cat <<EOF
 
 certificate-dev-setup : prepares development environment by registering certificates of each component created
-            in a single clone of Fed-BioMed. This is only for development purposes and it is required to
+            in a single clone of Fed-BioMed. This is only for development purposes and requires
             fedbiomed-researcher conda environment installed for this option.
 EOF
         ;;


### PR DESCRIPTION
**PR description**

Fix #1091 with minimal change.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`