### PR TITLE
Exception for empty list of nodes before starting a training job.

### DIFF
--- a/fedbiomed/researcher/federated_workflows/_experiment.py
+++ b/fedbiomed/researcher/federated_workflows/_experiment.py
@@ -737,12 +737,18 @@ class Experiment(TrainingPlanWorkflow):
         if missing:
             raise FedbiomedExperimentError(ErrorNumbers.FB411.value + ': missing one or several object needed for'
                                            ' starting the `Experiment`. Details:\n' + missing)
+        
         # Sample nodes for training
-
         training_nodes = self._node_selection_strategy.sample_nodes(
             from_nodes=self.filtered_federation_nodes(),
             round_i=self._round_current
         )
+        if not training_nodes:
+            raise FedbiomedExperimentError(
+                "Empty list of nodes for training: no nodes replied to original "
+                "`search_request` or sampling strategy returned an empty list."
+            )
+
         # Setup Secure Aggregation (it's a noop if not active)
         secagg_arguments = self.secagg_setup(training_nodes)
 

--- a/fedbiomed/researcher/federated_workflows/_experiment.py
+++ b/fedbiomed/researcher/federated_workflows/_experiment.py
@@ -743,7 +743,7 @@ class Experiment(TrainingPlanWorkflow):
             from_nodes=self.filtered_federation_nodes(),
             round_i=self._round_current
         )
-        if not training_nodes:
+        if len(training_nodes) == 0:
             raise FedbiomedExperimentError(
                 "Empty list of nodes for training: no nodes replied to original "
                 "`search_request` or sampling strategy returned an empty list."


### PR DESCRIPTION
**PR description**

This closes #1127. 

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`