### PR TITLE
Addition of details to error messages in datasets

### DIFF
--- a/fedbiomed/common/dataset/_dataset.py
+++ b/fedbiomed/common/dataset/_dataset.py
@@ -162,8 +162,15 @@ class Dataset(ABC):
         Returns:
             Transformed data
         """
-        data = self._validate_format_conversion(data, extra_info=extra_info)
-        data = self._validate_transformation(data, transform, extra_info=extra_info)
+        data = self._validate_format_conversion(
+            data,
+            extra_info=extra_info + " in format conversion step.",
+        )
+        data = self._validate_transformation(
+            data,
+            transform,
+            extra_info=extra_info + " when applying associated transform",
+        )
         return data
 
     # === Functions ===

--- a/fedbiomed/common/dataset/_medical_folder_dataset.py
+++ b/fedbiomed/common/dataset/_medical_folder_dataset.py
@@ -158,11 +158,20 @@ class MedicalFolderDataset(Dataset):
         # Apply and validate transforms
         if isinstance(transform, dict):
             for modality in modalities:
-                self._validate_transformation(
-                    data=data[modality],
-                    transform=transform[modality],
-                    extra_info=f"Modality: '{modality}'",
-                )
+                if modality != "demographics":
+                    self._validate_transformation(
+                        data=data[modality],
+                        transform=transform[modality],
+                        extra_info=f"Error raised by modality: '{modality}'",
+                    )
+                else:
+                    try:
+                        _ = transform["demographics"](data["demographics"])
+                    except Exception as e:
+                        raise FedbiomedError(
+                            f"{ErrorNumbers.FB632.value}: Failed to apply transform "
+                            f"to 'demographics' in {self._to_format.value} format."
+                        ) from e
         else:
             # transform: apply to the entire data dict
             try:

--- a/fedbiomed/common/dataset/_simple_dataset.py
+++ b/fedbiomed/common/dataset/_simple_dataset.py
@@ -60,9 +60,15 @@ class _SimpleDataset(Dataset):
         self._init_controller(controller_kwargs=controller_kwargs)
 
         sample = self._controller.get_sample(0)
-        self._validate_format_and_transformations(sample["data"], self._transform)
         self._validate_format_and_transformations(
-            sample["target"], self._target_transform
+            sample["data"],
+            self._transform,
+            extra_info="Error raised by 'data'",
+        )
+        self._validate_format_and_transformations(
+            sample["target"],
+            self._target_transform,
+            extra_info="Error raised by 'target'",
         )
 
     def __getitem__(self, idx: int) -> Tuple[DatasetDataItem, DatasetDataItem]:


### PR DESCRIPTION
**PR description**

Add details to error messages in datasets validation and avoids output validation of demographics for MFD.
closes #1467

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`