### PR TITLE
Adds FAReply FARequest message types

### DIFF
--- a/fedbiomed/common/message.py
+++ b/fedbiomed/common/message.py
@@ -886,6 +886,48 @@ class TrainingPlanStatusReply(RequestReply, RequiresProtocolVersion):
     training_plan_id: Optional[str]
 
 
+@catch_dataclass_exception
+@dataclass
+class FARequest(RequestReply, RequiresProtocolVersion):
+    """Message for requesting FA job from researcher to node.
+
+    Raises:
+        FedbiomedMessageError: triggered if message's fields validation failed
+    """
+
+    researcher_id: str
+    experiment_id: str
+    fa_id: str
+    dataset_id: str
+    fa_arguments: (
+        Dict  # TODO: Use dataclass to define precisely what arguments are expected
+    )
+
+
+@catch_dataclass_exception
+@dataclass
+class FAReply(RequestReply, RequiresProtocolVersion):
+    """Message that instantiated on the node side to reply FA job request from researcher
+
+    Attributes:
+        researcher_id: ID of the researcher that receives the reply
+        experiment_id: Id of the experiment that is sent by researcher
+        success: True if the node process the request as expected, false if any exception occurs
+        node_id: Node id that replies the request
+        node_name: Node Name that replies the request
+        msg: Custom message
+
+    """
+
+    researcher_id: str
+    experiment_id: str
+    fa_id: str
+    node_id: str
+    node_name: str
+    output: Dict
+    msg: Optional[str]
+
+
 # Train messages
 
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -18,6 +18,30 @@ from fedbiomed.common.message import (
 )
 
 
+def test_fa_request_message_creation():
+    """Test FARequest message creation"""
+    _ = message.FARequest(
+        researcher_id="researcher_1234",
+        experiment_id="experiment_1234",
+        fa_id="fa_1234",
+        dataset_id="dataset_1234",
+        fa_arguments={"test": "output_data"},
+    )
+
+
+def test_fa_reply_message_creation():
+    """Test FAReply message creation"""
+    _ = message.FAReply(
+        researcher_id="researcher_1234",
+        experiment_id="experiment_1234",
+        fa_id="fa_1234",
+        node_id="node_1234",
+        node_name="node_name_1234",
+        output={"test": "output_data"},
+        msg="This is a FA reply message",
+    )
+
+
 class TestMessage(unittest.TestCase):
     """
     Test the Message class


### PR DESCRIPTION
**PR description**

Implements FARequest and FAReply message types. 

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`