### PR TITLE
Fix e2e tests failure for secagg tests

### DIFF
--- a/fedbiomed/node/secagg.py
+++ b/fedbiomed/node/secagg.py
@@ -325,20 +325,9 @@ class SecaggBiprimeSetup(SecaggMpspdzSetup):
         """
         # don't update an existing default biprime
         if not self._secagg_manager.is_default_biprime(self._secagg_id):
-            # create a (currently dummy) context if it does not exist yet
-            time.sleep(3)
-            context = {
-                'biprime': int(random.randrange(10**12)),   # dummy biprime
-                'max_keysize': 0                            # prevent using the dummy biprime for real
-            }
-            logger.info("Not implemented yet, PUT SECAGG BIPRIME GENERATION PAYLOAD HERE, "
-                        f"secagg_id='{self._secagg_id}'")
-
-            # Currently, all biprimes can be used by all sets of parties.
-            # TODO: add a mode where biprime is restricted for `self._parties`
-            self._secagg_manager.add(self._secagg_id, None, context)
-            logger.info(
-                f"Biprime successfully created for node_id='{environ['NODE_ID']}' secagg_id='{self._secagg_id}'")
+            errmess = f'{ErrorNumbers.FB318.value}: non default biprimes are not implemented yet'
+            logger.error(errmess)
+            raise FedbiomedSecaggError(errmess)
 
 
 class SecaggDhSetup(SecaggBaseSetup):

--- a/tests/end2end/helpers/_execution.py
+++ b/tests/end2end/helpers/_execution.py
@@ -103,6 +103,34 @@ def kill_process(process):
         print('Parent process has became zombie process after killing child procesess')
 
 
+def fork_process(
+    command: Callable,
+    *args,
+    **kwargs,
+):
+    """Executes forked process
+
+    Args:
+        command: Command to execute in forked process
+        *args: optional args
+        **kwargs: optional kwargs
+    """
+    child_pid = os.fork()
+    if child_pid == 0:
+        commandcode = command(*args, **kwargs)
+        if not isinstance(commandcode, int):
+            # return code not supported in that case
+            commandcode = 0
+        os._exit(commandcode)
+    else:
+        returncode = os.waitpid(child_pid, 0)
+
+    if returncode[1] != 0:
+        # Other exceptions are caught by pytest
+        pytest.exit(f"Error: Forked process failed {command}. Args: {args} {kwargs} "
+                    "Please check the outputs.")
+
+
 def shell_process(
     command: list,
     activate: str = None,

--- a/tests/test_secagg_node.py
+++ b/tests/test_secagg_node.py
@@ -266,20 +266,12 @@ class TestSecaggBiprime(SecaggTestCase):
         # ):
 
         self.mock_bpm.is_default_biprime.return_value = True
-        with patch('time.sleep'):
-            reply = self.secagg_bprime.setup()
-            self.assertEqual(reply["success"], True)
+        reply = self.secagg_bprime.setup()
+        self.assertEqual(reply["success"], True)
 
         self.mock_bpm.is_default_biprime.return_value = False
-        fake_biprime = 134567654
-        with (patch('time.sleep'),
-              patch('fedbiomed.node.secagg.random.randrange') as builtin_randrange_mock):
-            builtin_randrange_mock.return_value = fake_biprime
-            reply = self.secagg_bprime.setup()
-            self.assertEqual(reply["success"], True)
-            self.mock_bpm.add.assert_called_once_with(self.args['secagg_id'],
-                                                      None,
-                                                      {'biprime': fake_biprime, 'max_keysize':0})
+        reply = self.secagg_bprime.setup()
+        self.assertEqual(reply["success"], False)
 
         self.mock_bpm.is_default_biprime.side_effect = FedbiomedError("error generaated for testing purposes")
         reply = self.secagg_bprime.setup()


### PR DESCRIPTION
**PR description**

Complete #1152

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`