### PR TITLE
remove dependencies to fedbiomed.node in fedbiomed.common, for v6.

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -62,6 +62,11 @@ For installing optional node GUI:
 pip install fedbiomed[gui]
 ```
 
+For installing optional dependency to FLamby:
+```
+pip install git+https://github.com/owkin/FLamby@main
+```
+
 Fed-BioMed is provided under [Apache 2.0 License](https://github.com/fedbiomed/fedbiomed/blob/master/LICENSE.md).
 
 

--- a/docs/user-guide/nodes/deploying-datasets.md
+++ b/docs/user-guide/nodes/deploying-datasets.md
@@ -42,7 +42,7 @@ The interface prompts you to select the type of dataset you would like to add. T
 
 For example, suppose you want to add a CSV dataset. To do this, type `1` and press Enter. The interface will then ask you to provide the common attributes: dataset name, tags, and description.
 
-!!! note "Falmby"
+!!! note "Flamby"
     To enable option 6 in Fed-BioMed, you'll need to install FLamby as an external dependency. After installing Fed-BioMed, use the following command: `pip install git+https://github.com/owkin/FLamby@main`."
 
 ```

--- a/fedbiomed/cli.py
+++ b/fedbiomed/cli.py
@@ -96,6 +96,9 @@ class ComponentParser(CLIArgumentParser):
     def create(self, args):
         """CLI Handler for creating configuration file and assets for given component
         """
+        if args.component is None:
+            CommonCLI.error("Error: bad command line syntax")
+
         if not args.path:
             if args.component.lower() == "researcher":
                 component_path = os.path.join(os.getcwd(), DEFAULT_RESEARCHER_NAME)
@@ -106,8 +109,6 @@ class ComponentParser(CLIArgumentParser):
 
         # Researcher specific case ----------------------------------------------------
         # This is a special case since researcher import
-        if args.component is None:
-            CommonCLI.error("Error: bad command line syntax")
         if args.component.lower() == "researcher":
             if DEFAULT_RESEARCHER_NAME in component_path and \
                 os.path.isdir(component_path) and \

--- a/fedbiomed/cli.py
+++ b/fedbiomed/cli.py
@@ -1,16 +1,158 @@
 # This file is originally part of Fed-BioMed
 # SPDX-License-Identifier: Apache-2.0
 
-
-import traceback
-import importlib
-from fedbiomed.common.cli import CommonCLI
 import os
+import sys
+import argparse
+import importlib
+
+from fedbiomed.common.constants import DEFAULT_NODE_NAME, DEFAULT_RESEARCHER_NAME
+from fedbiomed.common.config import docker_special_case
+from fedbiomed.common.cli import CLIArgumentParser, CommonCLI
+
+
+class UniqueStore(argparse.Action):
+    """Argparse action for avoiding having several time the same optional
+      argument"""
+    def __call__(self, parser, namespace, values, option_string):
+        if getattr(namespace, self.dest, self.default) is not self.default:
+            parser.error(option_string + " appears several times.")
+        setattr(namespace, self.dest, values)
+
+
+class ComponentParser(CLIArgumentParser):
+    """Instantiates configuration parser"""
+
+    def initialize(self):
+        """Initializes argument parser for creating configuration file."""
+
+        self._parser = self._subparser.add_parser(
+            "component",
+            help="The helper for generating or updating component configuration files, see `configuration -h`"
+            " for more details",
+        )
+
+        self._parser.set_defaults(func=self.default)
+
+        # Common parser to register common arguments for create and refresh
+        common_parser = argparse.ArgumentParser(add_help=False)
+        common_parser.add_argument(
+            "-p",
+            "--path",
+            action=UniqueStore,
+            metavar="COMPONENT_PATH",
+            type=str,
+            nargs="?",
+            required=False,
+            help="Path to specificy where Fed-BioMed component will be intialized.",
+        )
+
+        common_parser.add_argument(
+            "-c",
+            "--component",
+            metavar="COMPONENT_TYPE[ NODE|RESEARCHER ]",
+            type=str,
+            nargs="?",
+            required=True,
+            help="Component type NODE or RESEARCHER",
+        )
+
+        # Create sub parser under `configuration` command
+        component_sub_parsers = self._parser.add_subparsers()
+
+        create = component_sub_parsers.add_parser(
+            "create",
+            parents=[common_parser],
+            help="Creates component folder for the specified component if it does not exist. "
+            "If the component folder exists, leave it unchanged",
+        )
+
+        create.add_argument(
+            "-eo",
+            "--exist-ok",
+            action="store_true",
+            help="Creates configuration only if there isn't an existing one",
+        )
+
+        create.set_defaults(func=self.create)
+
+    def _get_component_instance(self, path: str, component: str):
+        """Gets component"""
+        if component.lower() == "node":
+            config_node = importlib.import_module("fedbiomed.node.config")
+            _component = config_node.node_component
+        elif component.lower() == "researcher":
+            os.environ["FBM_RESEARCHER_COMPONENT_ROOT"] = path
+            config_researcher = importlib.import_module(
+                "fedbiomed.researcher.config"
+            )
+            _component = config_researcher.researcher_component
+        else:
+            print(f"Undefined component type {component}")
+            sys.exit(101)
+
+        return _component
+
+    def create(self, args):
+        """CLI Handler for creating configuration file and assets for given component
+        """
+        if not args.path:
+            if args.component.lower() == "researcher":
+                component_path = os.path.join(os.getcwd(), DEFAULT_RESEARCHER_NAME)
+            else:
+                component_path = os.path.join(os.getcwd(), DEFAULT_NODE_NAME)
+        else:
+            component_path = args.path
+
+        # Researcher specific case ----------------------------------------------------
+        # This is a special case since researcher import
+        if args.component is None:
+            CommonCLI.error("Error: bad command line syntax")
+        if args.component.lower() == "researcher":
+            if DEFAULT_RESEARCHER_NAME in component_path and \
+                os.path.isdir(component_path) and \
+                not docker_special_case(component_path):
+                if not args.exist_ok:
+                    CommonCLI.error(
+                        f"Default component is already existing. In the directory {component_path} "
+                        "please remove existing one to re-initiate"
+                    )
+                    sys.exit(1)
+                else:
+                    CommonCLI.success(
+                        "Component is already existing. Using existing component."
+                    )
+                    sys.exit(0)
+            else:
+                self._get_component_instance(component_path, args.component)
+                return
+        else:
+            component = self._get_component_instance(component_path, args.component)
+            # Overwrite force configuration file
+            if component.is_component_existing(component_path):
+                if not args.exist_ok:
+                    CommonCLI.error(
+                        f"Component is already existing in the directory `{component_path}`. To ignore "
+                       "this error please execute component creation using `--exist-ok`"
+                )
+                else:
+                    CommonCLI.success(
+                        "Component is already exsiting. Using existing component."
+                    )
+                    return
+
+            component.initiate(component_path)
+
+        CommonCLI.success(f"Component has been initialized in {component_path}")
+
 
 
 cli = CommonCLI()
 cli.initialize_optional()
 
+# Initialize configuration parser
+configuration_parser = ComponentParser(cli.subparsers)
+configuration_parser.initialize()
 
 # Add node and researcher options
 node_p = cli.subparsers.add_parser(

--- a/fedbiomed/cli.py
+++ b/fedbiomed/cli.py
@@ -118,12 +118,11 @@ class ComponentParser(CLIArgumentParser):
                         f"Default component is already existing. In the directory {component_path} "
                         "please remove existing one to re-initiate"
                     )
-                    sys.exit(1)
                 else:
                     CommonCLI.success(
                         "Component is already existing. Using existing component."
                     )
-                    sys.exit(0)
+                    return
             else:
                 self._get_component_instance(component_path, args.component)
                 return
@@ -138,7 +137,7 @@ class ComponentParser(CLIArgumentParser):
                 )
                 else:
                     CommonCLI.success(
-                        "Component is already exsiting. Using existing component."
+                        "Component is already existing. Using existing component."
                     )
                     return
 

--- a/fedbiomed/common/cli.py
+++ b/fedbiomed/common/cli.py
@@ -8,20 +8,17 @@ This module includes common CLI methods and parser extension
 """
 
 import argparse
-import importlib
 import os
 import sys
 from abc import ABC, abstractmethod
 from typing import Dict, List
 
 from fedbiomed.common.certificate_manager import CertificateManager
-from fedbiomed.common.config import Config, docker_special_case
+from fedbiomed.common.config import Config
 from fedbiomed.common.constants import (
     CONFIG_FOLDER_NAME,
     DB_FOLDER_NAME,
     ComponentType,
-    DEFAULT_NODE_NAME,
-    DEFAULT_RESEARCHER_NAME,
     __version__,
 )
 from fedbiomed.common.exceptions import FedbiomedError
@@ -39,15 +36,6 @@ YLW = "\033[1;33m"  # yellow
 GRN = "\033[1;32m"  # green
 NC = "\033[0m"  # no color
 BOLD = "\033[1m"
-
-
-class UniqueStore(argparse.Action):
-    """Argparse action for avoiding having several time the same optional
-      argument"""
-    def __call__(self, parser, namespace, values, option_string):
-        if getattr(namespace, self.dest, self.default) is not self.default:
-            parser.error(option_string + " appears several times.")
-        setattr(namespace, self.dest, values)
 
 
 class CLIArgumentParser:
@@ -134,132 +122,6 @@ class ComponentDirectoryAction(ABC, argparse.Action):
         logger.setLevel("DEBUG")
 
 
-class ComponentParser(CLIArgumentParser):
-    """Instantiates configuration parser"""
-
-    def initialize(self):
-        """Initializes argument parser for creating configuration file."""
-
-        self._parser = self._subparser.add_parser(
-            "component",
-            help="The helper for generating or updating component configuration files, see `configuration -h`"
-            " for more details",
-        )
-
-        self._parser.set_defaults(func=self.default)
-
-        # Common parser to register common arguments for create and refresh
-        common_parser = argparse.ArgumentParser(add_help=False)
-        common_parser.add_argument(
-            "-p",
-            "--path",
-            action=UniqueStore,
-            metavar="COMPONENT_PATH",
-            type=str,
-            nargs="?",
-            required=False,
-            help="Path to specificy where Fed-BioMed component will be intialized.",
-        )
-
-        common_parser.add_argument(
-            "-c",
-            "--component",
-            metavar="COMPONENT_TYPE[ NODE|RESEARCHER ]",
-            type=str,
-            nargs="?",
-            required=True,
-            help="Component type NODE or RESEARCHER",
-        )
-
-        # Create sub parser under `configuration` command
-        component_sub_parsers = self._parser.add_subparsers()
-
-        create = component_sub_parsers.add_parser(
-            "create",
-            parents=[common_parser],
-            help="Creates component folder for the specified component if it does not exist. "
-            "If the component folder exists, leave it unchanged",
-        )
-
-        create.add_argument(
-            "-eo",
-            "--exist-ok",
-            action="store_true",
-            help="Creates configuration only if there isn't an existing one",
-        )
-
-        create.set_defaults(func=self.create)
-
-    def _get_component_instance(self, path: str, component: str):
-        """Gets component"""
-        if component.lower() == "node":
-            config_node = importlib.import_module("fedbiomed.node.config")
-            _component = config_node.node_component
-        elif component.lower() == "researcher":
-            os.environ["FBM_RESEARCHER_COMPONENT_ROOT"] = path
-            config_researcher = importlib.import_module(
-                "fedbiomed.researcher.config"
-            )
-            _component = config_researcher.researcher_component
-        else:
-            print(f"Undefined component type {component}")
-            sys.exit(101)
-        
-        return _component
-
-    def create(self, args):
-        """CLI Handler for creating configuration file and assets for given component
-        """
-        if not args.path:
-            if args.component.lower() == "researcher":
-                component_path = os.path.join(os.getcwd(), DEFAULT_RESEARCHER_NAME)
-            else:
-                component_path = os.path.join(os.getcwd(), DEFAULT_NODE_NAME)
-        else:
-            component_path = args.path
-
-        # Researcher specific case ----------------------------------------------------
-        # This is a special case since researcher import
-        if args.component is None:
-            CommonCLI.error("Error: bad command line syntax")
-        if args.component.lower() == "researcher":
-            if DEFAULT_RESEARCHER_NAME in component_path and \
-                os.path.isdir(component_path) and \
-                not docker_special_case(component_path):
-                if not args.exist_ok:
-                    CommonCLI.error(
-                        f"Default component is already existing. In the directory {component_path} "
-                        "please remove existing one to re-initiate"
-                    )
-                    sys.exit(1)
-                else:
-                    CommonCLI.success(
-                        "Component is already existing. Using existing component."
-                    )
-                    sys.exit(0)
-            else:
-                self._get_component_instance(component_path, args.component)
-                return
-        else:
-            component = self._get_component_instance(component_path, args.component)
-            # Overwrite force configuration file
-            if component.is_component_existing(component_path):
-                if not args.exist_ok:
-                    CommonCLI.error(
-                        f"Component is already existing in the directory `{component_path}`. To ignore "
-                       "this error please execute component creation using `--exist-ok`"
-                )
-                else:
-                    CommonCLI.success(
-                        "Component is already exsiting. Using existing component."
-                    )
-                    return
-
-            component.initiate(component_path)
-
-        CommonCLI.success(f"Component has been initialized in {component_path}")
-
-
 class CommonCLI:
 
     _arg_parsers_classes: List[type] = []
@@ -276,9 +138,6 @@ class CommonCLI:
         self._certificate_manager: CertificateManager = CertificateManager()
         self._description: str = ""
         self._args = None
-
-        # Initialize configuration parser
-        self.configuration_parser = ComponentParser(self._subparsers)
 
     @property
     def parser(self) -> argparse.ArgumentParser:
@@ -367,7 +226,6 @@ class CommonCLI:
         is not executed.
         """
 
-        self.configuration_parser.initialize()
         self.initialize_magic_dev_environment_parsers()
         self.initialize_version()
 

--- a/fedbiomed/common/config.py
+++ b/fedbiomed/common/config.py
@@ -113,7 +113,7 @@ class Config(metaclass=ABCMeta):
     def read(self) -> bool:
         """Reads configuration file that is already existing in given path
 
-        Raises verision compatibility error
+        Raises version compatibility error
         """
         self._cfg.read(self.config_path)
 

--- a/tests/test_common_cli.py
+++ b/tests/test_common_cli.py
@@ -1,63 +1,11 @@
-import argparse
 import shutil
 import sys
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
-from fedbiomed.common.cli import CommonCLI, ComponentParser
+from fedbiomed.common.cli import CommonCLI
 from fedbiomed.common.exceptions import FedbiomedError
-
-
-class TestComponentParser(unittest.TestCase):
-
-    def setUp(self):
-
-        self.main_parser = argparse.ArgumentParser()
-        self.parser = self.main_parser.add_subparsers()
-        self.conf_parser = ComponentParser(subparser=self.parser)
-        self.conf_parser.initialize()
-
-        self.tem = tempfile.TemporaryDirectory()
-
-
-
-    def tearDown(self):
-        self.tem.cleanup()
-        pass
-
-    def test_01_component_parser_initialize(self):
-        """Tests argument initialization"""
-        self.assertTrue("component" in self.conf_parser._subparser.choices)
-        self.assertTrue(
-            "create"
-            in self.conf_parser._subparser.choices["component"]
-            ._subparsers._group_actions[0]
-            .choices
-        )
-        self.assertEqual(
-            self.conf_parser._subparser.choices["component"]
-            ._subparsers._group_actions[0]
-            .choices["create"]
-            ._defaults["func"]
-            .__func__.__name__,
-            "create",
-        )
-
-    def test_02_component_parser_create(
-        self,
-    ):
-        args = self.main_parser.parse_args(
-            ["component", "create", "--path", self.tem.name, "--component", "NODE", "-eo"]
-        )
-        self.conf_parser.create(args)
-        self.tem.cleanup()
-
-
-        args = self.main_parser.parse_args(
-            ["component", "create", "--path", self.tem.name, "--component", "RESEARCHER", "-eo"]
-        )
-        self.conf_parser.create(args)
 
 
 class TestCommonCLI(unittest.TestCase):
@@ -106,7 +54,6 @@ class TestCommonCLI(unittest.TestCase):
         self.cli.initialize_optional()
 
         self.assertTrue("certificate-dev-setup" in self.cli._subparsers.choices)
-        self.assertTrue("component" in self.cli._subparsers.choices)
 
     def test_04_common_cli_initialize_magic_dev_environment_parsers(self):
         self.cli.initialize_magic_dev_environment_parsers()

--- a/tests/test_root_cli.py
+++ b/tests/test_root_cli.py
@@ -1,0 +1,61 @@
+import argparse
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from fedbiomed.cli import ComponentParser
+
+
+class TestComponentParser(unittest.TestCase):
+
+    def setUp(self):
+
+        self.main_parser = argparse.ArgumentParser()
+        self.parser = self.main_parser.add_subparsers()
+        self.conf_parser = ComponentParser(subparser=self.parser)
+        self.conf_parser.initialize()
+
+        self.tem = tempfile.TemporaryDirectory()
+
+
+
+    def tearDown(self):
+        self.tem.cleanup()
+        pass
+
+    def test_01_component_parser_initialize(self):
+        """Tests argument initialization"""
+        self.assertTrue("component" in self.conf_parser._subparser.choices)
+        self.assertTrue(
+            "create"
+            in self.conf_parser._subparser.choices["component"]
+            ._subparsers._group_actions[0]
+            .choices
+        )
+        self.assertEqual(
+            self.conf_parser._subparser.choices["component"]
+            ._subparsers._group_actions[0]
+            .choices["create"]
+            ._defaults["func"]
+            .__func__.__name__,
+            "create",
+        )
+
+    def test_02_component_parser_create(
+        self,
+    ):
+        args = self.main_parser.parse_args(
+            ["component", "create", "--path", self.tem.name, "--component", "NODE", "-eo"]
+        )
+        self.conf_parser.create(args)
+        self.tem.cleanup()
+
+
+        args = self.main_parser.parse_args(
+            ["component", "create", "--path", self.tem.name, "--component", "RESEARCHER", "-eo"]
+        )
+        self.conf_parser.create(args)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_root_cli.py
+++ b/tests/test_root_cli.py
@@ -17,11 +17,19 @@ class TestComponentParser(unittest.TestCase):
         self.conf_parser.initialize()
 
         self.tem = tempfile.TemporaryDirectory()
+        self.initial_dir = os.getcwd()
         os.chdir(self.tem.name)
 
     def tearDown(self):
+        os.chdir(self.initial_dir)
+        # forces the removal of config files for Nodes and Researchers
+        if 'fedbiomed.researcher.config' in sys.modules:
+            sys.modules.pop('fedbiomed.researcher.config')
+
+        if 'fedbiomed.node.config' in sys.modules:
+            sys.modules.pop('fedbiomed.node.config')
         self.tem.cleanup()
-        pass
+
 
     def test_01_component_parser_initialize(self):
         """Tests argument initialization"""
@@ -101,6 +109,7 @@ class TestComponentParser(unittest.TestCase):
             self.conf_parser._get_component_instance('any_path', 'bad_component_type')
 
         self.tem.cleanup()
+
         sys.modules.pop('fedbiomed.researcher.config')
 
 


### PR DESCRIPTION
**PR description**

- removes dependencies to `fedbiomed.node` and `fedbiomed.researcher` existing in `fedbiomed.common.cli` (last remaining task in #1233 ?). New version written for v6 (replaces PR #1257 which was written for v5.4)
- add more unit tests to the `fedbiomed configuration` parser code + fixes several bugs found in this subparser

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`