### PR TITLE
Node container automatically configures and starts node component

### DIFF
--- a/docs/user-guide/deployment/deployment-vpn-node2.md
+++ b/docs/user-guide/deployment/deployment-vpn-node2.md
@@ -54,6 +54,12 @@ For each node, choose a **unique** node tag (eg: *NODE2TAG* in this example) tha
     [user@node $] cp /tmp/config2.env ./node2/run_mounts/config/config.env
     ```
 
+* **optionally** force the use of secure aggregation by the node (node will refuse to train without the use of secure aggregation):
+
+    ```bash
+    [user@node $] export FBM_SECURITY_FORCE_SECURE_AGGREGATION=True
+    ```
+
 * start `node2` container
 
     ```bash
@@ -91,18 +97,6 @@ For each node, choose a **unique** node tag (eg: *NODE2TAG* in this example) tha
 
     `node2` container is now ready to be used.
 
-* **optionally** force the use of secure aggregation by the node (node will refuse to train without the use of secure aggregation):
-
-    ```bash
-    [user@node $] export FBM_SECURITY_FORCE_SECURE_AGGREGATION=True
-    ```
-
-* do initial node configuration
-
-    ```bash
-    [user@node $] docker compose exec -u $(id -u) node2 bash -ci 'export FBM_SECURITY_FORCE_SECURE_AGGREGATION='${FBM_SECURITY_FORCE_SECURE_AGGREGATION}' && export FBM_RESEARCHER_IP=10.222.0.2 && export FBM_RESEARCHER_PORT=50051 && FBM_SECURITY_TRAINING_PLAN_APPROVAL=True FBM_SECURITY_ALLOW_DEFAULT_TRAINING_PLANS=True fedbiomed component create --component NODE --path /fbm-node --exist-ok'
-    ```
-
 Optionally launch the node GUI :
 
 * start `gui2` container
@@ -137,7 +131,13 @@ Setup the node by sharing datasets and by launching the Fed-BioMed node:
 
 * if node GUI is launched, it can be used to share datasets. On the node side machine, connect to `http://localhost:8444`
 
-* connect to the `node2` container and launch commands, for example :
+* view the node component logs
+
+```bash
+[user@node $] docker compose logs node2
+```
+
+* **optionally** connect to the `node2` container and launch commands, instead of using the GUI, for example :
 
     * connect to the container
 
@@ -145,12 +145,14 @@ Setup the node by sharing datasets and by launching the Fed-BioMed node:
         [user@node $] cd ${FEDBIOMED_DIR}/envs/vpn/docker
         [user@node $] docker compose exec -u $(id -u) node2 bash
         ```
-
-    * start the Fed-BioMed node, for example in background:
+    * re-start the Fed-BioMed node, for example in background:
 
         ```bash
-        [user@node2-container $] nohup fedbiomed node start >/fbm-node/fedbiomed_node.out &
+        [user@node2-container $] kill $(ps auxwwww | grep -E 'python.*fedbiomed node start' | grep -Ev grep | awk '{ print $2}')
+        [user@node2-container $] nohup fedbiomed node start $(cat /fbm-node/FBM_NODE_OPTIONS) >/fbm-node/fedbiomed_node.out &
         ```
+
+        Please note that in that case, the node component output does not appear anymore in `docker compose logs node`
 
     * share one or more datasets, for example a MNIST dataset or an interactively defined dataset (can also be done via the GUI):
 

--- a/docs/user-guide/deployment/deployment-vpn.md
+++ b/docs/user-guide/deployment/deployment-vpn.md
@@ -200,6 +200,12 @@ For each node, choose a **unique** node tag (eg: *NODETAG* in this example) that
     [user@node $] cp /tmp/config.env ./node/run_mounts/config/config.env
     ```
 
+* **optionally** force the use of secure aggregation by the node (node will refuse to train without the use of secure aggregation):
+
+    ```bash
+    [user@node $] export FBM_SECURITY_FORCE_SECURE_AGGREGATION=True
+    ```
+
 * start `node` container
 
     ```bash
@@ -237,17 +243,6 @@ For each node, choose a **unique** node tag (eg: *NODETAG* in this example) that
 
     `node` container is now ready to be used.
 
-* **optionally** force the use of secure aggregation by the node (node will refuse to train without the use of secure aggregation):
-
-    ```bash
-    [user@node $] export FBM_SECURITY_FORCE_SECURE_AGGREGATION=True
-    ```
-
-* do initial node configuration. Following command will create node component located `/fbm-node/` directory of the container. This directory will be mounted in `{FEDBIOMED_DIR}/envs/vpn/docker/node/run_mounts` directory of the host.
-
-    ```bash
-    [user@node $] docker compose exec -u $(id -u) node bash -ci 'export FBM_SECURITY_FORCE_SECURE_AGGREGATION='${FBM_SECURITY_FORCE_SECURE_AGGREGATION}'&& export FBM_SECURITY_SECAGG_INSECURE_VALIDATION=false && export FBM_RESEARCHER_IP=10.222.0.2 && export FBM_RESEARCHER_PORT=50051 && export PYTHONPATH=/fedbiomed && FBM_SECURITY_TRAINING_PLAN_APPROVAL=True FBM_SECURITY_ALLOW_DEFAULT_TRAINING_PLANS=True fedbiomed component create --component NODE --exist-ok'
-    ```
 
 Optionally launch the node GUI :
 
@@ -313,11 +308,17 @@ This part of the tutorial is optionally executed on some nodes, after deploying 
 
 This part is executed at least once on each node, after deploying the node side containers.
 
-Setup the node by sharing datasets and by launching the Fed-BioMed node. The commands below will use default Fed-BioMed node directory which is located `/fbm-node` inside the container.
+Setup the node by sharing datasets. The commands below will use default Fed-BioMed node directory which is located `/fbm-node` inside the container.
 
 * if node GUI is launched, it can be used to share datasets. On the node side machine, connect to `https://localhost:8443` (or `https://<host_name_and_domain>:8443` if connection from distant machine is authorized)
 
