### PR TITLE
Introduces new configuration for `node_disconnection_timeout`

### DIFF
--- a/docs/user-guide/researcher/configuration.md
+++ b/docs/user-guide/researcher/configuration.md
@@ -60,7 +60,7 @@ db = ../var/db_RESEARCHER_2ba562cc-6943-4430-8f79-cb3877b2ea79.json
 [server]
 host = localhost
 port = 50051
-node_disconnection_timeput = 10
+node_disconnection_timeout = 10
 
 [certificate]
 private_key = certs/server_certificate.key

--- a/docs/user-guide/researcher/configuration.md
+++ b/docs/user-guide/researcher/configuration.md
@@ -54,12 +54,13 @@ Here is an example configuration file:
 [default]
 id = RESEARCHER_2ba562cc-6943-4430-8f79-cb3877b2ea79
 component = RESEARCHER
-version = 3
+version = 3.1.0
 db = ../var/db_RESEARCHER_2ba562cc-6943-4430-8f79-cb3877b2ea79.json
 
 [server]
 host = localhost
 port = 50051
+node_disconnection_timeput = 10
 
 [certificate]
 private_key = certs/server_certificate.key
@@ -80,6 +81,8 @@ This file contains settings for connecting to a server, managing security certif
 ### `[server]`
 - **host**: Defines the server host address to connect to.
 - **port**: Specifies the port number `50051` for the server connection.
+- **node_disconneciton_timeout**: A node is considered disconnected if it does not subscribe to new tasks within a given number of seconds.
+
 ### `[certificate]`
 - **private_key**: The path to the server's private key, which is used for secure communication.
 - **public_key**: The path to the server's public key, stored at `certs/server_certificate.pem`, which is used for encryption in secure communications.
@@ -137,5 +140,11 @@ fedbiomed researcher --path /path/to/another-researcher start
 2. **Communication Errors:** Verify the IP address, port, and certificates in the configuration file.
 3. **Permission Denied:** Check that you have write permissions for the working directory.
 
+
+### Running Researcher with delayed Network and Heavy ML Models
+
+In real-world applications, communication delays can be significant, causing default settings to fail. One encountered issue is that nodes may be considered disconnected if they do not re-subscribe to tasks from the researcher within a certain time frame. By default, the researcher expects nodes to send a new task subscription request within 10 seconds. However, due to network latency, message processing time, or other delays, node reconnection or subscription may take longer than 10 seconds.
+
+To address this, you can adjust the timeout setting on the researcher server using the `node_disconnection_timeout` configuration parameter.
 
 

--- a/fedbiomed/common/config.py
+++ b/fedbiomed/common/config.py
@@ -229,7 +229,20 @@ class Config(metaclass=ABCMeta):
 
     @abstractmethod
     def migrate(self):
-        """Provides migration"""
+        """Migration method to add configuration parameters
+
+        It is used for introducing  new parameters for in minor version or patch
+        to not break backward compatibility. This method has to updte `self._cfg`
+        direcly.
+
+        An example;
+
+        ```python
+        self._cfg["my-section"].update({"my-new-parameter": "my-new-value"})
+        ```
+        It should update the section only if the parameter is not exsiting to avoid
+        overwriting user defined values.
+        """
 
 
 class Component:

--- a/fedbiomed/common/config.py
+++ b/fedbiomed/common/config.py
@@ -135,6 +135,11 @@ class Config(metaclass=ABCMeta):
 
         return self._get(section, key, **kwargs).lower() in ("true", "1")
 
+    def getint(self, section, key, **kwargs) -> int:
+        """Gets int value of a given config"""
+
+        return self._cfg.getint(section, key, **kwargs)
+
     def _get(self, section, key, **kwargs) -> str:
         """ """
         environ_key = f"FBM_{section.upper()}_{key.upper()}"
@@ -199,6 +204,8 @@ class Config(metaclass=ABCMeta):
             self.add_parameters()
         else:
             self.read()
+            # Provide migration
+            self.migrate()
 
         self._update_vars()
 
@@ -219,6 +226,10 @@ class Config(metaclass=ABCMeta):
     @abstractmethod
     def add_parameters(self):
         """ "Component specific argument creation"""
+
+    @abstractmethod
+    def migrate(self):
+        """Provides migration"""
 
 
 class Component:

--- a/fedbiomed/common/constants.py
+++ b/fedbiomed/common/constants.py
@@ -84,7 +84,7 @@ SERVER_certificate_prefix = "server_certificate"
 
 __version__ = FBM_Component_Version(__version__)  # Fed-BioMed software version
 __researcher_config_version__ = FBM_Component_Version(
-    "3"
+    "3.1.0"
 )  # researcher config file version
 __node_config_version__ = FBM_Component_Version("2")  # node config file version
 __node_state_version__ = FBM_Component_Version("2")  # node state version

--- a/fedbiomed/common/constants.py
+++ b/fedbiomed/common/constants.py
@@ -83,10 +83,16 @@ SERVER_certificate_prefix = "server_certificate"
 # major version, else the minor version. Micro versions are supported but their use is currently discouraged.
 
 __version__ = FBM_Component_Version(__version__)  # Fed-BioMed software version
