### PR TITLE
Fix endurance test replacing os.fork with process spawn

### DIFF
--- a/tests/end2end/helpers/_execution.py
+++ b/tests/end2end/helpers/_execution.py
@@ -103,28 +103,6 @@ def kill_process(process):
         print('Parent process has became zombie process after killing child procesess')
 
 
-def fork_process(
-    command: Callable,
-    *args,
-    **kwargs,
-):
-    """Executes forked process
-
-    Args:
-        command: Command to execute in forked process
-        *args: optional args
-        **kwargs: optional kwargs
-    """
-    context = multiprocessing.get_context('spawn')
-    p = context.Process(target=command, args=args, kwargs=kwargs)
-    p.run()
-
-    if isinstance(p.exitcode, int) and p.exitcode != 0:
-        # Other exceptions are caught by pytest
-        pytest.exit(f"Error: Forked process failed {command}. Args: {args} {kwargs} "
-                    "Please check the outputs.")
-
-
 def shell_process(
     command: list,
     activate: str = None,

--- a/tests/end2end/helpers/_helpers.py
+++ b/tests/end2end/helpers/_helpers.py
@@ -18,19 +18,16 @@ import functools
 from contextlib import contextmanager
 from typing import Dict, Any, Tuple, Callable, List
 
-import pytest
-
 from fedbiomed.common.constants import TENSORBOARD_FOLDER_NAME, ComponentType
 from fedbiomed.common.config import Config
 from fedbiomed.common.utils import ROOT_DIR, CONFIG_DIR, VAR_DIR
 
 from ._execution import (
-    fork_process,
     shell_process,
     fedbiomed_run,
     execute_in_paralel,
 )
-from .constants import CONFIG_PREFIX, FEDBIOMED_SCRIPTS, End2EndError
+from .constants import CONFIG_PREFIX, End2EndError
 
 
 
@@ -357,10 +354,7 @@ def create_component(
     if _SecaggTableSingleton in _SecaggTableSingleton._objects:
         del _SecaggTableSingleton._objects[_SecaggTableSingleton]
 
-    # For now, executing in another process is not mandatory
-    # This is provision for future to prevent in config generation event
-    # (eg: creating a singleton object) to propagate to this process
-    fork_process(config.generate)
+    config.generate()
 
     # need to update configuration in parent process
     config.read()


### PR DESCRIPTION
**PR description**

Fix endurance test replacing os.fork with process spawn

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`