### PR TITLE
Fix breakpoint dysfunction for secure aggregation (regression)

### DIFF
--- a/fedbiomed/researcher/secagg/_secure_aggregation.py
+++ b/fedbiomed/researcher/secagg/_secure_aggregation.py
@@ -78,7 +78,7 @@ class SecureAggregation:
             },
             "attributes": {},
             "attributes_states": {
-                "__secagg": self.__secagg.save_state_breakpoint()
+                "_SecureAggregation__secagg": self.__secagg.save_state_breakpoint()
             }
         }
 

--- a/tests/end2end/e2e_secure_aggregation.py
+++ b/tests/end2end/e2e_secure_aggregation.py
@@ -302,13 +302,21 @@ def test_06_secagg_lom_pytorch_breakpoint(extra_nodes_for_lom):
     )
 
     exp.run()
+    secagg_id_before = exp.secagg.dh.secagg_id
 
     # Delete experiment but do not clear its data
     del exp
 
-    # Load experiment from latest breakpoint and continue training
+    # Load experiment from latest breakpoint
     loaded_exp = Experiment.load_breakpoint()
-    print("Running training round after loading the params")
+
+    # Check that `secagg_id` match (good hint that secagg context was properly reloaded)
+    print("\nAsserting secagg context match after loading the params")
+    secagg_id_after = loaded_exp.secagg.dh.secagg_id
+    assert secagg_id_before, secagg_id_after
+
+    # Continue training
+    print("\nRunning training round after loading the params")
     loaded_exp.run(rounds=2, increase=True)
 
     # Clear


### PR DESCRIPTION
**PR description**

Fix #1180

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`