### PR TITLE
Add unit tests for some LOM secagg new modules

### DIFF
--- a/fedbiomed/common/exceptions.py
+++ b/fedbiomed/common/exceptions.py
@@ -244,6 +244,13 @@ class FedbiomedStrategyError(FedbiomedError):
     pass
 
 
+class FedbiomedSynchroError(FedbiomedError):
+    """
+    Error in synchro objects
+    """
+    pass
+
+
 class FedbiomedTaskQueueError(FedbiomedError):
     """
     Exception specific to the internal queuing system.

--- a/fedbiomed/common/synchro.py
+++ b/fedbiomed/common/synchro.py
@@ -6,7 +6,7 @@ import threading
 import time
 
 from fedbiomed.common.constants import ErrorNumbers
-from fedbiomed.common.exceptions import FedbiomedNodeToNodeError
+from fedbiomed.common.exceptions import FedbiomedSynchroError
 from fedbiomed.common.logger import logger
 
 
@@ -149,8 +149,8 @@ class EventWaitExchange:
 
         # Check value for timeout, as bad value may cause hard to detect problems
         if not isinstance(timeout, (float, int)) or timeout < 0 or timeout > MAX_TRIGGERED_EVENT_TIMEOUT:
-            raise FedbiomedNodeToNodeError(f"{ErrorNumbers.FB324}: Cannot wait {timeout} seconds. "
-                                           f"Should be int or float between 0 and {MAX_TRIGGERED_EVENT_TIMEOUT}")
+            raise FedbiomedSynchroError(f"{ErrorNumbers.FB324}: Cannot wait {timeout} seconds. "
+                                        f"Should be int or float between 0 and {MAX_TRIGGERED_EVENT_TIMEOUT}")
 
         time_initial = time.time()
 

--- a/fedbiomed/node/requests/_overlay.py
+++ b/fedbiomed/node/requests/_overlay.py
@@ -1,11 +1,12 @@
 # This file is originally part of Fed-BioMed
 # SPDX-License-Identifier: Apache-2.0
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Tuple
 import os
 
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.exceptions import InvalidSignature
 
 from fedbiomed.common.utils import ROOT_DIR
 from fedbiomed.common.message import Message, InnerMessage, InnerRequestReply, \
@@ -193,7 +194,7 @@ def format_incoming_overlay(payload: List[bytes]) -> InnerMessage:
             ),
             hashes.SHA256()
         )
-    except ValueError as e:
+    except InvalidSignature as e:
         raise FedbiomedNodeToNodeError(
             f'{ErrorNumbers.FB324.value}: cannot verify payload integrity: {e}') from e
 

--- a/tests/test_common_synchro.py
+++ b/tests/test_common_synchro.py
@@ -7,7 +7,7 @@ from fedbiomed.common.exceptions import FedbiomedSynchroError
 from fedbiomed.common.synchro import EventWaitExchange, MAX_TRIGGERED_EVENT_TIMEOUT
 
 
-class TestCommonConfigUtils(unittest.TestCase):
+class TestCommonSynchro(unittest.TestCase):
     """Test for common synchro module"""
 
     def setUp(self):
@@ -110,7 +110,7 @@ class TestCommonConfigUtils(unittest.TestCase):
             with self.assertRaises(FedbiomedSynchroError):
                 exchange.wait([e1, e2], 1)
 
-            self.patcher_event.set.assert_not_called()
+            self.patcher_event.return_value.set.assert_not_called()
 
             # actions: add first event
             # check: one listener set for [e1]

--- a/tests/test_common_synchro.py
+++ b/tests/test_common_synchro.py
@@ -71,14 +71,14 @@ class TestCommonSynchro(unittest.TestCase):
 
             # one event waited, is it still there ?
             all_received, events_data = exchange.wait([e1], 1)
-            self.assertEqual(all_received, True)
+            self.assertTrue(all_received)
             self.assertEqual(events_data, [d1])
             self.assertEqual(e1 in events, not remove_delivered)
-            self.assertEqual(e2 in events, True)
+            self.assertTrue(e2 in events)
 
             # another event waited, is it still there ?
             all_received, events_data = exchange.wait([e2], 1)
-            self.assertEqual(all_received, True)
+            self.assertTrue(all_received)
             self.assertEqual(events_data, [d3])
             self.assertEqual(e2 in events, not remove_delivered)
             self.assertEqual(e1 in events, not remove_delivered)
@@ -167,7 +167,7 @@ class TestCommonSynchro(unittest.TestCase):
                 all_received, events_data = exchange.wait(['dummy_id'], max_timeout / 2)
 
                 # check
-                self.assertEqual(all_received, False)
+                self.assertFalse(all_received)
                 self.assertEqual(events_data, [])
 
     @patch('fedbiomed.common.synchro.GRACE_TRIGGERED_EVENT', 0)

--- a/tests/test_common_synchro.py
+++ b/tests/test_common_synchro.py
@@ -1,0 +1,208 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import time
+import threading
+
+from fedbiomed.common.exceptions import FedbiomedSynchroError
+from fedbiomed.common.synchro import EventWaitExchange, MAX_TRIGGERED_EVENT_TIMEOUT
+
+
+class TestCommonConfigUtils(unittest.TestCase):
+    """Test for common synchro module"""
+
+    def setUp(self):
+        self.mock_event = MagicMock(spec=threading.Event)
+        self.patch_event = patch('fedbiomed.common.synchro.threading.Event', self.mock_event)
+        self.patcher_event = self.patch_event.start()
+
+    def tearDown(self):
+        self.patch_event.stop()
+
+    def test_synchro_01_init_ok(self):
+        """Instantiate EventWaitExchange successfully"""
+
+        # prepare
+
+        # action
+        for remove_delivered in [True, False]:
+            EventWaitExchange(remove_delivered)
+
+        # test
+        # nothing to test at this point
+
+    def test_synchro_02_add_wait_events(self):
+        """Add event(s) to the exchange, check they are correctly stored.
+            Then wait, check they are correctly retrieved.
+        """
+
+        # prepare
+        e1 = "event1"
+        d1 = [ 'one', 'two']
+        e2 = "event2"
+        d2 = 12345
+        d3 = 23456
+
+        for remove_delivered in [True, False]:
+            exchange = EventWaitExchange(remove_delivered)
+            # need to access private member to avoid creating an (un-needed) getter
+            events = exchange._triggered_events
+
+            # actions + checks
+
+            # empty
+            self.assertEqual(events, {})
+
+            # one event
+            exchange.event(e1, d1)
+            self.assertEqual(set(events.keys()), set([e1]))
+            self.assertEqual(events[e1]['data'], d1)
+
+            # two events
+            exchange.event(e2, d2)
+            self.assertEqual(set(events.keys()), set([e1, e2]))
+            self.assertEqual(events[e1]['data'], d1)
+            self.assertEqual(events[e2]['data'], d2)
+
+            # two events, previous version overwritten
+            exchange.event(e2, d3)
+            self.assertEqual(set(events.keys()), set([e1, e2]))
+            self.assertEqual(events[e1]['data'], d1)
+            self.assertEqual(events[e2]['data'], d3)
+
+            # one event waited, is it still there ?
+            all_received, events_data = exchange.wait([e1], 1)
+            self.assertEqual(all_received, True)
+            self.assertEqual(events_data, [d1])
+            self.assertEqual(e1 in events, not remove_delivered)
+            self.assertEqual(e2 in events, True)
+
+            # another event waited, is it still there ?
+            all_received, events_data = exchange.wait([e2], 1)
+            self.assertEqual(all_received, True)
+            self.assertEqual(events_data, [d3])
+            self.assertEqual(e2 in events, not remove_delivered)
+            self.assertEqual(e1 in events, not remove_delivered)
+
+    def test_synchro_03_wait_add_events(self):
+        """Wait for events listeners, then add events, then check listeners are woken up
+        """
+
+        # prepare
+        e1 = "event1"
+        d1 = [ 'one', 'two']
+        e2 = "event2"
+        d2 = 12345
+
+        # terminate the wait call - need to modify the
+        self.patch_event.stop()
+        self.mock_event.return_value.wait.side_effect = FedbiomedSynchroError
+        self.patcher_event = self.patch_event.start()
+
+        for remove_delivered in [True, False]:
+            exchange = EventWaitExchange(remove_delivered)
+
+            # actions: add listeners in exchange
+            # check; no event set
+            with self.assertRaises(FedbiomedSynchroError):
+                exchange.wait([e1], 1)
+            with self.assertRaises(FedbiomedSynchroError):
+                exchange.wait([e2], 1)
+            with self.assertRaises(FedbiomedSynchroError):
+                exchange.wait([e1, e2], 1)
+
+            self.patcher_event.set.assert_not_called()
+
+            # actions: add first event
+            # check: one listener set for [e1]
+            exchange.event(e1, d1)
+            self.patcher_event.return_value.set.assert_called_once()
+            self.patcher_event.return_value.set.reset_mock()
+
+            # actions: add second event
+            # check: three listeners set for [e1] [e2] [e1, e2]
+            exchange.event(e2, d2)
+            self.assertEqual(self.patcher_event.return_value.set.call_count, 3)
+            self.patcher_event.return_value.set.reset_mock()
+
+    @patch('fedbiomed.common.synchro.EventWaitExchange._all_events', return_value=True)
+    def test_synchro_04_wait_arguments_ok_bad(self, event_wait_exchange):
+        """Wait called with good and bad arguments
+        """
+        # prepare
+        timeouts = [ -0.0, 3, 12, 0.4, 7.65, 60, MAX_TRIGGERED_EVENT_TIMEOUT]
+
+        for remove_delivered in [True, False]:
+            for timeout in timeouts:
+                exchange = EventWaitExchange(remove_delivered)
+
+                # test
+                exchange.wait(['dummy_id'], timeout)
+
+                # no speficic check
+
+        # prepare
+        timeouts = ['another', [1], ['bad]'], -1, -2.3,
+                    MAX_TRIGGERED_EVENT_TIMEOUT + 0.1, MAX_TRIGGERED_EVENT_TIMEOUT + 1]
+
+        for remove_delivered in [True, False]:
+            for timeout in timeouts:
+                exchange = EventWaitExchange(remove_delivered)
+
+                # test + check
+                with self.assertRaises(FedbiomedSynchroError):
+                    exchange.wait(['dummy_id'], timeout)
+
+    @patch('fedbiomed.common.synchro.GRACE_TRIGGERED_EVENT', 0)
+    def test_synchro_05_wait_timeout(self):
+        """Call to `wait()` is timeouted
+        """
+        # prepare
+        max_timeout = 0.1
+
+        with patch('fedbiomed.common.synchro.MAX_TRIGGERED_EVENT_TIMEOUT', max_timeout):
+            for remove_delivered in [True, False]:
+                exchange = EventWaitExchange(remove_delivered)
+
+                # test
+                all_received, events_data = exchange.wait(['dummy_id'], max_timeout / 2)
+
+                # check
+                self.assertEqual(all_received, False)
+                self.assertEqual(events_data, [])
+
+    @patch('fedbiomed.common.synchro.GRACE_TRIGGERED_EVENT', 0)
+    def test_synchro_06_event_timeout(self):
+        """Stored event is timeouted
+        """
+        # prepare
+        max_timeout = 0.1
+
+        e1 = "event1"
+        d1 = [ 'one', 'two']
+        e2 = "event2"
+        d2 = 12345
+
+        with patch('fedbiomed.common.synchro.MAX_TRIGGERED_EVENT_TIMEOUT', max_timeout):
+            for remove_delivered in [True, False]:
+                exchange = EventWaitExchange(remove_delivered)
+                # need to access private member to avoid creating an (un-needed) getter
+                events = exchange._triggered_events
+
+                # test + check
+
+                # one event
+                exchange.event(e1, d1)
+                self.assertEqual(set(events.keys()), set([e1]))
+                self.assertEqual(events[e1]['data'], d1)
+
+                # trigger timeout
+                time.sleep(max_timeout)
+
+                # two events, one timeouted
+                exchange.event(e2, d2)
+                self.assertEqual(set(events.keys()), set([e2]))
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_insert_untested_python_files_here.py
+++ b/tests/test_insert_untested_python_files_here.py
@@ -71,6 +71,10 @@ import fedbiomed.node.environ
 import fedbiomed.node.history_monitor
 import fedbiomed.node.training_plan_security_manager
 import fedbiomed.node.node
+import fedbiomed.node.requests.__init__
+import fedbiomed.node.requests._n2n_controller
+import fedbiomed.node.requests._n2n_router
+import fedbiomed.node.requests._overlay
 import fedbiomed.node.round
 import fedbiomed.node.secagg
 import fedbiomed.node.secagg_manager

--- a/tests/test_insert_untested_python_files_here.py
+++ b/tests/test_insert_untested_python_files_here.py
@@ -43,6 +43,7 @@ import fedbiomed.common.secagg._secagg_crypter
 import fedbiomed.common.secagg_manager
 import fedbiomed.common.serializer
 import fedbiomed.common.singleton
+import fedbiomed.common.synchro
 import fedbiomed.common.tasks_queue
 import fedbiomed.common.training_args
 import fedbiomed.common.training_plans.__init__

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -88,6 +88,9 @@ class TestNode(NodeTestCase):
                                       return_value=None)
         self.task_patcher = self.task_queue_patch.start()
 
+        self.exchange_patch = patch('fedbiomed.node.node.EventWaitExchange', autospec=True)
+        self.exchange_patcher = self.exchange_patch.start()
+
         # mocks
         mock_dataset_manager = DatasetManager()
         mock_dataset_manager.search_by_tags = MagicMock(return_value=self.database_val)
@@ -107,6 +110,7 @@ class TestNode(NodeTestCase):
         self.grpc_send_patch.stop()
         self.task_queue_patch.stop()
         self.grpc_controller_patch.stop()
+        self.exchange_patch.stop()
 
     @patch('fedbiomed.common.tasks_queue.TasksQueue.add')
     def test_node_01_add_task_normal_case_scenario(self, task_queue_add_patcher):

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -91,6 +91,9 @@ class TestNode(NodeTestCase):
         self.exchange_patch = patch('fedbiomed.node.node.EventWaitExchange', autospec=True)
         self.exchange_patcher = self.exchange_patch.start()
 
+        self.n2n_router_patch = patch('fedbiomed.node.node.NodeToNodeRouter', autospec=True)
+        self.n2n_router_patcher = self.n2n_router_patch.start()
+
         # mocks
         mock_dataset_manager = DatasetManager()
         mock_dataset_manager.search_by_tags = MagicMock(return_value=self.database_val)
@@ -111,6 +114,7 @@ class TestNode(NodeTestCase):
         self.task_queue_patch.stop()
         self.grpc_controller_patch.stop()
         self.exchange_patch.stop()
+        self.n2n_router_patch.stop()
 
     @patch('fedbiomed.common.tasks_queue.TasksQueue.add')
     def test_node_01_add_task_normal_case_scenario(self, task_queue_add_patcher):

--- a/tests/test_node_n2n_controller.py
+++ b/tests/test_node_n2n_controller.py
@@ -1,0 +1,158 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+#############################################################
+# Import NodeTestCase before importing FedBioMed Module
+from testsupport.base_case import NodeTestCase
+#############################################################
+
+from fedbiomed.common.message import NodeMessages
+from fedbiomed.node.requests._n2n_controller import NodeToNodeController
+
+from testsupport.fake_message import FakeMessages
+
+
+def func_return_argument(message):
+    return message
+
+
+class TestNodeToNodeController(unittest.IsolatedAsyncioTestCase, NodeTestCase):
+    """Test for node2node controller module, NodeToNodeRouter class"""
+
+    def setUp(self):
+        self.format_outgoing_patch = patch('fedbiomed.node.requests._n2n_controller.format_outgoing_overlay', autospec=True)
+
+        self.format_outgoing_patcher = self.format_outgoing_patch.start()
+        def fake_format_outgoing_message(message):
+            return message
+        self.format_outgoing_patcher.side_effect = func_return_argument
+
+        self.grpc_controller_mock = MagicMock(autospec=True)
+        self.pending_requests_mock = MagicMock(autospec=True)
+        self.controller_data_mock = MagicMock(autospec=True)
+
+        self.n2n_controller = NodeToNodeController(
+            self.grpc_controller_mock, self.pending_requests_mock, self.controller_data_mock)
+
+        self.overlay_msg = {
+            'researcher_id': 'dummy researcher',
+            'node_id': 'dummy source overlay node',
+            'dest_node_id': 'dummy dest overlay node',
+            'overlay': ['dummy overlay content'],
+            'command': 'overlay',
+        }
+        self.inner_msg = FakeMessages({
+            'node_id': 'dummy source inner node',
+            'dest_node_id': 'dummy dest inner node',
+            'request_id': 'dummy request id',
+            'secagg_id': 'dummy secagg id',
+            'command': 'key-request',
+        })
+
+
+    def tearDown(self):
+        self.format_outgoing_patch.stop()
+
+    @patch('fedbiomed.node.requests._n2n_controller.NodeToNodeMessages.format_outgoing_message')
+    @patch('fedbiomed.node.requests._n2n_controller.NodeMessages.format_outgoing_message')
+    async def test_n2n_controller_01_handle_key_request(self, nm_format_outgoing, n2nm_format_outgoing):
+        """Handle incoming message KeyRequest in node to node controller
+        """
+        # 1. public key is available
+
+        # prepare
+        public_key = 'my dummy pubkey'
+        self.controller_data_mock.wait.return_value = [True, [{'public_key': public_key}]]
+
+        nm_format_outgoing.side_effect = func_return_argument
+        n2nm_format_outgoing.side_effect = func_return_argument
+
+        # action
+        result = await self.n2n_controller.handle(self.overlay_msg, self.inner_msg)
+
+        # check
+        self.assertTrue(isinstance(result, dict))
+        self.assertEqual(set(result.keys()), set(['overlay_resp']))
+        self.assertEqual(result['overlay_resp']['researcher_id'], self.overlay_msg['researcher_id'])
+        self.assertEqual(result['overlay_resp']['overlay']['request_id'], self.inner_msg.get_param('request_id'))
+        self.assertEqual(result['overlay_resp']['overlay']['public_key'], public_key)
+
+
+        # 2. public key is not available
+
+        # prepare
+        self.controller_data_mock.wait.return_value = [False, [{'any': 'dummy'}]]
+
+        # action
+        result = await self.n2n_controller.handle(self.overlay_msg, self.inner_msg)
+
+        # check
+        self.assertTrue(result is None)
+
+    async def test_n2n_controller_02_handle_key_reply(self):
+        """Handle incoming message KeyReply in node to node controller
+        """
+        # prepare
+        inner_msg = FakeMessages({
+            'node_id': 'dummy source inner node',
+            'dest_node_id': 'dummy dest inner node',
+            'request_id': 'dummy request id',
+            'public-bytes': b'dummy public bytes',
+            'secagg_id': 'dummy secagg id',
+            'command': 'key-reply',
+        })
+
+        # action
+        result = await self.n2n_controller.handle(self.overlay_msg, inner_msg)
+
+        # check
+        self.assertTrue(isinstance(result, dict))
+        self.assertEqual(set(result.keys()), set(['inner_msg']))
+        self.assertEqual(result['inner_msg'].get_param('public-bytes'), inner_msg.get_param('public-bytes'))
+
+    async def test_n2n_controller_03_handle_key_default(self):
+        """Handle incoming message non existing in node to node controller
+        """
+        # prepare
+        inner_msg = FakeMessages({
+            'command': 'not-existing',
+        })
+
+        # action
+        result = await self.n2n_controller.handle(self.overlay_msg, inner_msg)
+
+        # check
+        self.assertTrue(result is None)
+
+    async def test_n2n_controller_04_final_key_request(self):
+        """Final handler for key request in node to node controller
+        """
+        # prepare
+        overlay_msg = NodeMessages.format_outgoing_message({
+            'researcher_id': 'dummy researcher',
+            'node_id': 'dummy source overlay node',
+            'dest_node_id': 'dummy dest overlay node',
+            'overlay': ['dummy overlay content'],
+            'command': 'overlay',
+        })
+
+        # action
+        await self.n2n_controller.final('key-request', overlay_resp=overlay_msg)
+
+        # check
+        self.grpc_controller_mock.send.assert_called_once()
+
+    async def test_n2n_controller_04_final_key_reply(self):
+        """Final handler for key reply in node to node controller
+        """
+        # prepare
+
+        # action
+        await self.n2n_controller.final('key-reply', inner_msg=self.inner_msg)
+
+        # check
+        self.pending_requests_mock.event.assert_called_once()
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()

--- a/tests/test_node_n2n_controller.py
+++ b/tests/test_node_n2n_controller.py
@@ -71,7 +71,7 @@ class TestNodeToNodeController(unittest.IsolatedAsyncioTestCase, NodeTestCase):
         result = await self.n2n_controller.handle(self.overlay_msg, self.inner_msg)
 
         # check
-        self.assertTrue(isinstance(result, dict))
+        self.assertIsInstance(result, dict)
         self.assertEqual(set(result.keys()), set(['overlay_resp']))
         self.assertEqual(result['overlay_resp']['researcher_id'], self.overlay_msg['researcher_id'])
         self.assertEqual(result['overlay_resp']['overlay']['request_id'], self.inner_msg.get_param('request_id'))
@@ -87,7 +87,7 @@ class TestNodeToNodeController(unittest.IsolatedAsyncioTestCase, NodeTestCase):
         result = await self.n2n_controller.handle(self.overlay_msg, self.inner_msg)
 
         # check
-        self.assertTrue(result is None)
+        self.assertIsNone(result)
 
     async def test_n2n_controller_02_handle_key_reply(self):
         """Handle incoming message KeyReply in node to node controller
