### PR TITLE
Optimizers don't get properly parent class with PyTorch 2.9.0+

### DIFF
--- a/fedbiomed/common/optimizers/generic_optimizers.py
+++ b/fedbiomed/common/optimizers/generic_optimizers.py
@@ -601,7 +601,7 @@ class OptimizerBuilder:
             The parent class type, or the class itself, if class is just under `object`
         """
         if hasattr(type_optimizer, "__bases__"):
-            if type_optimizer.__bases__[0] is object:
+            if type_optimizer is object or type_optimizer.__bases__[0] is object:
                 # in this case, `type_optimizer` is already the parent class
                 # (it only has `object`as parent class)
                 return type_optimizer

--- a/tests/test_generic_optimizer.py
+++ b/tests/test_generic_optimizer.py
@@ -1206,19 +1206,19 @@ class TestOptimizerBuilder(unittest.TestCase):
                 self.assertIsInstance(optim_wrapper, DeclearnOptimizer)
 
     def test_02_get_parent_class(self):
-        def check_type(obj, parent_obj):
+        def check_type(obj, parent_class):
             """Tests that function `get_parent_class` returns
             the appropriate type of the highest parent class (just after `object`)
 
             Args:
                 obj : sub-calss or class of the object from which to guess the parent class type
-                parent_obj : highest parent class from which `obj` object has been built
+                parent_class : highest parent class from which `obj` object has been built
 
             Raises:
                 AssertionError: raised if function `get_parent_class` doesn't return the expected type
             """
             res = optim_builder.get_parent_class(obj)
-            self.assertEqual(res, type(parent_obj))
+            self.assertEqual(res, parent_class)
 
         class A:
             pass
@@ -1235,11 +1235,11 @@ class TestOptimizerBuilder(unittest.TestCase):
         class E(C, A):
             pass
 
-        objects = [A, B, C, D, E]
+        objects = [A(), B(), C(), D(), E()]
 
         optim_builder = OptimizerBuilder()
         # test with `object`
-        check_type(object, object)
+        check_type(object(), object)
 
         # test with `None`
         res = optim_builder.get_parent_class(None)


### PR DESCRIPTION
**PR description**

Fix #1511 (Optimizer does not get properly parent optimizer class with recent versions of PyTorch)

Issue only appears with recent versions of PyTorch.
Fix was tested with PyTorch 2.9.0 in containers.
Unit tests are not broken by fix.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`