### PR TITLE
Feature/1086 pass fail replies to strategy

### DIFF
--- a/fedbiomed/researcher/federated_workflows/jobs/_training_job.py
+++ b/fedbiomed/researcher/federated_workflows/jobs/_training_job.py
@@ -93,7 +93,7 @@ class TrainingJob(Job):
 
         # Loops over replies
         for node_id, reply in replies.items():
-            node_reply = reply.get_dict().copy()
+            node_reply = reply.get_dict()
 
             if not reply.success:
                 self._nodes.remove(reply.node_id)  # remove the faulty node from the list

--- a/fedbiomed/researcher/strategies/default_strategy.py
+++ b/fedbiomed/researcher/strategies/default_strategy.py
@@ -89,18 +89,15 @@ class DefaultStrategy(Strategy):
                 - if a Node has not sent `sample_size` value in the TrainingReply, making it
                 impossible to compute aggregation weights.
         """
-        if not self._sampling_node_history.get(round_i):
-            raise FedbiomedStrategyError(ErrorNumbers.FB407.value)
-        
         missing_node_replies = []
         for node in self._sampling_node_history.get(round_i):
             if node not in training_replies:
                 missing_node_replies.append(node)
-                logger.error(ErrorNumbers.FB408.value + " (node = " + node + ")")
+                logger.error(ErrorNumbers.FB409.value + " (node = " + node + ")")
         if missing_node_replies:
             raise FedbiomedStrategyError(
                 ErrorNumbers.FB408.value
-                + f": {len(missing_node_replies)} missing nodes replies for round {round_i}"
+                + f": {len(missing_node_replies)} missing training replies for round {round_i}"
             )
 
         # check that all nodes that answer could successfully train
@@ -130,7 +127,9 @@ class DefaultStrategy(Strategy):
                 self._success_node_history[round_i].append(tr["node_id"])
             else:
                 all_success = False
-                logger.error(f"{ErrorNumbers.FB409.value} (node = {tr['node_id']} )")
+                msg = tr.get("msg") or ""
+                logger.error("Unsuccessful training reply{} (node = {} )".format(
+                    f": {msg}" if msg else "", tr["node_id"]))
 
         if not all_success:
             raise FedbiomedStrategyError(ErrorNumbers.FB402.value)

--- a/fedbiomed/researcher/strategies/default_strategy.py
+++ b/fedbiomed/researcher/strategies/default_strategy.py
@@ -13,17 +13,17 @@ from typing import Dict, List, Tuple, Union
 from fedbiomed.common.constants import ErrorNumbers
 from fedbiomed.common.exceptions import FedbiomedStrategyError
 from fedbiomed.common.logger import logger
-from fedbiomed.researcher.datasets import FederatedDataSet
+from fedbiomed.common.message import TrainReply
 from fedbiomed.researcher.strategies import Strategy
 
 
 class DefaultStrategy(Strategy):
     """
     Default strategy to be used when sampling/selecting nodes
-    and checking whether nodes have responded or not
+    and to check whether nodes have responded or not
 
     Strategy is:
-    - select all node for each round
+    - select all nodes for each round
     - raise an error if one node does not answer
     - raise an error is one node returns an error
     """
@@ -46,7 +46,7 @@ class DefaultStrategy(Strategy):
 
     def refine(
             self,
-            training_replies: Dict,
+            training_replies: Dict[str, TrainReply],
             round_i: int
     ) -> Tuple[Dict[str, Dict[str, Union['torch.Tensor', 'numpy.ndarray']]],
                Dict[str, float],
@@ -56,21 +56,10 @@ class DefaultStrategy(Strategy):
         The method where node selection is completed by extracting parameters and length from the training replies
 
         Args:
-            training_replies: is a list of elements of type
-                 Response( { 'success': m['success'],
-                             'msg': m['msg'],
-                             'dataset_id': m['dataset_id'],
-                             'node_id': m['node_id'],
-                             'params_path': params_path,
-                             'params': params,
-                             'sample_size': sample_size
-                             } )
-            round_i: Current round of experiment
+            training_replies: Dictionary of replies from nodes.
+            round_i: Current round of experiment.
 
         Returns:
-            weights: Proportions list, each element of this list represents a dictionary with
-                its only key as the node_id and its value the proportion of lines the node has
-                with respect to the whole,
             model_params: list with each element representing a dictionary. Its only key represents
                 the node_id and the corresponding value is a dictionary containing list of weight
                 matrices of every node : [{"n1":{"layer1":m1,"layer2":m2},{"layer3":"m3"}},{"n2":
@@ -79,15 +68,18 @@ class DefaultStrategy(Strategy):
                 The correction is updated every round. The computation of correction states at round
                 i is dependant to client states and correction states of round i-1. Since
                 training_replies    can potentially order the node replies differently from round to
-                round, the bridge between all these parameters is represented by the node_id.
+                round, the bridge between all these parameters is represented by the node_id
+            weights: Proportions list, each element of this list represents a dictionary with
+                its only key as the node_id and its value the proportion of lines the node has
+                with respect to the whole
             total_rows: sum of number of samples used by all nodes
             encryption_factors: encryption factors from the participating nodes
 
         Raises:
-            FedbiomedStrategyError: - Miss-matched in answered nodes and existing nodes
-                - If not all nodes successfully completes training
-                - if a Node has not sent `sample_size` value in the TrainingReply, making it
-                impossible to compute aggregation weights.
+            FedbiomedStrategyError: If any of the following occur:
+                - A node in the sampling list does not reply
+                - Not all nodes successfully complete training
+                - A successful reply does not include `sample_size` value.
         """
         missing_node_replies = []
         for node in self._sampling_node_history.get(round_i):

