### PR TITLE
Fix misc bug: GUI container execution fails

### DIFF
--- a/envs/vpn/docker/gui/build_files/entrypoint.bash
+++ b/envs/vpn/docker/gui/build_files/entrypoint.bash
@@ -91,7 +91,7 @@ fi
 
 # caveat: expect `data-folder` to be mounted under same path as in `node` container
 # to avoid inconsistencies in dataset declaration
-$SETUSER ./scripts/fedbiomed_run node gui --host "$GUI_HOST" --port "$GUI_PORT" --production --data-folder /data config config_node.ini start &
+$SETUSER ./scripts/fedbiomed_gui --host "$GUI_HOST" --port "$GUI_PORT" --production --data-folder /data config config_node.ini start &
 
 # allow to stop/restart the gui without terminating the container
 sleep infinity &


### PR DESCRIPTION
**PR description**

Fix #1095 (continues #1091)

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`