### PR TITLE
Improve gRPC layer for stability

### DIFF
--- a/fedbiomed/common/constants.py
+++ b/fedbiomed/common/constants.py
@@ -74,6 +74,7 @@ MAX_MESSAGE_BYTES_LENGTH = 4000000 - sys.getsizeof(bytes("", encoding="UTF-8")) 
 # Max number of retries for sending message (node and researcher side)
 MAX_SEND_RETRIES = 5
 
+
 class _BaseEnum(Enum):
     """
     Parent class to pass default methods to enumeration classes

--- a/fedbiomed/common/constants.py
+++ b/fedbiomed/common/constants.py
@@ -74,6 +74,9 @@ MAX_MESSAGE_BYTES_LENGTH = 4000000 - sys.getsizeof(bytes("", encoding="UTF-8")) 
 # Max number of retries for sending message (node and researcher side)
 MAX_SEND_RETRIES = 5
 
+# Max number of retries for retrieving a task when error occurs (on the node)
+MAX_RETRIEVE_ERROR_RETRIES = 5
+
 
 class _BaseEnum(Enum):
     """

--- a/fedbiomed/transport/client.py
+++ b/fedbiomed/transport/client.py
@@ -427,7 +427,8 @@ class TaskListener(Listener):
             except Exception as exp:
                 await self._on_status_change(ClientStatus.FAILED)
                 raise FedbiomedCommunicationError(
-                    f"{ErrorNumbers.FB628}: Task listener has stopped due to unknown reason: {exp}") from exp
+                    f"{ErrorNumbers.FB628}: Task listener has stopped due to unknown reason: "
+                    f"{type(exp).__name__} {exp}") from exp
 
 
     async def _request(self, callback: Optional[Callable] = None) -> None:
@@ -527,7 +528,8 @@ class Sender(Listener):
             except Exception as exp:
                 await self._on_status_change(ClientStatus.FAILED)
                 raise FedbiomedCommunicationError(
-                    f"{ErrorNumbers.FB628}: Sender has stopped due to unknown reason: {exp}") from exp
+                    f"{ErrorNumbers.FB628}: Sender has stopped due to unknown reason: "
+                    f"{type(exp).__name__} {exp}") from exp
 
             except GeneratorExit as exp:
                 await self._on_status_change(ClientStatus.FAILED)
@@ -587,7 +589,7 @@ class Sender(Listener):
 
             else:
                 raise FedbiomedCommunicationError(
-                    "Unknown type of stub built from gRPC Sender listener {msg['stub']}"
+                    f"Unknown type of stub built from gRPC Sender listener {msg['stub']}"
                 )
 
             self._queue.task_done()

--- a/fedbiomed/transport/client.py
+++ b/fedbiomed/transport/client.py
@@ -596,7 +596,7 @@ class Sender(Listener):
 
         # Extract useful information for detailed log without assumption on message structures
         # to cover possible bug cases
-        if isinstance(self._retry_item, dict) and {'stub', 'message'} <= self._retry_item.keys():
+        if isinstance(self._retry_item, dict):
             msg = self._retry_item['message']
             if hasattr(msg, 'command'):
                 command = msg.get_param('command')

--- a/fedbiomed/transport/client.py
+++ b/fedbiomed/transport/client.py
@@ -431,7 +431,7 @@ class Listener:
                                                          want_retry=self._want_retry_grpc_error,
                                                          want_reconnect=True)
 
-                    case (grpc.StatusCode.UNKNOWN, _):
+                    case grpc.StatusCode.UNKNOWN | _:
                         logger.error(f"Unexpected error raised by researcher gRPC server in {self._task_name}: {exp}. "
                                      f"Will retry connect in {GRPC_CLIENT_CONN_RETRY_TIMEOUT} seconds")
                         await self._handle_after_process(ClientStatus.FAILED,


### PR DESCRIPTION
**PR description**


- try mitigate #1100 by introducing gRPC client retries at application level
- #1097 add more gRPC client message when an error occurs
- fix message send retries on gRPC server
- refactor gRPC client `Listener` classes to factor code and clarify/simplify when possible

Run manual tests for these modifications before merging** (keep `batch_maxnum=100`)
  - [x] 101 notebook + 4 nodes + 10 rounds 
  - [x] 101 notebook + 4 nodes + 10 rounds + big model (450MB params)
    ```
    self.fc1 = nn.Linear(9216, 12800)
    self.fc2 = nn.Linear(12800, 10)
    ```
  - [x] 101 notebook + 10 nodes + 10 rounds
  - [x] 101 notebook + 4 nodes + 2 rounds + no `batch_maxnum` 
  - [x] secure aggregation tutorial + 4 nodes + 5 rounds + secagg
  - [x] secure aggregation tutorial + 4 nodes + 2 rounds + secagg + medium model (45MB params)


**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`