--- a/fedbiomed/researcher/strategies/default_strategy.py
+++ b/fedbiomed/researcher/strategies/default_strategy.py
@@ -112,7 +112,7 @@ class DefaultStrategy(Strategy):
                 model_params[tr["node_id"]] = tr["params"]
                 encryption_factors[tr["node_id"]] = tr.get("encryption_factor", None)
 
-                if tr["sample_size"] is None:
+                if tr.get("sample_size") is None:
                     # if a Node `sample_size` is None, we cannot compute the weights: in this case
                     # return an error
                     raise FedbiomedStrategyError(

--- a/fedbiomed/researcher/strategies/strategy.py
+++ b/fedbiomed/researcher/strategies/strategy.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Tuple, Union
 from fedbiomed.common.constants  import ErrorNumbers
 from fedbiomed.common.exceptions import FedbiomedStrategyError
 from fedbiomed.common.logger     import logger
+from fedbiomed.common.message import TrainReply
 
 from fedbiomed.researcher.datasets import FederatedDataSet
 
@@ -51,7 +52,7 @@ class Strategy:
 
     def refine(
             self,
-            training_replies: Dict,
+            training_replies: Dict[str, TrainReply],
             round_i: int
                ) -> Tuple[Dict[str, Dict[str, Union['torch.Tensor', 'numpy.ndarray']]],
                           Dict[str, float],
@@ -61,13 +62,7 @@ class Strategy:
         Abstract method that must be implemented by child class
 
         Args:
-            training_replies: is a list of elements of type
-                 Response( { 'success': m['success'],
-                             'msg': m['msg'],
-                             'dataset_id': m['dataset_id'],
-                             'node_id': m['node_id'],
-                             'params_path': params_path,
-                             'params': params } )
+            training_replies: Dictionary of replies from nodes
             round_i: Current round of experiment
 
         Raises:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -327,8 +327,9 @@ class TestJob(unittest.TestCase):
                             expected_replies.update({
                                 node_id: {
                                     **r.get_dict(),
-                                    **({'params_path': os.path.join(job._keep_files_dir,
-                                    f"params_{node_id}_{mock_uuid.return_value}.mpk")} if success_status[node_id] else {})
+                                    **({'params_path': os.path.join(
+                                        job._keep_files_dir, f"params_{node_id}_{mock_uuid.return_value}.mpk"
+                                    )} if success_status[node_id] else {})
                                 }
                             })
                     self.assertDictEqual(training_replies, expected_replies)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -323,11 +323,12 @@ class TestJob(unittest.TestCase):
                     # populate expected replies
                     expected_replies = {}
                     for node_id, r in self.federated_request_mock.replies.return_value.items():
-                        if not error_status[node_id] and success_status[node_id]:
+                        if not error_status[node_id]:
                             expected_replies.update({
                                 node_id: {
                                     **r.get_dict(),
-                                    'params_path': os.path.join(job._keep_files_dir, f"params_{node_id}_{mock_uuid.return_value}.mpk")
+                                    **({'params_path': os.path.join(job._keep_files_dir,
+                                    f"params_{node_id}_{mock_uuid.return_value}.mpk")} if success_status[node_id] else {})
                                 }
                             })
                     self.assertDictEqual(training_replies, expected_replies)

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,72 @@
+import pytest
+
+from fedbiomed.common.constants import ErrorNumbers
+from fedbiomed.common.exceptions import FedbiomedStrategyError
+from fedbiomed.researcher.strategies.default_strategy import DefaultStrategy
+
+
+@pytest.fixture
+def default_strategy():
+    return DefaultStrategy()
+
+def test_default_strategy_sample_nodes_returns_all(default_strategy):
+    nodes = ['node-1', 'node-2']
+    sampled = default_strategy.sample_nodes(nodes, 0)
+    assert sampled == nodes
+    assert default_strategy._sampling_node_history[0] == nodes
+
+def test_default_strategy_refine_successful_replies(default_strategy):
+    default_strategy._sampling_node_history[0] = ['node-1', 'node-2']
+    training_replies = {
+        'node-1': {
+            'success': True,
+            'node_id': 'node-1',
+            'params': {'w': [1]},
+            'sample_size': 100,
+            'encryption_factor': [0.5],
+        },
+        'node-2': {
+            'success': True,
+            'node_id': 'node-2',
+            'params': {'w': [2]},
+            'sample_size': 300,
+        },
+    }
+
+    model_params, weights, total_rows, encryption_factors = default_strategy.refine(training_replies, 0)
+    assert model_params == {'node-1': {'w': [1]}, 'node-2': {'w': [2]}}
+    assert weights == {'node-1': 0.25, 'node-2': 0.75}
+    assert total_rows == 400
+    assert encryption_factors == {'node-1': [0.5], 'node-2': None}
+
+def test_default_strategy_refine_missing_node_reply_raises(default_strategy):
+    default_strategy._sampling_node_history[0] = ['node-1', 'node-2']
+    training_replies = {
+        'node-1': {
+            'success': True,
+            'node_id': 'node-1',
+            'params': {'w': [1]},
+            'sample_size': 100,
+        }
+    }
+    with pytest.raises(FedbiomedStrategyError, match=ErrorNumbers.FB408.value):
+        default_strategy.refine(training_replies, 0)
+
+def test_default_strategy_refine_unsuccessful_node_reply_raises(default_strategy):
+    default_strategy._sampling_node_history[0] = ['node-1', 'node-2']
+    training_replies = {
+        'node-1': {
+            'success': True,
+            'node_id': 'node-1',
+            'params': {'w': [1]},
+            'sample_size': 100,
+        },
+        'node-2': {
+            'success': False,
+            'node_id': 'node-2',
+            'msg': 'Something happened',
+        },
+    }
+    with pytest.raises(FedbiomedStrategyError, match=ErrorNumbers.FB402.value):
+        default_strategy.refine(training_replies, 0)
+        

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -36,13 +36,12 @@ def test_default_strategy_02_refine_successful_replies(
     sample_training_replies,
 ):
     default_strategy._sampling_node_history[0] = ['node-1', 'node-2']
-    training_replies = sample_training_replies
     (
         model_params,
         weights,
         total_rows,
         encryption_factors
-    ) = default_strategy.refine(training_replies, 0)
+    ) = default_strategy.refine(sample_training_replies, 0)
     assert model_params == {'node-1': {'w': [1]}, 'node-2': {'w': [2]}}
     assert weights == {'node-1': 0.25, 'node-2': 0.75}
     assert total_rows == 400
@@ -65,7 +64,6 @@ def test_default_strategy_04_refine_successful_node_reply_missing_sample_size_ra
     default_strategy._sampling_node_history[0] = ['node-1', 'node-2']
     training_replies = sample_training_replies
     training_replies['node-2'].pop('sample_size')
-    print(training_replies)
     with pytest.raises(FedbiomedStrategyError, match=ErrorNumbers.FB402.value):
         default_strategy.refine(training_replies, 0)
 
@@ -76,7 +74,6 @@ def test_default_strategy_05_refine_successful_node_reply_sample_size_is_none_ra
     default_strategy._sampling_node_history[0] = ['node-1', 'node-2']
     training_replies = sample_training_replies
     training_replies['node-2']['sample_size'] = None
-    print(training_replies)
     with pytest.raises(FedbiomedStrategyError, match=ErrorNumbers.FB402.value):
         default_strategy.refine(training_replies, 0)
 
@@ -91,6 +88,5 @@ def test_default_strategy_06_refine_unsuccessful_node_reply_raises(
         'node_id': 'node-2',
         'msg': 'Error message',
     }
-    print(training_replies)
     with pytest.raises(FedbiomedStrategyError, match=ErrorNumbers.FB402.value):
         default_strategy.refine(training_replies, 0)

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,23 +1,15 @@
 import pytest
-
 from fedbiomed.common.constants import ErrorNumbers
 from fedbiomed.common.exceptions import FedbiomedStrategyError
 from fedbiomed.researcher.strategies.default_strategy import DefaultStrategy
-
 
 @pytest.fixture
 def default_strategy():
     return DefaultStrategy()
 
-def test_default_strategy_sample_nodes_returns_all(default_strategy):
-    nodes = ['node-1', 'node-2']
-    sampled = default_strategy.sample_nodes(nodes, 0)
-    assert sampled == nodes
-    assert default_strategy._sampling_node_history[0] == nodes
-
-def test_default_strategy_refine_successful_replies(default_strategy):
-    default_strategy._sampling_node_history[0] = ['node-1', 'node-2']
-    training_replies = {
+@pytest.fixture
+def sample_training_replies():
+    return {
         'node-1': {
             'success': True,
             'node_id': 'node-1',
@@ -33,40 +25,72 @@ def test_default_strategy_refine_successful_replies(default_strategy):
         },
     }
 
-    model_params, weights, total_rows, encryption_factors = default_strategy.refine(training_replies, 0)
+def test_default_strategy_01_sample_nodes_returns_all(default_strategy):
+    nodes = ['node-1', 'node-2']
+    sampled = default_strategy.sample_nodes(nodes, 0)
+    assert sampled == nodes
+    assert default_strategy._sampling_node_history[0] == nodes
+
+def test_default_strategy_02_refine_successful_replies(
+    default_strategy,
+    sample_training_replies,
+):
+    default_strategy._sampling_node_history[0] = ['node-1', 'node-2']
+    training_replies = sample_training_replies
+    (
+        model_params,
+        weights,
+        total_rows,
+        encryption_factors
+    ) = default_strategy.refine(training_replies, 0)
     assert model_params == {'node-1': {'w': [1]}, 'node-2': {'w': [2]}}
     assert weights == {'node-1': 0.25, 'node-2': 0.75}
     assert total_rows == 400
     assert encryption_factors == {'node-1': [0.5], 'node-2': None}
 
-def test_default_strategy_refine_missing_node_reply_raises(default_strategy):
+def test_default_strategy_03_refine_missing_node_reply_raises(
+    default_strategy,
+    sample_training_replies,
+):
     default_strategy._sampling_node_history[0] = ['node-1', 'node-2']
-    training_replies = {
-        'node-1': {
-            'success': True,
-            'node_id': 'node-1',
-            'params': {'w': [1]},
-            'sample_size': 100,
-        }
-    }
+    training_replies = sample_training_replies
+    training_replies.pop('node-2')
     with pytest.raises(FedbiomedStrategyError, match=ErrorNumbers.FB408.value):
         default_strategy.refine(training_replies, 0)
 
-def test_default_strategy_refine_unsuccessful_node_reply_raises(default_strategy):
+def test_default_strategy_04_refine_successful_node_reply_missing_sample_size_raises(
+        default_strategy,
+        sample_training_replies,
+):
     default_strategy._sampling_node_history[0] = ['node-1', 'node-2']
-    training_replies = {
-        'node-1': {
-            'success': True,
-            'node_id': 'node-1',
-            'params': {'w': [1]},
-            'sample_size': 100,
-        },
-        'node-2': {
-            'success': False,
-            'node_id': 'node-2',
-            'msg': 'Something happened',
-        },
-    }
+    training_replies = sample_training_replies
+    training_replies['node-2'].pop('sample_size')
+    print(training_replies)
     with pytest.raises(FedbiomedStrategyError, match=ErrorNumbers.FB402.value):
         default_strategy.refine(training_replies, 0)
-        
+
+def test_default_strategy_05_refine_successful_node_reply_sample_size_is_none_raises(
+    default_strategy,
+    sample_training_replies,
+):
+    default_strategy._sampling_node_history[0] = ['node-1', 'node-2']
+    training_replies = sample_training_replies
+    training_replies['node-2']['sample_size'] = None
+    print(training_replies)
+    with pytest.raises(FedbiomedStrategyError, match=ErrorNumbers.FB402.value):
+        default_strategy.refine(training_replies, 0)
+
+def test_default_strategy_06_refine_unsuccessful_node_reply_raises(
+    default_strategy,
+    sample_training_replies,
+):
+    default_strategy._sampling_node_history[0] = ['node-1', 'node-2']
+    training_replies = sample_training_replies
+    training_replies['node-2']= {
+        'success': False,
+        'node_id': 'node-2',
+        'msg': 'Error message',
+    }
+    print(training_replies)
+    with pytest.raises(FedbiomedStrategyError, match=ErrorNumbers.FB402.value):
+        default_strategy.refine(training_replies, 0)


### PR DESCRIPTION
**PR description**

- Correction to some error messages that can be raised in DefaultStrategy class.
- Errors collected with `federated_req` are not given to function `_get_training_results`. Directly displayed in logs and removed from property `_nodes` of `TrainingJob`.
- Unsuccessful training replies are kept in variable `training_replies`.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`