### PR TITLE
Rename SimpleDataset to ImageLabelDataset and correct pytorch transfo…

### DIFF
--- a/docs/tutorials/pytorch/01_PyTorch_MNIST_Single_Node_Tutorial.ipynb
+++ b/docs/tutorials/pytorch/01_PyTorch_MNIST_Single_Node_Tutorial.ipynb
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "9d7c3f83",
    "metadata": {
     "pycharm": {
@@ -174,8 +174,7 @@
     "\n",
     "    def training_data(self):\n",
     "        transform = transforms.Normalize((0.1307,), (0.3081,))\n",
-    "        target_transform = transforms.Lambda(lambda y: y.long())\n",
-    "        dataset1 = MnistDataset(transform=transform, target_transform=target_transform)\n",
+    "        dataset1 = MnistDataset(transform=transform)\n",
     "        loader_arguments = {'shuffle': True}\n",
     "        return DataManager(dataset1, **loader_arguments)\n",
     "\n",

--- a/fedbiomed/common/dataset/_simple_dataset.py
+++ b/fedbiomed/common/dataset/_simple_dataset.py
@@ -20,7 +20,7 @@ from fedbiomed.common.exceptions import FedbiomedError, FedbiomedValueError
 from ._dataset import Dataset
 
 
-class _SimpleDataset(Dataset):
+class _ImageLabelDataset(Dataset):
     "Dataset where data and target are implicitly predefined by the controller"
 
     _native_to_framework = {
@@ -28,7 +28,7 @@ class _SimpleDataset(Dataset):
         DataReturnFormat.TORCH: lambda x: (
             T.ToTensor()(x)  # In case the target is a PIL Image
             if isinstance(x, (Image.Image, np.ndarray))
-            else torch.tensor(x).float()
+            else torch.tensor(x)
         ),
     }
 
@@ -37,10 +37,10 @@ class _SimpleDataset(Dataset):
         transform: Optional[Callable] = None,
         target_transform: Optional[Callable] = None,
     ):
-        if type(self) is _SimpleDataset:
+        if type(self) is _ImageLabelDataset:
             raise FedbiomedValueError(
                 f"{ErrorNumbers.FB632.value}: "
-                "`SimpleDataset` cannot be instantiated directly"
+                "`_ImageLabelDataset` cannot be instantiated directly"
             )
         self._transform = self._validate_transform(transform)
         self._target_transform = self._validate_transform(target_transform)
@@ -84,13 +84,13 @@ class _SimpleDataset(Dataset):
         return sample["data"], sample["target"]
 
 
-class ImageFolderDataset(_SimpleDataset):
+class ImageFolderDataset(_ImageLabelDataset):
     _controller_cls = ImageFolderController
 
 
-class MedNistDataset(_SimpleDataset):
+class MedNistDataset(_ImageLabelDataset):
     _controller_cls = MedNistController
 
 
-class MnistDataset(_SimpleDataset):
+class MnistDataset(_ImageLabelDataset):
     _controller_cls = MnistController

--- a/tests/end2end/experiments/training_plans/mnist_pytorch_training_plan.py
+++ b/tests/end2end/experiments/training_plans/mnist_pytorch_training_plan.py
@@ -1,10 +1,13 @@
 import torch
 import torch.nn as nn
-from fedbiomed.common.training_plans import TorchTrainingPlan
+import torch.nn.functional as F
+from torchvision import transforms
+
 from fedbiomed.common.datamanager import DataManager
-from torchvision import datasets, transforms
-from fedbiomed.common.optimizers.optimizer import Optimizer
+from fedbiomed.common.dataset import MnistDataset
 from fedbiomed.common.optimizers.declearn import ScaffoldClientModule
+from fedbiomed.common.optimizers.optimizer import Optimizer
+from fedbiomed.common.training_plans import TorchTrainingPlan
 
 
 # Here we define the model to be used.
@@ -20,7 +23,10 @@ class MyTrainingPlan(TorchTrainingPlan):
 
     # Declares and return dependencies
     def init_dependencies(self):
-        deps = ["from torchvision import datasets, transforms"]
+        deps = [
+            "from torchvision import transforms",
+            "from fedbiomed.common.dataset import MnistDataset",
+        ]
         return deps
 
     class Net(nn.Module):
@@ -51,12 +57,8 @@ class MyTrainingPlan(TorchTrainingPlan):
 
     def training_data(self):
         # Custom torch Dataloader for MNIST data
-        transform = transforms.Compose(
-            [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
-        )
-        dataset1 = datasets.MNIST(
-            self.dataset_path, train=True, download=False, transform=transform
-        )
+        transform = transforms.Normalize((0.1307,), (0.3081,))
+        dataset1 = MnistDataset(transform=transform)
         train_kwargs = {"shuffle": True}
         return DataManager(dataset=dataset1, **train_kwargs)
 
@@ -79,7 +81,10 @@ class BigModelMyTrainingPlan(TorchTrainingPlan):
 
     # Declares and return dependencies
     def init_dependencies(self):
-        deps = ["from torchvision import datasets, transforms"]
+        deps = [
+            "from torchvision import transforms",
+            "from fedbiomed.common.dataset import MnistDataset",
+        ]
         return deps
 
     class Net(nn.Module):
@@ -113,12 +118,8 @@ class BigModelMyTrainingPlan(TorchTrainingPlan):
 
     def training_data(self):
         # Custom torch Dataloader for MNIST data
-        transform = transforms.Compose(
-            [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
-        )
-        dataset1 = datasets.MNIST(
-            self.dataset_path, train=True, download=False, transform=transform
-        )
+        transform = transforms.Normalize((0.1307,), (0.3081,))
+        dataset1 = MnistDataset(transform=transform)
         train_kwargs = {"shuffle": True}
         return DataManager(dataset=dataset1, **train_kwargs)
 
@@ -141,7 +142,8 @@ class MnistModelScaffoldDeclearn(TorchTrainingPlan):
     # Declares and return dependencies
     def init_dependencies(self):
         deps = [
-            "from torchvision import datasets, transforms",
+            "from torchvision import transforms",
+            "from fedbiomed.common.dataset import MnistDataset",
             "from fedbiomed.common.optimizers.optimizer import Optimizer",
             "from fedbiomed.common.optimizers.declearn import ScaffoldClientModule, AdamModule, FedProxRegularizer",
         ]
@@ -175,12 +177,8 @@ class MnistModelScaffoldDeclearn(TorchTrainingPlan):
 
     def training_data(self):
         # Custom torch Dataloader for MNIST data
-        transform = transforms.Compose(
-            [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
-        )
-        dataset1 = datasets.MNIST(
-            self.dataset_path, train=True, download=False, transform=transform
-        )
+        transform = transforms.Normalize((0.1307,), (0.3081,))
+        dataset1 = MnistDataset(transform=transform)
         train_kwargs = {"shuffle": True}
         return DataManager(dataset=dataset1, **train_kwargs)
 

--- a/tests/test_dataset/test_dataset_simple_dataset.py
+++ b/tests/test_dataset/test_dataset_simple_dataset.py
@@ -7,7 +7,7 @@ from PIL import Image
 from torchvision import transforms
 
 from fedbiomed.common.dataset import ImageFolderDataset
-from fedbiomed.common.dataset._simple_dataset import _SimpleDataset
+from fedbiomed.common.dataset._simple_dataset import _ImageLabelDataset
 from fedbiomed.common.dataset_types import DataReturnFormat
 from fedbiomed.common.exceptions import FedbiomedError, FedbiomedValueError
 
@@ -69,7 +69,7 @@ def test_init_controller_instantiation_failure(tmp_path):
 
 def test_simple_dataset_cannot_be_instantiated():
     with pytest.raises(FedbiomedError) as excinfo:
-        _ = _SimpleDataset()
+        _ = _ImageLabelDataset()
     assert "cannot be instantiated directly" in str(excinfo.value)
 
 


### PR DESCRIPTION
closes #1492 
Rename SimpleDataset to ImageLabelDataset for clarity (file of name does not change)
Correct by-default target transformation for the class

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`