### PR TITLE
ignore unsuccesfull training replies for node state

### DIFF
--- a/fedbiomed/researcher/federated_workflows/_experiment.py
+++ b/fedbiomed/researcher/federated_workflows/_experiment.py
@@ -624,7 +624,7 @@ class Experiment(TrainingPlanWorkflow):
             FedbiomedExperimentError: bad flag type
         """
         self._training_args['test_on_local_updates'] = flag
-        
+
         return self._training_args['test_on_local_updates'] #, self._training_args['shuffle_data_local_updates']
 
     @exp_exceptions
@@ -737,7 +737,7 @@ class Experiment(TrainingPlanWorkflow):
         if missing:
             raise FedbiomedExperimentError(ErrorNumbers.FB411.value + ': missing one or several object needed for'
                                            ' starting the `Experiment`. Details:\n' + missing)
-        
+
         # Sample nodes for training
         training_nodes = self._node_selection_strategy.sample_nodes(
             from_nodes=self.filtered_federation_nodes(),
@@ -793,9 +793,6 @@ class Experiment(TrainingPlanWorkflow):
         # Collect training replies and (opt.) optimizer auxiliary variables.
         training_replies, nodes_aux_var = job.execute()
 
-        # Update node states with node answers + when used node list has changed during the round.
-        self._update_nodes_states_agent(before_training=False, training_replies=training_replies)
-
         # If no Optimizer is used but auxiliary variables were received, raise.
         if (self._agg_optimizer is None) and nodes_aux_var:
             raise FedbiomedExperimentError(
@@ -811,6 +808,9 @@ class Experiment(TrainingPlanWorkflow):
                 training_replies, self._round_current
             )
         )
+
+        # Update node states with node answers + when used node list has changed during the round.
+        self._update_nodes_states_agent(before_training=False, training_replies=training_replies)
 
         # (Secure-)Aggregate model parameters and optimizer auxiliary variables.
         if self._secagg.active:
@@ -836,7 +836,7 @@ class Experiment(TrainingPlanWorkflow):
             )
 
         # Process optimizer auxiliary variables if any.
-        
+
         if aggregated_auxvar:
             self._agg_optimizer.set_aux(aggregated_auxvar)
 


### PR DESCRIPTION
**PR description**

Assings node state id only for successful training replies. 

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`