### PR TITLE
Fix LOM secagg failure with some "many nodes" scenarios

### DIFF
--- a/fedbiomed/common/secagg/_lom.py
+++ b/fedbiomed/common/secagg/_lom.py
@@ -186,7 +186,7 @@ class LOM:
         """
         list_y_u_tau = np.array(list_y_u_tau, dtype=self._vector_dtype)
         decrypted_vector = np.sum(list_y_u_tau, axis=0)
-        decrypted_vector = decrypted_vector.astype(np.int32)
+        decrypted_vector = decrypted_vector.astype(np.uint32)
         decrypted_vector = decrypted_vector.tolist()
 
         return decrypted_vector

--- a/fedbiomed/common/secagg/_lom.py
+++ b/fedbiomed/common/secagg/_lom.py
@@ -136,7 +136,7 @@ class LOM:
         _node_bits = math.ceil(math.log2(num_nodes))
 
         if _max_param_bits > self._values_bit - _node_bits:
-            _max_nodes = 2**(self._values_bit - _max_param_bits) - 1
+            _max_nodes = 2**(self._values_bit - _max_param_bits)
             _missing_bits = _max_param_bits + _node_bits - self._values_bit
             raise FedbiomedSecaggError(
                 f"{ErrorNumbers.FB417.value}: Computation overflow using LOM secagg "

--- a/fedbiomed/common/utils/_secagg_utils.py
+++ b/fedbiomed/common/utils/_secagg_utils.py
@@ -101,8 +101,8 @@ def quantize(
 
     _check_clipping_range(weights, clipping_range)
 
-    # CAVEAT: ensure to be converting from `float` to `uint64`` (no intermediate `int64`)
-    # Process ensures an to compute an `int`` in the range [0, target_range -1]
+    # CAVEAT: ensure to be converting from `float` to `uint64` (no intermediate `int64`)
+    # Process ensures to compute an `int`` in the range [0, target_range -1]
     # This enables to use at most 2**64 as target_range (max value of `uint` - 1)
     f = np.vectorize(
         lambda x: min(

--- a/fedbiomed/researcher/secagg/_secure_aggregation.py
+++ b/fedbiomed/researcher/secagg/_secure_aggregation.py
@@ -150,9 +150,7 @@ class _SecureAggregation(ABC):
                 f"but got {type(active)} "
             )
 
-        if clipping_range is not None and (
-            not isinstance(clipping_range, int) or isinstance(clipping_range, bool)
-        ):
+        if clipping_range is not None and not isinstance(clipping_range, int):
             raise FedbiomedSecureAggregationError(
                 f"{ErrorNumbers.FB417.value}: Clipping range should be None or an integer, "
                 f"but got not {type(clipping_range)}"

--- a/tests/test_secure_aggregation.py
+++ b/tests/test_secure_aggregation.py
@@ -52,7 +52,7 @@ class TestJLSecureAggregation(MockRequestModule, ResearcherTestCase):
             JoyeLibertSecureAggregation(clipping_range="Not an integer")
 
         with self.assertRaises(FedbiomedSecureAggregationError):
-            JoyeLibertSecureAggregation(clipping_range=True)
+            JoyeLibertSecureAggregation(clipping_range=[True])
 
     def test_jl_secure_aggregation_02_activate(self):
         """Tests secure aggregation activation"""


### PR DESCRIPTION
**PR description**

Address #1210 LOM secagg failing with "many nodes" scenarios:

- clarify cases where it should fail/succeed
- node side: give clearer message to user when failing due to limitations
- researcher side: fix a bug when aggregated value is >= 2**31 (and is converted to < 0 `int`)

Reviewer may want to (re) test scenarios of LOM secagg:
- success with 7 or 8 nodes
- failure with 9 or 10 nodes
- success with 10 nodes and `test_ratio: 0.4`


**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`