### PR TITLE
Feature/1105 fix loading image when name contains dots bug

### DIFF
--- a/fedbiomed/common/data/_medical_datasets.py
+++ b/fedbiomed/common/data/_medical_datasets.py
@@ -7,6 +7,7 @@ Provides classes managing dataset for common cases of use in healthcare:
 - NIFTI: For NIFTI medical images
 """
 from os import PathLike
+import os
 from pathlib import Path
 from typing import Union, Tuple, Dict, Iterable, Optional, List, Callable
 from enum import Enum
@@ -755,15 +756,29 @@ class MedicalFolderDataset(Dataset, MedicalFolderBase):
         Returns:
             Subject image data as victories where keys represent each modality.
         """
+        # FIXME: improvment suggestion of this function at #1279
+
         subject_data = {}
 
         for modality in modalities:
             modality_folder = self._subject_modality_folder(subject_folder, modality)
             image_folder = subject_folder.joinpath(modality_folder)
-            nii_files = [p.resolve() for p in image_folder.glob("**/*")
-                         if ''.join(p.suffixes) in self.ALLOWED_EXTENSIONS]
+            nii_files = [p.resolve() for p in image_folder.glob("**/*")]
 
             # Load the first, we assume there is going to be a single image per modality for now.
+
+            nii_files = tuple(
+                img for img in nii_files if any(str(img).endswith(fmt) for fmt in self.ALLOWED_EXTENSIONS)
+                              )
+            if len(nii_files) < 1:
+                raise FedbiomedDatasetError(f"{ErrorNumbers.FB613.value}: folder {os.path.join(image_folder, modality)}"
+                                            " is empty, but should contain an niftii image. Aborting")
+
+            elif len(nii_files) > 1:
+                raise FedbiomedDatasetError(f"{ErrorNumbers.FB613.value}: more than one niftii file has been detected"
+                                            " {', '.join(tuple(str(f) for f in nii_files))}. "
+                                            "\nThere should be only one niftii image per modality. Aborting")
+
             img_path = nii_files[0]
             img = self._reader(img_path)
             subject_data[modality] = img


### PR DESCRIPTION
**PR description**
Fixes and closes #1105 .

Provides a fix and unit test

Nota: bug fix may not be complete, because if an image has not the correct extension, loading it in Fed-BioMed MedicalFolderDataset will still fail.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`