### PR TITLE
misc fixes for VPN+containers mode

### DIFF
--- a/envs/vpn/README.md
+++ b/envs/vpn/README.md
@@ -153,7 +153,7 @@ On the build machine
 ```bash
 [user@build $] cd ./envs/vpn/docker
 # if needed, clean the configurations in ./node/run_mounts before
-[user@build $] tar cvzf /tmp/vpn-node-files.tar.gz ./docker compose_run_node.yml ./node/run_mounts
+[user@build $] tar cvzf /tmp/vpn-node-files.tar.gz ./docker-compose_run_node.yml ./node/run_mounts
 ```
 
 On the node machine
@@ -239,8 +239,8 @@ Run this for all launches of the container :
 [user@node $] docker compose exec -u $(id -u) $NODE bash
 # example : add MNIST dataset using persistent (mounted) /fbm-node/data
 [user@node-container $] fedbiomed node dataset add -m /fbm-node/data
-# - start with training plan approval enabled and default training plans allowed
-[user@node-container $] FBM_SECURITY_TRAINING_PLAN_APPROVAL=True FBM_SECURITY_ALLOW_DEFAULT_TRAINING_PLANS=True fedbiomed node start --gpu
+# - start with training plan approval enabled and default training plans not allowed
+[user@node-container $] FBM_SECURITY_TRAINING_PLAN_APPROVAL=True FBM_SECURITY_ALLOW_DEFAULT_TRAINING_PLANS=False fedbiomed node start --gpu
 # alternative: re-start the node in background
 # [user@node-container $] nohup fedbiomed node start >./fedbiomed_node.out &
 ```
@@ -318,7 +318,13 @@ On the build machine
 ```bash
 [user@build $] docker image save fedbiomed/vpn-gui | gzip >/tmp/vpn-gui-image.tar.gz
 ```
-* we assume files needed for running container were already installed (see node documentation)
+* we assume files needed for running `node` container were already installed (see node documentation)
+* save additional files needed for running `gui` container
+```bash
+[user@build $] cd ./envs/vpn/docker
+# if needed, clean the configurations in ./node/run_mounts before
+[user@build $] tar cvzf /tmp/vpn-gui-files.tar.gz ./gui/run_mounts
+```
 
 On the node and gui machine
 
@@ -327,7 +333,13 @@ On the node and gui machine
 [user@node $] docker image load </tmp/vpn-gui-image.tar.gz
 ```
 * change to directory you want to use as base directory for running this container
-* we assume files and data needed for running container were already installed (see node documentation)
+* we assume files and data needed for running `node` container were already installed (see node documentation)
+* load additional files needed for running `gui` container
+```bash
+[user@node $] mkdir -p ./envs/vpn/docker
+[user@node $] cd ./envs/vpn/docker
+[user@node $] tar xvzf /tmp/vpn-gui-files.tar.gz
+```
 
 Then follow the common instructions for gui (below).
 

--- a/envs/vpn/docker/node/build_files/entrypoint.bash
+++ b/envs/vpn/docker/node/build_files/entrypoint.bash
@@ -31,7 +31,7 @@ trap finish TERM INT QUIT
 su -c "export FBM_SECURITY_FORCE_SECURE_AGGREGATION=\"${FBM_SECURITY_FORCE_SECURE_AGGREGATION}\" && \
       export FBM_SECURITY_SECAGG_INSECURE_VALIDATION=false && export FBM_RESEARCHER_IP=10.222.0.2 && \
       export FBM_RESEARCHER_PORT=50051 && export PYTHONPATH=/fedbiomed && \
-      FBM_SECURITY_TRAINING_PLAN_APPROVAL=True FBM_SECURITY_ALLOW_DEFAULT_TRAINING_PLANS=True \
+      FBM_SECURITY_TRAINING_PLAN_APPROVAL=True FBM_SECURITY_ALLOW_DEFAULT_TRAINING_PLANS=False \
       fedbiomed component create --component NODE --exist-ok" $CONTAINER_USER
 
 # Overwrite node options file if re-launching container


### PR DESCRIPTION
in containers

**PR description**

Misc fixes for VPN+containers mode:
- regression: no default training plan should now be allowed in container mode
- VPN documentation typos

No associated issue.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`