+
+"""
+!IMPORTANT!
+`[ResearcherConfig](./fedbiomed/researcher/config.py)` and `[NodeConfig](./fedbiomed/researcher/config.py)` contain a `migrate` method used to introduce new configuration variables without breaking backward compatibility for minor versions and patches. However, if a major version of the researcher or node configuration is released (config version not Fed-BioMed version), it indicates that previous configurations are no longer compatible with the new version. In such cases, the migration logic is no longer necessary and can be removed after the major release.  
+"""
 __researcher_config_version__ = FBM_Component_Version(
     "3.1.0"
 )  # researcher config file version
 __node_config_version__ = FBM_Component_Version("2")  # node config file version
+
 __node_state_version__ = FBM_Component_Version("2")  # node state version
 __breakpoints_version__ = FBM_Component_Version("3")  # breakpoints format version
 __messaging_protocol_version__ = FBM_Component_Version("5")  # format of gRPC messages.

--- a/fedbiomed/node/config.py
+++ b/fedbiomed/node/config.py
@@ -57,6 +57,10 @@ class NodeConfig(Config):
             "port": os.getenv("FBM_RESEARCHER_PORT", "50051"),
         }
 
+    def migrate(self):
+        """Please add migration value for the values that are introduced"""
+        pass
+
 
 component_root = os.environ.get("FBM_NODE_COMPONENT_ROOT", None)
 

--- a/fedbiomed/node/config.py
+++ b/fedbiomed/node/config.py
@@ -58,7 +58,10 @@ class NodeConfig(Config):
         }
 
     def migrate(self):
-        """Please add migration value for the values that are introduced"""
+        """Please add migrated parameters for the new version.
+
+        See [`Config.migrate`][fedbiomed.common.config.Config.migrate] for more information
+        """
         pass
 
 

--- a/fedbiomed/researcher/config.py
+++ b/fedbiomed/researcher/config.py
@@ -60,8 +60,10 @@ class ResearcherConfig(Config):
         }
 
     def migrate(self):
-        """Migrate configuration to newer configuration setting"""
+        """Please add migrated parameters for the new version.
 
+        See [`Config.migrate`][fedbiomed.common.config.Config.migrate] for more information
+        """
         if "node_disconnection_timeout" not in self._cfg["server"]:
             logger.warning(
                 "DEPRECATION: You are using an old configuration file for researcher. "

--- a/fedbiomed/researcher/config.py
+++ b/fedbiomed/researcher/config.py
@@ -30,6 +30,9 @@ class ResearcherConfig(Config):
 
         grpc_host = os.getenv("FBM_SERVER_HOST", "localhost")
         grpc_port = os.getenv("FBM_SERVER_PORT", "50051")
+        node_disconnection_timeout = str(
+            os.getenv("FBM_SERVER_NODE_DISCONNECTION_TIMEOUT", "10")
+        )
 
         # Generate certificate for gRPC server
         key_file, pem_file = generate_certificate(
@@ -42,7 +45,7 @@ class ResearcherConfig(Config):
         self._cfg["server"] = {
             "host": grpc_host,
             "port": grpc_port,
-            "node_disconnection_timeout": 10,
+            "node_disconnection_timeout": node_disconnection_timeout,
         }
 
         self._cfg["certificate"] = {

--- a/fedbiomed/researcher/config.py
+++ b/fedbiomed/researcher/config.py
@@ -42,6 +42,7 @@ class ResearcherConfig(Config):
         self._cfg["server"] = {
             "host": grpc_host,
             "port": grpc_port,
+            "node_disconnection_timeout": 10,
         }
 
         self._cfg["certificate"] = {
@@ -57,6 +58,24 @@ class ResearcherConfig(Config):
                 "FBM_SECURITY_SECAGG_INSECURE_VALIDATION", True
             )
         }
+
+    def migrate(self):
+        """Migrate configuration to newer configuration setting"""
+
+        if "node_disconnection_timeout" not in self._cfg["server"]:
+            logger.warning(
+                "DEPRECATION: You are using an old configuration file for researcher. "
+                "Please add 'node_disconnection_timeout' value in `server` section "
+                "of the researcher configuration."
+            )
+
+            self._cfg["server"].update(
+                {
+                    "node_disconnection_timeout": str(
+                        os.getenv("FBM_SERVER_NODE_DISCONNECTION_TIMEOUT", "10")
+                    )
+                }
+            )
 
     def _update_vars(self):
         """Updates component dynamic vars"""

--- a/fedbiomed/researcher/requests/_requests.py
+++ b/fedbiomed/researcher/requests/_requests.py
@@ -283,6 +283,7 @@ class Requests(metaclass=SingletonMeta):
         self._grpc_server = GrpcServer(
             host=server_host,
             port=server_port,
+            config=config,
             on_message=self.on_message,
             ssl=SSLCredentials(key=cert_priv, cert=cert_pub),
         )


### PR DESCRIPTION
**PR description**

- Introduces new config value for server to avoid node disconnections due to communication delay and big ML models
- Updates unittests
- Implements migration hook to provide backward compatibility for new config value

This PR party resolves some of the issue mentioned in  the issue #1251 


**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`