### PR TITLE
Solves active tab color glitch in add dataset page

### DIFF
--- a/fedbiomed_gui/ui/src/App.js
+++ b/fedbiomed_gui/ui/src/App.js
@@ -5,7 +5,8 @@ import { EuiProvider } from '@elastic/eui';
 import {
   BrowserRouter as Router,
   Routes,
-  Route
+  Route,
+  Navigate,
 } from "react-router-dom";
 
 import Home from './pages/Home'
@@ -60,7 +61,8 @@ function App(props) {
                   <Route path="/datasets/" element={<Datasets/>} />
                   <Route path="/datasets/preview/:dataset_id" element={<DatasetPreview />} />
                   <Route path="/datasets/add-dataset/" element={<AddDataset/>} >
-                    <Route index element={<CommonStandards/>} />
+                    <Route index element={<Navigate to="common-standards" replace />} />
+                    <Route path="common-standards" element={<CommonStandards/>} />
                     <Route path="medical-folder-dataset" element={<MedicalFolderDataset/>} />
                   </Route>
                   <Route

--- a/fedbiomed_gui/ui/src/pages/datasets/AddDataset.js
+++ b/fedbiomed_gui/ui/src/pages/datasets/AddDataset.js
@@ -9,7 +9,7 @@ const AddDataset = (props) => {
     return (
         <React.Fragment>
             <Tab
-                tabs={[{name: "Common Standards", to:'/datasets/add-dataset/'}, {name : "Medical Folder Dataset", to:'/datasets/add-dataset/medical-folder-dataset/'}]}
+                tabs={[{name: "Common Standards", to:'/datasets/add-dataset/common-standards'}, {name : "Medical Folder Dataset", to:'/datasets/add-dataset/medical-folder-dataset/'}]}
             />
             <div className={styles.main}>
                 <Outlet/>


### PR DESCRIPTION
**PR description**

This PR solves the issue of active tab color tab in Add Dataset page. `Common Standards` tab had always active color background even `Medical Folder Dataset` tab selected.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`