### PR TITLE
Prevent creation a unused new experiment folder when load breakpoint

### DIFF
--- a/fedbiomed/researcher/federated_workflows/_federated_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_workflow.py
@@ -837,13 +837,15 @@ class FederatedWorkflow(ABC):
         bkpt_fds = saved_state.get('training_data')
         bkpt_fds = FederatedDataSet(bkpt_fds)
 
+        # retrieve experimentation folder
+        exp_folder = saved_state.get('experimentation_folder')
+
         # initializing experiment
-        loaded_exp = cls()
+        loaded_exp = cls(experimentation_folder=exp_folder)
         loaded_exp._experiment_id = saved_state.get('id')
         loaded_exp.set_training_data(bkpt_fds)
         loaded_exp._tags = saved_state.get('tags')
         loaded_exp.set_nodes(saved_state.get('nodes'))
-        loaded_exp.set_experimentation_folder(saved_state.get('experimentation_folder'))
 
         secagg = SecureAggregation.load_state_breakpoint(saved_state.get('secagg'))
         loaded_exp.set_secagg(secagg)


### PR DESCRIPTION
**PR description**

Avoid the creation of a new empty and unused experiment folder when load_breakpoint is used. See detailed discussion in #1181 

Closes #1181 

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`