@@ -106,7 +106,7 @@ class TestNodeToNodeController(unittest.IsolatedAsyncioTestCase, NodeTestCase):
         result = await self.n2n_controller.handle(self.overlay_msg, inner_msg)
 
         # check
-        self.assertTrue(isinstance(result, dict))
+        self.assertIsInstance(result, dict)
         self.assertEqual(set(result.keys()), set(['inner_msg']))
         self.assertEqual(result['inner_msg'].get_param('public-bytes'), inner_msg.get_param('public-bytes'))
 
@@ -122,7 +122,7 @@ class TestNodeToNodeController(unittest.IsolatedAsyncioTestCase, NodeTestCase):
         result = await self.n2n_controller.handle(self.overlay_msg, inner_msg)
 
         # check
-        self.assertTrue(result is None)
+        self.assertIsNone(result)
 
     async def test_n2n_controller_04_final_key_request(self):
         """Final handler for key request in node to node controller

--- a/tests/test_node_n2n_router.py
+++ b/tests/test_node_n2n_router.py
@@ -19,7 +19,7 @@ class DummyException(Exception):
 
 
 class TestNodeToNodeAsyncRouter(unittest.IsolatedAsyncioTestCase, NodeTestCase):
-    """Test for node2node router module, NodeToNodeRouter class"""
+    """Test for node2node router module, _NodeToNodeAsyncRouter class"""
 
     def setUp(self):
         self.async_queue_patch = patch('fedbiomed.node.requests._n2n_router.asyncio.Queue', autospec=True)

--- a/tests/test_node_n2n_router.py
+++ b/tests/test_node_n2n_router.py
@@ -1,0 +1,341 @@
+import unittest
+from unittest.mock import patch, MagicMock, AsyncMock
+import asyncio
+import time
+
+#############################################################
+# Import NodeTestCase before importing FedBioMed Module
+from testsupport.base_case import NodeTestCase
+#############################################################
+
+from fedbiomed.common.exceptions import FedbiomedNodeToNodeError
+from fedbiomed.node.environ import environ
+from fedbiomed.node.requests._n2n_router import NodeToNodeRouter, _NodeToNodeAsyncRouter
+
+from testsupport.fake_message import FakeMessages
+
+class DummyException(Exception):
+    pass
+
+
+class TestNodeToNodeAsyncRouter(unittest.IsolatedAsyncioTestCase, NodeTestCase):
+    """Test for node2node router module, NodeToNodeRouter class"""
+
+    def setUp(self):
+        self.async_queue_patch = patch('fedbiomed.node.requests._n2n_router.asyncio.Queue', autospec=True)
+        self.async_queue_patch.side_effect = AsyncMock()
+        self.n2n_controller_patch = patch('fedbiomed.node.requests._n2n_router.NodeToNodeController', autospec=True)
+        self.n2n_controller_patch.side_effect = AsyncMock()
+        self.format_incoming_patch = patch('fedbiomed.node.requests._n2n_router.format_incoming_overlay', autospec=True)
+
+        self.async_queue_patcher = self.async_queue_patch.start()
+        self.n2n_controller_patcher = self.n2n_controller_patch.start()
+        self.format_incoming_patcher = self.format_incoming_patch.start()
+
+        self.grpc_controller_mock = MagicMock(autospec=True)
+        self.pending_requests_mock = MagicMock(autospec=True)
+        self.controller_data_mock = MagicMock(autospec=True)
+
+        self.n2n_async_router = _NodeToNodeAsyncRouter(
+            self.grpc_controller_mock, self.pending_requests_mock, self.controller_data_mock)
+
+    def tearDown(self):
+
+        self.async_queue_patch.stop()
+        self.n2n_controller_patch.stop()
+        self.format_incoming_patch.stop()
+
+
+    async def test_n2n_async_router_01_remove_finished_tasks(self):
+        """Remove finished tasks of a n2n async router
+        """
+
+        # prepare
+        async def dummy_task(*args, **kwargs):
+            pass
+        t1 = asyncio.create_task(dummy_task())
+        t2 = asyncio.create_task(dummy_task())
+        t3 = asyncio.create_task(dummy_task())
+
+        # need to access private list of active tasks
+        active_tasks = self.n2n_async_router._active_tasks
+        # will not timeout
+        active_tasks[t1.get_name()] = {
+            'start_time': time.time(),
+            'task': t1,
+            'finally': False,
+        }
+        active_tasks[t2.get_name()] = {
+            'start_time': time.time(),
+            'task': t2,
+            'finally': False,
+        }
+
+        # 1. remove task existing in active tasks
+
+        # action
+        self.n2n_async_router._remove_finished_task(t1)
+        await asyncio.sleep(0.1) # give time to complete task
+
+        self.assertEqual(set(active_tasks.keys()), set([t2.get_name()]))
+
+        # 1. remove task not existing in active tasks
+
+        # action
+        self.n2n_async_router._remove_finished_task(t3)
+        await asyncio.sleep(0.1)  # give time to complete task
+
+        self.assertEqual(set(active_tasks.keys()), set([t2.get_name()]))
+
+
+    @patch('fedbiomed.node.requests._n2n_router.asyncio.sleep')
+    @patch('fedbiomed.node.requests._n2n_router.OVERLAY_MESSAGE_PROCESS_TIMEOUT', 0.5)
+    async def test_n2n_async_router_02_clean_active_tasks(
+        self,
+        asyncio_sleep,
+    ):
+        """Clean active tasks of a n2n async router
+        """
+        # prepare
+        asyncio_sleep.side_effect = [ None, DummyException]
+
+        async def dummy_task(*args, **kwargs):
+            pass
+        t1 = asyncio.create_task(dummy_task())
+        t2 = asyncio.create_task(dummy_task())
+        start_time = time.time()
+
+        # need to access private list of active tasks
+        active_tasks = self.n2n_async_router._active_tasks
+        # will not timeout
+        active_tasks[t1.get_name()] = {
+            'start_time': start_time,
+            'task': t1,
+            'finally': False,
+        }
+        # will timeout
+        active_tasks[t2.get_name()] = {
+            'start_time': start_time - 1,
+            'task': t2,
+            'finally': False,
+        }
+
+        # action
+        with self.assertRaises(DummyException):
+            await self.n2n_async_router._clean_active_tasks()
+
+        # checks
+        self.assertEqual(active_tasks[t1.get_name()]['finally'], False)
+        self.assertEqual(active_tasks[t2.get_name()]['finally'], True)
+
+
+    @patch('fedbiomed.node.requests._n2n_router._NodeToNodeAsyncRouter._overlay_message_process')
+    @patch('fedbiomed.node.requests._n2n_router._NodeToNodeAsyncRouter._remove_finished_task')
+    @patch('fedbiomed.node.requests._n2n_router._NodeToNodeAsyncRouter._clean_active_tasks')
+    async def test_n2n_async_router_03_run_async(
+            self,
+            clean_active_tasks,
+            remove_finished_task,
+            overlay_message_process
+    ):
+        """Run async of a n2n async router
+        """
+        # prepare
+        async def dummy_task(*args, **kwargs):
+            pass
+        clean_active_tasks.return_value = asyncio.create_task(dummy_task())
+        remove_finished_task.return_value = asyncio.create_task(dummy_task())
+        overlay_message_process.return_value = asyncio.create_task(dummy_task())
+
+        message = {
+            'dest_node_id': environ['NODE_ID'],
+            'overlay': 'dummy content',
+        }
+        self.async_queue_patcher.return_value.get.side_effect = [message, DummyException]
+
+        # action
+        with self.assertRaises(DummyException):
+            await self.n2n_async_router._run_async()
+
+        # check
+        clean_active_tasks.assert_called_once()
+        overlay_message_process.assert_called_once()
+
+    async def test_n2n_async_router_04_submit(self):
+        """Submit message to a n2n async router
+        """
+        # successful
+        await self.n2n_async_router._submit('dummy_message')
+        self.async_queue_patcher.return_value.put_nowait.assert_called_once()
+        self.async_queue_patcher.return_value.put_nowait.reset_mock()
+
+        # failed
+        self.async_queue_patcher.return_value.put_nowait.side_effect = asyncio.QueueFull
+        await self.n2n_async_router._submit('dummy_messagfe')
+        self.async_queue_patcher.return_value.put_nowait.assert_called_once()
+        self.async_queue_patcher.return_value.put_nowait.reset_mock()
+
+    async def test_n2n_async_router_05_overlay_process(self):
+        """Process overlay message in n2n async router
+        """
+        #
+        # 1. successful call
+        #
+
+        # prepare
+        self.format_incoming_patcher.return_value = FakeMessages({
+            'command': 'dummy command'
+        })
+        self.n2n_controller_patcher.return_value.handle.return_value = None
+        self.n2n_controller_patcher.return_value.final.return_value = None
+        msg = {
+            'dest_node_id': environ['NODE_ID'],
+            'overlay': 'dummy content',
+            'command': 'dummy command',
+        }
+        # need to initialize private variable (store current active task)
+        self.n2n_async_router._active_tasks[asyncio.current_task().get_name()] = {}
+
+        # action
+        await self.n2n_async_router._overlay_message_process(msg)
+
+        # check
+        self.format_incoming_patcher.assert_called_once()
+        self.n2n_controller_patcher.return_value.handle.assert_called_once()
+        self.n2n_controller_patcher.return_value.final.assert_called_once()
+
+        # reset
+        self.format_incoming_patcher.reset_mock()
+        self.n2n_controller_patcher.reset_mock()
+
+        #
+        # 2. bad message failure call
+        # 
+
+        # prepare
+        msg2 = {
+            'dest_node_id': 'incorrect id',
+            'overlay': 'dummy content',
+            'command': 'dummy command',
+        }
+
+        # action
+        await self.n2n_async_router._overlay_message_process(msg2)
+
+        # check
+        self.format_incoming_patcher.assert_not_called()
+        self.n2n_controller_patcher.return_value.handle.assert_not_called()
+        self.n2n_controller_patcher.return_value.final.assert_not_called()
+
+        # reset
+        self.format_incoming_patcher.reset_mock()
+        self.n2n_controller_patcher.reset_mock()
+
+        #
+        # 3. cancelled handling failure call
+        #
+
+        # prepare
+        self.n2n_controller_patcher.return_value.handle.side_effect = asyncio.CancelledError
+
+        # action
+        await self.n2n_async_router._overlay_message_process(msg)
+
+        # check
+        self.format_incoming_patcher.assert_called_once()
+        self.n2n_controller_patcher.return_value.handle.assert_called_once()
+        self.n2n_controller_patcher.return_value.final.assert_not_called()
+
+        # reset
+        self.format_incoming_patcher.reset_mock()
+        self.n2n_controller_patcher.reset_mock()
+
+        #
+        # 3. other error failure call
+        #
+
+        # prepare
+        self.n2n_controller_patcher.return_value.handle.side_effect = DummyException
+
+        # action
+        await self.n2n_async_router._overlay_message_process(msg)
+
+        # check
+        self.format_incoming_patcher.assert_called_once()
+        self.n2n_controller_patcher.return_value.handle.assert_called_once()
+        self.n2n_controller_patcher.return_value.final.assert_not_called()
+
+        # reset
+        self.format_incoming_patcher.reset_mock()
+        self.n2n_controller_patcher.reset_mock()
+
+
+
+class TestNodeToNodeRouter(unittest.IsolatedAsyncioTestCase, NodeTestCase):
+    """Test for node2node router module, NodeToNodeRouter class"""
+
+    def setUp(self):
+
+        self.async_patch = patch('fedbiomed.node.requests._n2n_router.asyncio', autospec=True)
+        self.thread_patch = patch('fedbiomed.node.requests._n2n_router.Thread', autospec=True)
+        self.n2n_controller_patch = patch('fedbiomed.node.requests._n2n_router.NodeToNodeController', autospec=True)
+        self.n2n_controller_patch.side_effect = AsyncMock()
+
+        self.async_patcher = self.async_patch.start()
+        self.thread_patcher = self.thread_patch.start()
+        self.n2n_controller_patcher = self.n2n_controller_patch.start()
+
+        self.grpc_controller_mock = MagicMock(autospec=True)
+        self.pending_requests_mock = MagicMock(autospec=True)
+        self.controller_data_mock = MagicMock(autospec=True)
+
+        self.n2n_router = NodeToNodeRouter(
+            self.grpc_controller_mock, self.pending_requests_mock, self.controller_data_mock)
+
+    def tearDown(self):
+
+        self.async_patch.stop()
+        self.thread_patch.stop()
+        self.n2n_controller_patch.stop()
+
+
+    def test_n2n_router_01_start(self):
+        """Start a n2n router
+        """
+        self.n2n_router.start()
+        self.thread_patcher.return_value.start.assert_called_once()
+
+    def test_n2n_router_02_private_run(self):
+        """Call `_run()` from n2n router
+        """
+        # successful run
+        self.n2n_router._run()
+        self.async_patcher.run.assert_called_once()
+
+        # failed run
+        self.async_patcher.run.side_effect = DummyException
+        with self.assertRaises(DummyException):
+            self.n2n_router._run()
+
+    def test_n2n_router_03_submit(self):
+        """Submit message to a n2n router
+        """
+        # correct message
+        message = {'command': 'overlay'}
+        self.n2n_router.submit(message)
+        self.async_patcher.run_coroutine_threadsafe.assert_called_once()
+
+        # bad message
+        message = {'command': 'not_overlay'}
+        with self.assertRaises(FedbiomedNodeToNodeError):
+            self.n2n_router.submit(message)
+
+        # failed submission
+        message = {'command': 'overlay'}
+        self.async_patcher.run_coroutine_threadsafe.side_effect = DummyException
+        with self.assertRaises(DummyException):
+            self.n2n_router.submit(message)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()

--- a/tests/test_node_overlay.py
+++ b/tests/test_node_overlay.py
@@ -1,0 +1,227 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+
+#############################################################
+# Import NodeTestCase before importing FedBioMed Module
+from testsupport.base_case import NodeTestCase
+#############################################################
+
+from fedbiomed.common.exceptions import FedbiomedNodeToNodeError
+from fedbiomed.common.message import Message, KeyRequest, InnerMessage, InnerRequestReply
+from fedbiomed.common.serializer import Serializer
+from fedbiomed.node.requests._overlay import format_outgoing_overlay, format_incoming_overlay, send_nodes, \
+    _default_n2n_key, _CHUNK_SIZE, load_default_n2n_key
+
+
+class TestNodeRequestsOverlay(NodeTestCase):
+    """Test for node overlay communications module"""
+
+    def setUp(self):
+        self.grpc_controller_mock = MagicMock(autospec=True)
+        self.pending_requests_mock = MagicMock(autospec=True)
+
+        self.inner_message = InnerMessage(
+            node_id= 'my node id',
+            dest_node_id= 'my dest node id',
+        )
+
+    def tearDown(self):
+        pass
+
+    def test_overlay_01_format_out_in(self):
+        """Test outgoing + incoming formatting function
+        """
+        # prepare
+        src_message = KeyRequest(
+            node_id= 'my node id',
+            dest_node_id= 'my dest node id',
+            request_id='my request id',
+            secagg_id='my secagg id',
+            command='key-request',
+        )
+        # nota: not mocking all subclasses like Serializer, Message, etc.
+        # would make tests (uselessly ?) too complicated
+
+        # action
+        dest_message = format_incoming_overlay(format_outgoing_overlay(src_message))
+
+        # check
+        self.assertIsInstance(dest_message, InnerMessage)
+        self.assertEqual(set(src_message.get_dict().keys()), set(dest_message.get_dict().keys()))
+        for k in src_message.get_dict().keys():
+            self.assertEqual(src_message.get_param(k), dest_message.get_param(k))
+
+
+    @patch('fedbiomed.node.requests._overlay.format_outgoing_overlay')
+    @patch('fedbiomed.node.requests._overlay.NodeMessages.format_outgoing_message')
+    def test_overlay_02_send_nodes(self, nm_format_outgoing, format_outgoing):
+        """Test send_nodes function
+        """
+        # prepare
+        def pending_requests_wait(request_ids, timeout):
+            return True, request_ids
+        self.pending_requests_mock.wait.side_effect = pending_requests_wait
+
+        nodes = [ 'node1', 'node2']
+        request_id = 'my dummy id for inner request reply'
+        messages = [
+            InnerMessage(
+                node_id= 'my node id',
+                dest_node_id= nodes[0],
+            ),
+            InnerRequestReply(
+                node_id= 'my node id',
+                dest_node_id= nodes[0],
+                request_id= request_id,
+            )
+        ]
+
+        # action
+        _, replies = send_nodes(
+            self.grpc_controller_mock,
+            self.pending_requests_mock,
+            'dummy_researcher_id',
+            nodes,
+            messages,
+        )
+
+        # check
+        self.assertEqual(set(replies), set([request_id]))
+
+    def test_overlay_03_format_outgoing_failure_arguments(self):
+        """Test outgoing formatting function failure because of bad arguments
+        """
+        # prepare
+        messages = [
+            Message(),
+            {'command': 'key-request'},
+            False,
+            3
+        ]
+
+        # action + check
+        for m in messages:
+            with self.assertRaises(FedbiomedNodeToNodeError):
+                format_outgoing_overlay(m)
+
+    @patch('fedbiomed.node.requests._overlay._CHUNK_SIZE', 10**6)
+    def test_overlay_04_format_outgoing_failure_key_size(self):
+        """Test outgoing formatting function failure because of bad key size
+        """
+        # prepare
+
+        # action + check
+        with self.assertRaises(FedbiomedNodeToNodeError):
+            format_outgoing_overlay(self.inner_message)
+
+    def test_overlay_05_format_incoming_failure_arguments(self):
+        """Test incoming formatting function failure because of bad arguments
+        """
+        # prepare
+        payloads = [
+            [3],
+            [3, b'4'],
+            [b'4', 3],
+            [b'5',1, b'5'],
+            [[b'4']],
+        ]
+
+        # action + check
+        for p in payloads:
+            with self.assertRaises(FedbiomedNodeToNodeError):
+                format_incoming_overlay(p)
+
+    @patch('fedbiomed.node.requests._overlay._CHUNK_SIZE', 10**6)
+    def test_overlay_06_format_incoming_failure_key_size(self):
+        """Test incoming formatting function failure because of bad key size
+        """
+        # prepare
+        payload = [b'123456123456123456']
+
+        # action + check
+        with self.assertRaises(FedbiomedNodeToNodeError):
+            format_incoming_overlay(payload)
+
+    def test_overlay_07_format_incoming_failure_decrypt(self):
+        """Test incoming formatting function failure at decryption
+        """
+        # prepare
+        payload = [b'123456123456123456']
+
+        # action + check
+        with self.assertRaises(FedbiomedNodeToNodeError):
+            format_incoming_overlay(payload)
+
+    def test_overlay_08_format_incoming_failure_bad_message_content(self):
+        """Test incoming formatting function failure bad encrypted message content
+        """
+        # prepare
+        signed = Serializer.dumps({
+            'message': self.inner_message.get_dict(),
+            # intentionally forget to add signature field
+        })
+        payload = [
+            _default_n2n_key.public_key().encrypt(
+                signed[i:i + _CHUNK_SIZE],
+                padding.OAEP(
+                    mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                    algorithm=hashes.SHA256(),
+                    label=None
+                )
+            )
+            for i in range(0, len(signed), _CHUNK_SIZE)
+        ]
+
+        # action + check
+        with self.assertRaises(FedbiomedNodeToNodeError):
+            format_incoming_overlay(payload)
+
+    def test_overlay_09_format_incoming_failure_bad_message_signature(self):
+        """Test incoming formatting function failure bad encrypted message signature
+        """
+        # prepare
+        inner_message_modified = {
+            'node_id': 'different node id',
+            'dest_node_id': 'my dest node id',
+        }
+        signed = Serializer.dumps({
+            'message': self.inner_message.get_dict(),
+            'signature': _default_n2n_key.sign(
+                Serializer.dumps(inner_message_modified),
+                padding.PSS(
+                    mgf=padding.MGF1(hashes.SHA256()),
+                    salt_length=padding.PSS.MAX_LENGTH
+                ),
+                hashes.SHA256()
+
+            )
+        })
+        payload = [
+            _default_n2n_key.public_key().encrypt(
+                signed[i:i + _CHUNK_SIZE],
+                padding.OAEP(
+                    mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                    algorithm=hashes.SHA256(),
+                    label=None
+                )
+            )
+            for i in range(0, len(signed), _CHUNK_SIZE)
+        ]
+
+        # action + check
+        with self.assertRaises(FedbiomedNodeToNodeError):
+            format_incoming_overlay(payload)
+
+    @patch('fedbiomed.node.requests._overlay._DEFAULT_N2N_KEY_FILE', 'non_existing_filename')
+    def test_overlay_10_load_default_key_failure(self):
+        """Test loading default key failure
+        """
+        # prepare
+        with self.assertRaises(FedbiomedNodeToNodeError):
+            load_default_n2n_key()
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
**PR description**

Partial implementation of #942: add unit tests for some LOM secagg code

   * `common/synchro.py`
   * `node/requests/_n2n_router.py`
   * `node/requests/_n2n_controller.py`
   * `node/requests/_overlay.py`

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`