### PR TITLE
Correct and rename param extra_info to handle None properly

### DIFF
--- a/fedbiomed/common/dataset/_dataset.py
+++ b/fedbiomed/common/dataset/_dataset.py
@@ -152,26 +152,27 @@ class Dataset(ABC):
         return data
 
     def _validate_format_and_transformations(
-        self, data: Any, transform: Optional[Callable], extra_info: Optional[str] = None
+        self, data: Any, transform: Optional[Callable], label: Optional[str] = None
     ) -> Any:
         """Validates and applies format conversion and `transform`
 
         Args:
             data: from `self._controller.get_sample`
             transform: `Callable` given at instantiation of cls
-            extra_info: info to add to error message to indicate concerned variables
+            label: to add to error message to indicate concerned variables
 
         Returns:
             Transformed data
         """
+        by = " " if label is None else f" by '{label}' "
         data = self._validate_format_conversion(
             data,
-            extra_info=extra_info + " in format conversion step.",
+            extra_info=f"Error raised{by}in format conversion step.",
         )
         data = self._validate_transformation(
             data,
             transform,
-            extra_info=extra_info + " when applying associated transform",
+            extra_info=f"Error raised{by}when applying associated transform",
         )
         return data
 

--- a/fedbiomed/common/dataset/_simple_dataset.py
+++ b/fedbiomed/common/dataset/_simple_dataset.py
@@ -63,12 +63,12 @@ class _SimpleDataset(Dataset):
         self._validate_format_and_transformations(
             sample["data"],
             self._transform,
-            extra_info="Error raised by 'data'",
+            label="data",
         )
         self._validate_format_and_transformations(
             sample["target"],
             self._target_transform,
-            extra_info="Error raised by 'target'",
+            label="target",
         )
 
     def __getitem__(self, idx: int) -> Tuple[DatasetDataItem, DatasetDataItem]:


### PR DESCRIPTION
**PR description**

closes #1477 
Parameter "extra_info" was not properly handling value `None`. Parameter renamed to "label"

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`