-* connect to the `node` container and launch commands, for example :
+* view the node component logs
+
+```bash
+[user@node $] docker compose logs node
+```
+
+* **optionally** connect to the `node` container and launch commands, instead of using the GUI, for example :
 
     * connect to the container
 
@@ -326,11 +327,14 @@ Setup the node by sharing datasets and by launching the Fed-BioMed node. The com
         [user@node $] docker compose exec -u $(id -u) node bash
         ```
 
-    * start the Fed-BioMed node, for example in background:
+    * re-start the Fed-BioMed node, for example in background:
 
         ```bash
-        [user@node-container $] nohup fedbiomed node start >/fbm-node/fedbiomed_node.out &
+        [user@node-container $] kill $(ps auxwwww | grep -E 'python.*fedbiomed node start' | grep -Ev grep | awk '{ print $2}')
+        [user@node-container $] nohup fedbiomed node start $(cat /fbm-node/FBM_NODE_OPTIONS) >/fbm-node/fedbiomed_node.out &
         ```
+
+        Please note that in that case, the node component output does not appear anymore in `docker compose logs node`
 
     * share one or more datasets, for example a MNIST dataset or an interactively defined dataset (can also be done via the GUI):
 

--- a/envs/vpn/docker/docker-compose.yml
+++ b/envs/vpn/docker/docker-compose.yml
@@ -20,6 +20,8 @@ x-node:
     - CONTAINER_GID
     - CONTAINER_USER
     - CONTAINER_GROUP
+    - FBM_NODE_OPTIONS
+    - FBM_SECURITY_FORCE_SECURE_AGGREGATION
   cap_add:
     - net_admin
     - sys_module
@@ -45,6 +47,8 @@ x-node2:
     - CONTAINER_GID
     - CONTAINER_USER
     - CONTAINER_GROUP
+    - FBM_NODE_OPTIONS
+    - FBM_SECURITY_FORCE_SECURE_AGGREGATION
   cap_add:
     - net_admin
     - sys_module

--- a/envs/vpn/docker/docker-compose_run_node.yml
+++ b/envs/vpn/docker/docker-compose_run_node.yml
@@ -18,6 +18,8 @@ x-node:
     - CONTAINER_GID
     - CONTAINER_USER
     - CONTAINER_GROUP
+    - FBM_NODE_OPTIONS
+    - FBM_SECURITY_FORCE_SECURE_AGGREGATION
   cap_add:
     - net_admin
     - sys_module
@@ -40,6 +42,8 @@ x-node2:
     - CONTAINER_GID
     - CONTAINER_USER
     - CONTAINER_GROUP
+    - FBM_NODE_OPTIONS
+    - FBM_SECURITY_FORCE_SECURE_AGGREGATION
   cap_add:
     - net_admin
     - sys_module

--- a/envs/vpn/docker/node/build_files/entrypoint.bash
+++ b/envs/vpn/docker/node/build_files/entrypoint.bash
@@ -9,7 +9,6 @@ source /entrypoint_functions.bash
 
 # read config.env
 source ~/bashrc_entrypoint
-echo here
 check_vpn_environ
 
 init_misc_environ
@@ -27,7 +26,21 @@ fi
 
 trap finish TERM INT QUIT
 
-# TODO: refactor to launch gRPC communications node here ?
+
+# Create node configuration if not existing yet
+su -c "export FBM_SECURITY_FORCE_SECURE_AGGREGATION=\"${FBM_SECURITY_FORCE_SECURE_AGGREGATION}\" && \
+      export FBM_SECURITY_SECAGG_INSECURE_VALIDATION=false && export FBM_RESEARCHER_IP=10.222.0.2 && \
+      export FBM_RESEARCHER_PORT=50051 && export PYTHONPATH=/fedbiomed && \
+      FBM_SECURITY_TRAINING_PLAN_APPROVAL=True FBM_SECURITY_ALLOW_DEFAULT_TRAINING_PLANS=True \
+      fedbiomed component create --component NODE --exist-ok" $CONTAINER_USER
+
+# Overwrite node options file if re-launching container
+#   eg FBM_NODE_OPTIONS="--gpu-only" can be used for starting node forcing GPU usage
+su -c "echo \"$FBM_NODE_OPTIONS\" >/fbm-node/FBM_NODE_OPTIONS" $CONTAINER_USER
+
+# Launch node using node options
+$SETUSER fedbiomed node start $FBM_NODE_OPTIONS &
+
 
 sleep infinity &
 


### PR DESCRIPTION
**PR description**

Implements #1296 ( which is partial implementation of #1149 #266 ) : node container automatically configures and starts node component

- modify node container startup scripts: tested with `node`, `node2` and also with GPU
- update deployment documentaton, README, and VPN test github action

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`