### PR TITLE
Feature/1546 use federated dataset object as state of datasets of the experiment

### DIFF
--- a/docs/tutorials/advanced/in-depth-experiment-configuration.ipynb
+++ b/docs/tutorials/advanced/in-depth-experiment-configuration.ipynb
@@ -338,10 +338,20 @@
     "Training data is a `FederatedDataset` instance which comes from the module `fedbiomed.researcher.datasets`. There are several ways to define your training data.\n",
     "\n",
     "1. You can run `set_training_data(training_data=None, from_tags=True)`. This will send search request to the nodes to get dataset information by using the `tags` which are defined before.\n",
-    "2. You can provide `training_data` argument which is an instance of `FederatedDataSet`. \n",
-    "3. You can provide `training_data` argument as python dictionary `dict` and setter will create a `FederatedDataSet` object by itself.\n",
+    "2. You can provide `training_data` argument as python dictionary `dict` and setter will create a `FederatedDataSet` object by itself.\n",
     "\n",
-    "While using the last option please make sure that your `dict` object is configured accordingly to `FederatedDataSet` schema. Otherwise, you might get error while running your experiment.\n",
+    "    !!! warning \"Attention\"\n",
+    "    Providing `training_data` argument which is an instance of `FederatedDataSet` is deprecated. This functionality will be removed in the future releases. \n",
+    "\n",
+    "While using the last option, please make sure that your dict object is configured according to the `FederatedDataSet` schema. Otherwise, you may encounter errors when running your experiment. It is strongly recommended to rely on tags or to retrieve the dataset dict from an existing FederatedDataSet object rather than writing the data dictionary from scratch.\n",
+    "\n",
+    "```python\n",
+    "{\n",
+    "    \"<node-1>\": {\"name\": <...>, \"dataset_id\": <...>}\n",
+    "    \"...\": {...}\n",
+    "} \n",
+    "```\n",
+    "\n",
     "\n",
     "A `FederatedDataSet` object must have **one unique** dataset per node to ensure training uses only one dataset for each node. This is checked and enforced when creating a `FederatedDataSet`\n",
     "\n",
@@ -399,7 +409,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As it is mentioned before, setting training data once doesn't mean that you can't change it, for you can create a new `FederatedDataSet` with a `dict` that includes the information about the datasets. This will allow you to select the datasets that will be used for federated training.\n",
+    "As mentioned earlier, setting the training data once does not mean that it cannot be changed. You can pass a `dict` that includes information about the datasets, which allows you to select the datasets to be used for federated training.\n",
+    "\n",
+    "The dictionary must follow the correct format; otherwise, it may introduce unexpected errors. The structure and content of the datasets may vary from one dataset type to another. Therefore, it is recommended to build the dictionary based on an example returned by a `search` or `list` operation.\n",
+    "\n",
     "\n",
     "<div class=\"note\"><p>Since the dataset information will be provided, there will be no need to send request to the nodes</p></div>"
    ]
@@ -413,24 +426,6 @@
     "from fedbiomed.researcher.datasets import FederatedDataSet \n",
     "\n",
     "tr_data = training_data.data()\n",
-    "tr_data = training_data.data()\n",
-    "federated_dataset = FederatedDataSet(tr_data)\n",
-    "exp.set_training_data(training_data = federated_dataset)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Or, you can directly use `tr_data` in `set_training_data()`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "exp.set_training_data(training_data = tr_data)"
    ]
   },

--- a/docs/tutorials/advanced/in-depth-experiment-configuration.ipynb
+++ b/docs/tutorials/advanced/in-depth-experiment-configuration.ipynb
@@ -338,12 +338,12 @@
     "Training data is a `FederatedDataset` instance which comes from the module `fedbiomed.researcher.datasets`. There are several ways to define your training data.\n",
     "\n",
     "1. You can run `set_training_data(training_data=None, from_tags=True)`. This will send search request to the nodes to get dataset information by using the `tags` which are defined before.\n",
-    "2. You can provide `training_data` argument as python dictionary `dict` and setter will create a `FederatedDataSet` object by itself.\n",
+    "2. You can provide `training_data` argument as python dictionary `dict` and setter will create a `FederatedDataset` object by itself.\n",
     "\n",
     "    !!! warning \"Attention\"\n",
-    "    Providing `training_data` argument which is an instance of `FederatedDataSet` is deprecated. This functionality will be removed in the future releases. \n",
+    "    Providing `training_data` argument which is an instance of `FederatedDataset` is deprecated. This functionality will be removed in the future releases. \n",
     "\n",
-    "While using the last option, please make sure that your dict object is configured according to the `FederatedDataSet` schema. Otherwise, you may encounter errors when running your experiment. It is strongly recommended to rely on tags or to retrieve the dataset dict from an existing FederatedDataSet object rather than writing the data dictionary from scratch.\n",
+    "While using the last option, please make sure that your dict object is configured according to the `FederatedDataset` schema. Otherwise, you may encounter errors when running your experiment. It is strongly recommended to rely on tags or to retrieve the dataset dict from an existing FederatedDataset object rather than writing the data dictionary from scratch.\n",
     "\n",
     "```python\n",
     "{\n",
@@ -353,7 +353,7 @@
     "```\n",
     "\n",
     "\n",
-    "A `FederatedDataSet` object must have **one unique** dataset per node to ensure training uses only one dataset for each node. This is checked and enforced when creating a `FederatedDataSet`\n",
+    "A `FederatedDataset` object must have **one unique** dataset per node to ensure training uses only one dataset for each node. This is checked and enforced when creating a `FederatedDataset`\n",
     "\n",
     "If you run `set_training_data(training_data=None)`, this means that no training data is defined yet for the experiment (`training_data` is set to `None`).\n"
    ]
@@ -377,7 +377,7 @@
    "source": [
     "Since the training data setter will send search request to the nodes, the output will inform you about selected nodes for training. It means that those nodes have the dataset, and they will be able to train your model defined in the training plan class.\n",
     "\n",
-    "`set_training_data` will return a `FederatedDataSet` object. You can either use the return value of the setter or the getter for training data which is `training_data()`."
+    "`set_training_data` will return a `FederatedDataset` object. You can either use the return value of the setter or the getter for training data which is `training_data()`."
    ]
   },
   {
@@ -393,7 +393,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To inspect the result in detail you can call the method `data()` of the `FederatedDataSet` object. This will return a python dictionary that includes information about the datasets that has been found in the nodes. "
+    "To inspect the result in detail you can call the method `data()` of the `FederatedDataset` object. This will return a python dictionary that includes information about the datasets that has been found in the nodes. "
    ]
   },
   {
@@ -423,7 +423,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fedbiomed.researcher.datasets import FederatedDataSet \n",
+    "from fedbiomed.researcher.datasets import FederatedDataset \n",
     "\n",
     "tr_data = training_data.data()\n",
     "exp.set_training_data(training_data = tr_data)"

--- a/docs/user-guide/researcher/experiment.md
+++ b/docs/user-guide/researcher/experiment.md
@@ -49,7 +49,7 @@ exp = Experiment(tags=tags,
 
 Under the hood, the `Experiment` class takes care of a lot of heavy lifting for you.
 For example, when you initialize an experiment with the `tags` argument, it uses them to automatically create a
-`FederatedDataSet` by querying the federation.
+`FederatedDataset` by querying the federation.
 Afterwards, `Experiment` initializes several internal variables to manage federated training on all participating nodes.
 Finally, it also creates the strategy to select the nodes for each training round.
 When the `node_selection_strategy` is set to `None`, the experiment uses the default strategy which is `DefaultStrategy`.
@@ -87,7 +87,7 @@ print(tags)
 
 !!! warning "Tags matching multiple datasets"
     An `Experiment` object must have **one unique** dataset per node.
-    Object creation fails if this is not the case when trying to instantiate the `FederatedDataSet` object.
+    Object creation fails if this is not the case when trying to instantiate the `FederatedDataset` object.
     This is done to ensure that training for an `Experiment` uses only a single dataset for each node.
 
 As a consequence, `tags` specified for an `Experiment` should not be ambiguous, which means they cannot match multiple datasets on one node.

--- a/docs/user-guide/researcher/experiment.md
+++ b/docs/user-guide/researcher/experiment.md
@@ -96,17 +96,9 @@ For example if you instantiate `Experiment(tags='#dataset')` and a node has regi
 
 #### Setting the training data by providing the metadata directly
 
-The dataset metadata can be provided directly using the `set_training_data` method.
-The metadata can be a `FederatedDataSet` object or a nested `dict` with format `{node_id: {metadata_key: metadata_value}}`.
+The dataset metadata can be provided directly using the `set_training_data` method. The metadata can be nested `dict` with format `{node_id: {metadata_key: metadata_value}}`.
 
 When you provide a metadata object directly, the `Experiment`'s tags attribute is set to `None`.
-
-#### Under-the-hood consistency with all members of `Experiment`
-
-When you change the training data (either through `set_tags` or `set_training_data`), the `Experiment` class
-performs a lot of operations to ensure that consistency is maintained for all of its attributes that use the
-training data.
-In particular, the `aggregator` and `node_state_agent` classes are updated with the new training data.
 
 ### Selecting specific Nodes for the training
 

--- a/fedbiomed/common/exceptions.py
+++ b/fedbiomed/common/exceptions.py
@@ -108,14 +108,6 @@ class FedbiomedExperimentError(FedbiomedError):
     pass
 
 
-class FedbiomedFederatedDataSetError(FedbiomedError):
-    """
-    Exception specific to the FederatedDataSetError class.
-    """
-
-    pass
-
-
 class FedbiomedLoadingBlockError(FedbiomedError):
     """
     Exception specific to the DataLoadingBlock classes/subclasses.

--- a/fedbiomed/researcher/aggregators/aggregator.py
+++ b/fedbiomed/researcher/aggregators/aggregator.py
@@ -16,7 +16,7 @@ from fedbiomed.common.exceptions import FedbiomedAggregatorError
 from fedbiomed.common.logger import logger
 from fedbiomed.common.secagg import SecaggCrypter
 from fedbiomed.common.serializer import Serializer
-from fedbiomed.researcher.datasets import FederatedDataSet
+from fedbiomed.researcher.datasets import FederatedDataset
 
 if TYPE_CHECKING:
     from fedbiomed.common.training_plans._base_training_plan import BaseTrainingPlan
@@ -30,7 +30,7 @@ class Aggregator:
 
     def __init__(self):
         self._aggregator_args: dict = None
-        self._fds: FederatedDataSet = None
+        self._fds: FederatedDataset = None
         self._training_plan_type: TrainingPlans = None
         self._secagg_crypter = SecaggCrypter()
 
@@ -114,13 +114,13 @@ class Aggregator:
     def check_values(self, *args, **kwargs) -> True:
         return True
 
-    def set_fds(self, fds: FederatedDataSet) -> FederatedDataSet:
-        """Sets the FederatedDataSet to be used by the Aggregator.
+    def set_fds(self, fds: FederatedDataset) -> FederatedDataset:
+        """Sets the FederatedDataset to be used by the Aggregator.
 
         Args:
-            fds: FederatedDataSet to be used by the Aggregator
+            fds: FederatedDataset to be used by the Aggregator
         Returns:
-            The FederatedDataSet set to be used by the Aggregator
+            The FederatedDataset set to be used by the Aggregator
         """
         self._fds = fds
         return self._fds

--- a/fedbiomed/researcher/aggregators/aggregator.py
+++ b/fedbiomed/researcher/aggregators/aggregator.py
@@ -115,6 +115,13 @@ class Aggregator:
         return True
 
     def set_fds(self, fds: FederatedDataSet) -> FederatedDataSet:
+        """Sets the FederatedDataSet to be used by the Aggregator.
+
+        Args:
+            fds: FederatedDataSet to be used by the Aggregator
+        Returns:
+            The FederatedDataSet set to be used by the Aggregator
+        """
         self._fds = fds
         return self._fds
 

--- a/fedbiomed/researcher/aggregators/scaffold.py
+++ b/fedbiomed/researcher/aggregators/scaffold.py
@@ -18,7 +18,7 @@ from fedbiomed.common.serializer import Serializer
 from fedbiomed.common.training_plans import BaseTrainingPlan
 from fedbiomed.researcher.aggregators.aggregator import Aggregator
 from fedbiomed.researcher.aggregators.functional import initialize
-from fedbiomed.researcher.datasets import FederatedDataSet
+from fedbiomed.researcher.datasets import FederatedDataset
 
 
 class Scaffold(Aggregator):
@@ -86,7 +86,7 @@ class Scaffold(Aggregator):
         {node id: learning rate}
     """
 
-    def __init__(self, server_lr: float = 1.0, fds: Optional[FederatedDataSet] = None):
+    def __init__(self, server_lr: float = 1.0, fds: Optional[FederatedDataset] = None):
         """Constructs `Scaffold` object as an instance of [`Aggregator`]
         [fedbiomed.researcher.aggregators.Aggregator].
 

--- a/fedbiomed/researcher/aggregators/scaffold.py
+++ b/fedbiomed/researcher/aggregators/scaffold.py
@@ -108,8 +108,7 @@ class Scaffold(Aggregator):
         # within 2 Rounds
         self.nodes_deltas: Dict[str, Dict[str, Union[torch.Tensor, np.ndarray]]] = {}
         self.nodes_lr: Dict[str, Dict[str, float]] = {}
-        if fds is not None:
-            self.set_fds(fds)
+        self.set_fds(fds)
         self._aggregator_args = {}  # we need `_aggregator_args` to be not None
 
     def aggregate(
@@ -213,10 +212,9 @@ class Scaffold(Aggregator):
                 this aggregator.
         """
         # Gather node ids from the attached FederatedDataset.
-        if self._fds is None:
+        if not self._fds:
             raise FedbiomedAggregatorError(
-                "Cannot initialize correction states: Scaffold aggregator does "
-                "not have a FederatedDataset attached."
+                "Cannot initialize correction states: federated datasets is empty."
             )
         node_ids = self._fds.node_ids()
         # Initialize nodes states with zero scalars, that will be summed into actual tensors.

--- a/fedbiomed/researcher/datasets.py
+++ b/fedbiomed/researcher/datasets.py
@@ -3,6 +3,7 @@
 
 """Module includes the classes that allow researcher to interact with remote datasets (federated datasets)."""
 
+import copy
 from asyncio.log import logger
 from typing import Dict, List, Optional
 
@@ -10,7 +11,7 @@ from fedbiomed.common.constants import ErrorNumbers
 from fedbiomed.common.exceptions import FedbiomedError
 
 
-class FederatedDataSet:
+class FederatedDataset:
     """A class that allows researcher to interact with remote datasets (federated datasets).
 
     It contains details about remote datasets, such as client ids, data size that can be useful for aggregating
@@ -18,7 +19,7 @@ class FederatedDataSet:
     """
 
     def __init__(self, data: Optional[Dict] = None):
-        """Construct FederatedDataSet object.
+        """Construct FederatedDataset object.
 
         Args:
             data:  Dictionary of datasets. Each key is a `str` representing a node's ID. Each value is
@@ -41,18 +42,18 @@ class FederatedDataSet:
                 of the dataset associated to this node in the federated dataset.
 
         Raises:
-            FedbiomedFederatedDataSetError: bad `data` format
+            FedbiomedError: bad `data` format
         """
         # check structure of data
         # DEPRECATED: to be removed in future versions
-        if isinstance(datasets, FederatedDataSet):
+        if isinstance(datasets, FederatedDataset):
             logger.warning(
-                "DEPRECATED: Passing a `FederatedDataSet` instance"
-                " to the `data` parameter of `FederatedDataSet` is deprecated and "
+                "DEPRECATED: Passing a `FederatedDataset` instance"
+                " to the `data` parameter of `FederatedDataset` is deprecated and "
                 "will not be supported in future versions. Please pass a `dict` "
                 "representing the federated dataset instead."
             )
-            datasets = datasets.data()
+            datasets = copy.deepcopy(datasets.data())
 
         if isinstance(datasets, dict) is False:
             raise FedbiomedError(
@@ -98,7 +99,7 @@ class FederatedDataSet:
         return self._data
 
     def node_ids(self) -> List[str]:
-        """Retrieve Node ids from `FederatedDataSet`.
+        """Retrieve Node ids from `FederatedDataset`.
 
         Returns:
             List of node ids
@@ -110,7 +111,7 @@ class FederatedDataSet:
 
         Returns:
             List of sample sizes in federated datasets in the same order with
-                [node_ids][fedbiomed.researcher.datasets.FederatedDataSet.node_ids]
+                [node_ids][fedbiomed.researcher.datasets.FederatedDataset.node_ids]
         """
         sample_sizes = []
         for _, val in self._data.items():
@@ -122,7 +123,7 @@ class FederatedDataSet:
         """Get shape of FederatedDatasets by node ids.
 
         Returns:
-            Includes [`sample_sizes`][fedbiomed.researcher.datasets.FederatedDataSet.sample_sizes] by node_ids.
+            Includes [`sample_sizes`][fedbiomed.researcher.datasets.FederatedDataset.sample_sizes] by node_ids.
         """
         shapes_dict = {}
         for node_id, node_data_size in zip(
@@ -131,3 +132,6 @@ class FederatedDataSet:
             shapes_dict[node_id] = node_data_size
 
         return shapes_dict
+
+
+FederatedDataSet = FederatedDataset  # backward compatibility

--- a/fedbiomed/researcher/datasets.py
+++ b/fedbiomed/researcher/datasets.py
@@ -3,12 +3,10 @@
 
 """Module includes the classes that allow researcher to interact with remote datasets (federated datasets)."""
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from fedbiomed.common.constants import ErrorNumbers
-from fedbiomed.common.exceptions import FedbiomedFederatedDataSetError
-from fedbiomed.common.logger import logger
-from fedbiomed.common.validator import Validator, ValidatorError
+from fedbiomed.common.exceptions import FedbiomedError
 
 
 class FederatedDataSet:
@@ -18,11 +16,11 @@ class FederatedDataSet:
     or sampling strategies on researcher's side
     """
 
-    def __init__(self, data: Dict):
+    def __init__(self, data: Optional[Dict] = None):
         """Construct FederatedDataSet object.
 
         Args:
-            data: Dictionary of datasets. Each key is a `str` representing a node's ID. Each value is
+            data:  Dictionary of datasets. Each key is a `str` representing a node's ID. Each value is
                 a `dict` (or a `list` containing exactly one `dict`). Each `dict` contains the description
                 of the dataset associated to this node in the federated dataset.
 
@@ -30,34 +28,31 @@ class FederatedDataSet:
             FedbiomedFederatedDataSetError: bad `data` format
         """
         # check structure of data
-        self._v = Validator()
-        self._v.register("list_or_dict", self._dataset_type, override=True)
-        try:
-            self._v.validate(data, dict)
-            for node, ds in data.items():
-                self._v.validate(node, str)
-                self._v.validate(ds, "list_or_dict")
-                if isinstance(ds, list):
-                    if len(ds) == 1:
-                        self._v.validate(ds[0], dict)
-                        # convert list of one dict to dict
-                        data[node] = ds[0]
-                    else:
-                        errmess = (
-                            f"{ErrorNumbers.FB416.value}: {node} must have one unique dataset "
-                            f"but has {len(ds)} datasets."
-                        )
-                        logger.error(errmess)
-                        raise FedbiomedFederatedDataSetError(errmess)
-        except ValidatorError as e:
-            errmess = (
-                f"{ErrorNumbers.FB416.value}: bad parameter `data` must be a `dict` of "
-                f"(`list` of one) `dict`: {e}"
-            )
-            logger.error(errmess)
-            raise FedbiomedFederatedDataSetError(errmess) from e
+        if data is not None:
+            self.set_federated_dataset(data)
+        else:
+            self._data = {}
 
-        self._data = data
+    def set_federated_dataset(self, datasets: Dict) -> None:
+        """Set federated dataset.
+
+        Args:
+            datasets:  Dictionary of datasets. Each key is a `str` representing a node's ID. Each value is
+                a `dict` (or a `list` containing exactly one `dict`). Each `dict` contains the description
+                of the dataset associated to this node in the federated dataset.
+
+        Raises:
+            FedbiomedFederatedDataSetError: bad `data` format
+        """
+        # check structure of data
+
+        if isinstance(datasets, dict) is False:
+            raise FedbiomedError(
+                f"{ErrorNumbers.FB416.value}: bad parameter `data` must be a `dict` of "
+                f"(`list` of one) `dict`."
+            )
+
+        self._data = datasets
 
     @staticmethod
     def _dataset_type(value) -> bool:

--- a/fedbiomed/researcher/datasets.py
+++ b/fedbiomed/researcher/datasets.py
@@ -3,6 +3,7 @@
 
 """Module includes the classes that allow researcher to interact with remote datasets (federated datasets)."""
 
+from asyncio.log import logger
 from typing import Dict, List, Optional
 
 from fedbiomed.common.constants import ErrorNumbers
@@ -23,11 +24,9 @@ class FederatedDataSet:
             data:  Dictionary of datasets. Each key is a `str` representing a node's ID. Each value is
                 a `dict` (or a `list` containing exactly one `dict`). Each `dict` contains the description
                 of the dataset associated to this node in the federated dataset.
-
-        Raises:
-            FedbiomedFederatedDataSetError: bad `data` format
         """
         # check structure of data
+
         if data is not None:
             self.set_federated_dataset(data)
         else:
@@ -45,12 +44,36 @@ class FederatedDataSet:
             FedbiomedFederatedDataSetError: bad `data` format
         """
         # check structure of data
+        # DEPRECATED: to be removed in future versions
+        if isinstance(datasets, FederatedDataSet):
+            logger.warning(
+                "DEPRECATED: Passing a `FederatedDataSet` instance"
+                " to the `data` parameter of `FederatedDataSet` is deprecated and "
+                "will not be supported in future versions. Please pass a `dict` "
+                "representing the federated dataset instead."
+            )
+            datasets = datasets.data()
 
         if isinstance(datasets, dict) is False:
             raise FedbiomedError(
                 f"{ErrorNumbers.FB416.value}: bad parameter `data` must be a `dict` of "
                 f"(`list` of one) `dict`."
             )
+
+        for node_id, node_data in datasets.items():
+            if not (isinstance(node_data, dict) or isinstance(node_data, list)):
+                raise FedbiomedError(
+                    f"{ErrorNumbers.FB416.value}: bad parameter `data` for node {node_id}. "
+                    f"Must be a `dict` or a `list` containing exactly one `dict`."
+                )
+            if isinstance(node_data, list):
+                if len(node_data) != 1 or not isinstance(node_data[0], dict):
+                    raise FedbiomedError(
+                        f"{ErrorNumbers.FB416.value}: bad parameter `data` for node {node_id}. "
+                        f"Must be a `dict` or a `list` containing exactly one `dict`."
+                    )
+                else:
+                    datasets[node_id] = node_data[0]
 
         self._data = datasets
 

--- a/fedbiomed/researcher/federated_workflows/_experiment.py
+++ b/fedbiomed/researcher/federated_workflows/_experiment.py
@@ -1432,7 +1432,7 @@ class Experiment(TrainingPlanWorkflow):
     ) -> None:
         """Updates [`NodeStateAgent`][fedbiomed.researcher.node_state_agent.NodeStateAgent], with the latest
         state_id coming from `Nodes` contained among all `Nodes` within
-        [`FederatedDataset`][fedbiomed.researcher.datasets.FederatedDataSet].
+        [`FederatedDataset`][fedbiomed.researcher.datasets.FederatedDataset].
 
         Args:
             before_training: whether to update `NodeStateAgent` at the beginning or at the end of a `Round`:

--- a/fedbiomed/researcher/federated_workflows/_experiment.py
+++ b/fedbiomed/researcher/federated_workflows/_experiment.py
@@ -30,7 +30,6 @@ from fedbiomed.common.optimizers import (
 )
 from fedbiomed.common.serializer import Serializer
 from fedbiomed.researcher.aggregators import Aggregator, FedAverage
-from fedbiomed.researcher.datasets import FederatedDataSet
 from fedbiomed.researcher.federated_workflows.jobs import TrainingJob
 from fedbiomed.researcher.filetools import choose_bkpt_file
 from fedbiomed.researcher.monitor import Monitor
@@ -404,41 +403,11 @@ class Experiment(TrainingPlanWorkflow):
             # at this point, `aggregator` is an instance / inheriting of `Aggregator`
             self._aggregator = aggregator
         self.aggregator_args["aggregator_name"] = self._aggregator.aggregator_name
-        # ensure consistency with federated dataset
+
+        # Set federated dataset
         self._aggregator.set_fds(self._fds)
 
         return self._aggregator
-
-    @exp_exceptions
-    def set_training_data(
-        self,
-        training_data: Union[FederatedDataSet, dict, None],
-        from_tags: bool = False,
-    ) -> Union[FederatedDataSet, None]:
-        """Sets training data for federated training + verification on arguments type
-
-        See
-        [`FederatedWorkflow.set_training_data`][fedbiomed.researcher.federated_workflows.FederatedWorkflow.set_training_data]
-        for more information.
-
-        Ensures consistency also with the Experiment's aggregator and node state agent
-
-        !!! warning "Setting to None forfeits consistency checks"
-            Setting training_data to None does not trigger consistency checks, and may therefore leave the class in an
-            inconsistent state.
-
-        Returns:
-            Dataset metadata
-        """
-        super().set_training_data(training_data, from_tags)
-        # Below: Experiment-specific operations for consistency
-        if self._aggregator is not None and self._fds is not None:
-            # update the aggregator's training data
-            self._aggregator.set_fds(self._fds)
-        if self._node_state_agent is not None and self._fds is not None:
-            # update the node state agent (member of FederatedWorkflow)
-            self._node_state_agent.update_node_states(self.all_federation_nodes())
-        return self._fds
 
     @exp_exceptions
     def set_agg_optimizer(
@@ -793,8 +762,6 @@ class Experiment(TrainingPlanWorkflow):
         # Collect auxiliary variables from the aggregator optimizer, if any.
         optim_aux_var = self._collect_optim_aux_var()
 
-        # update node states when list of nodes has changed from one round to another
-        self._update_nodes_states_agent(before_training=True)
         # TODO check node state agent
         nodes_state_ids = self._node_state_agent.get_last_node_states()
 
@@ -839,9 +806,7 @@ class Experiment(TrainingPlanWorkflow):
         )
 
         # Update node states with node answers + when used node list has changed during the round.
-        self._update_nodes_states_agent(
-            before_training=False, training_replies=training_replies
-        )
+        self._update_nodes_states_agent(training_replies=training_replies)
 
         # (Secure-)Aggregate model parameters and optimizer auxiliary variables.
         if self._secagg.active:
@@ -1463,7 +1428,7 @@ class Experiment(TrainingPlanWorkflow):
         return Optimizer.load_state(state)
 
     def _update_nodes_states_agent(
-        self, before_training: bool = True, training_replies: Optional[Dict] = None
+        self, training_replies: Optional[Dict] = None
     ) -> None:
         """Updates [`NodeStateAgent`][fedbiomed.researcher.node_state_agent.NodeStateAgent], with the latest
         state_id coming from `Nodes` contained among all `Nodes` within
@@ -1479,18 +1444,13 @@ class Experiment(TrainingPlanWorkflow):
         Raises:
             FedBiomedNodeStateAgenError: failing to update `NodeStateAgent`.
         """
-        node_ids = self.all_federation_nodes()
-        if before_training:
-            self._node_state_agent.update_node_states(node_ids)
-            return
-
         # extract last node state
         if training_replies is None:
             raise FedbiomedValueError(
                 f"{ErrorNumbers.FB323.value}: Cannot update NodeStateAgent if No "
                 "replies form Node(s) has(ve) been received!"
             )
-        self._node_state_agent.update_node_states(node_ids, training_replies)
+        self._node_state_agent.update_node_states(training_replies)
 
     @staticmethod
     @exp_exceptions

--- a/fedbiomed/researcher/federated_workflows/_federated_analytics.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_analytics.py
@@ -64,7 +64,9 @@ class FederatedAnalytics:
 
         return node_ids
 
-    def mean(self, col_names: Optional[list[str | int]]) -> Union[Any, Dict[str, Any]]:
+    def mean(
+        self, col_names: Optional[list[str | int]] = None
+    ) -> Union[Any, Dict[str, Any]]:
         """Compute mean analytics across nodes.
 
         Returns:

--- a/fedbiomed/researcher/federated_workflows/_federated_analytics.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_analytics.py
@@ -2,7 +2,7 @@ import uuid
 from typing import Any, Dict, Optional, Union
 
 from fedbiomed.common.exceptions import FedbiomedExperimentError
-from fedbiomed.researcher.datasets import FederatedDataSet
+from fedbiomed.researcher.datasets import FederatedDataset
 from fedbiomed.researcher.federated_workflows.jobs import FARequestJob
 from fedbiomed.researcher.requests import Requests
 
@@ -15,7 +15,7 @@ class FederatedAnalytics:
 
     def __init__(
         self,
-        fds: FederatedDataSet,
+        fds: FederatedDataset,
         experiment_id: str,
         researcher_id: str,
         reqs: Requests,
@@ -52,7 +52,7 @@ class FederatedAnalytics:
         """
         if self._fds is None:
             raise FedbiomedExperimentError(
-                "No defined FederatedDataSet found for FederatedAnalytics."
+                "No defined FederatedDataset found for FederatedAnalytics."
             )
 
         node_ids = self._fds.node_ids()
@@ -74,7 +74,7 @@ class FederatedAnalytics:
         """
         if self._fds is None:
             raise FedbiomedExperimentError(
-                "No defined FederatedDataSet found for FederatedAnalytics."
+                "No defined FederatedDataset found for FederatedAnalytics."
             )
 
         node_ids = self.get_node_ids()

--- a/fedbiomed/researcher/federated_workflows/_federated_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_workflow.py
@@ -147,7 +147,7 @@ class FederatedWorkflow(ABC):
         self,
         tags: Optional[List[str] | str] = None,
         nodes: Optional[List[str]] = None,
-        training_data: Optional[Dict] = None,
+        training_data: Optional[FederatedDataSet | Dict] = None,
         experimentation_folder: Union[str, None] = None,
         secagg: Union[bool, SecureAggregation] = False,
         save_breakpoints: bool = False,
@@ -203,11 +203,7 @@ class FederatedWorkflow(ABC):
         self.config = config
         # predefine all class variables, so no need to write try/except
         # block each time we use it
-        self._fds: Optional[FederatedDataSet] = (
-            self.set_training_data(training_data=training_data)
-            if training_data
-            else FederatedDataSet()
-        )
+        self._fds: Optional[FederatedDataSet] = FederatedDataSet(training_data)
 
         self._reqs: Requests = Requests(config=self.config)
         self._nodes_filter: Optional[List[str]] = (
@@ -240,16 +236,11 @@ class FederatedWorkflow(ABC):
         if tags:
             self.set_tags(tags)
 
-        if training_data:
-            self.set_training_data(training_data)
-
         self.set_nodes(nodes)
         self.set_save_breakpoints(save_breakpoints)
 
         self.set_experimentation_folder(experimentation_folder)
-        self._node_state_agent = NodeStateAgent(
-            list(self._fds.data().keys()) if self._fds and self._fds.data() else []
-        )
+        self._node_state_agent = NodeStateAgent(federated_dataset=self._fds)
 
         self.analytics = FederatedAnalytics(
             fds=self._fds,
@@ -475,14 +466,14 @@ class FederatedWorkflow(ABC):
         # (value None == not defined yet for _fds,)
 
         _not_runable_if_missing = {
-            "Training Data": self._fds,
+            "Training Data": self._fds.data(),
         }
 
         if missing_objects:
             _not_runable_if_missing.update(missing_objects)
         missing: str = ""
         for key, value in _not_runable_if_missing.items():
-            if value in (None, False):
+            if value in (None, False, {}):
                 missing += f"- {key}\n"
 
         return missing
@@ -662,7 +653,7 @@ class FederatedWorkflow(ABC):
                 )
 
         if isinstance(training_data, dict):
-            self._fds = self._fds.set_federated_dataset(training_data)
+            self._fds.set_federated_dataset(training_data)
         else:
             raise FedbiomedTypeError(
                 ErrorNumbers.FB410.value
@@ -941,7 +932,7 @@ class FederatedWorkflow(ABC):
         # initializing experiment
         loaded_exp = cls(experimentation_folder=exp_folder)
         loaded_exp._experiment_id = saved_state.get("id")
-        loaded_exp.set_training_data(bkpt_fds)
+        loaded_exp._fds = bkpt_fds
         loaded_exp._tags = saved_state.get("tags")
         loaded_exp.set_nodes(saved_state.get("nodes"))
 

--- a/fedbiomed/researcher/federated_workflows/_federated_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_workflow.py
@@ -147,7 +147,7 @@ class FederatedWorkflow(ABC):
         self,
         tags: Optional[List[str] | str] = None,
         nodes: Optional[List[str]] = None,
-        training_data: Union[FederatedDataSet, dict, None] = None,
+        training_data: Optional[Dict] = None,
         experimentation_folder: Union[str, None] = None,
         secagg: Union[bool, SecureAggregation] = False,
         save_breakpoints: bool = False,
@@ -204,8 +204,11 @@ class FederatedWorkflow(ABC):
         # predefine all class variables, so no need to write try/except
         # block each time we use it
         self._fds: Optional[FederatedDataSet] = (
-            None  # dataset metadata from the full federation
+            self.set_training_data(training_data=training_data)
+            if training_data
+            else FederatedDataSet()
         )
+
         self._reqs: Requests = Requests(config=self.config)
         self._nodes_filter: Optional[List[str]] = (
             None  # researcher-defined nodes filter
@@ -589,7 +592,7 @@ class FederatedWorkflow(ABC):
     @exp_exceptions
     def set_training_data(
         self,
-        training_data: Union[FederatedDataSet, dict, None],
+        training_data: Union[Dict, None],
         from_tags: bool = False,
     ) -> Union[FederatedDataSet, None]:
         """Sets training data for federated training + verification on arguments type
@@ -631,52 +634,40 @@ class FederatedWorkflow(ABC):
         """
 
         if not isinstance(from_tags, bool):
-            msg = (
-                ErrorNumbers.FB410.value
-                + f" `from_tags` : got {type(from_tags)} but expected a boolean"
+            raise FedbiomedTypeError(
+                f"{ErrorNumbers.FB410.value} `from_tags` has incorrect type: {type(from_tags)} "
+                "but expected a boolean"
             )
-            logger.critical(msg)
-            raise FedbiomedTypeError(msg)
+
         if from_tags and training_data is not None:
-            msg = (
-                ErrorNumbers.FB410.value
-                + " set_training_data: cannot specify a training_data argument if "
-                "from_tags is True"
+            raise FedbiomedValueError(
+                f"{ErrorNumbers.FB410.value}: set_training_data: cannot specify a training_data "
+                "argument if from_tags is True"
             )
-            logger.critical(msg)
-            raise FedbiomedValueError(msg)
 
         # case where no training data are passed
         if training_data is None:
             if from_tags is True:
                 if not self._tags:
-                    msg = (
+                    raise FedbiomedValueError(
                         f"{ErrorNumbers.FB410.value}: attempting to "
                         "set training data from undefined tags. Please consider set tags before "
                         "using set_tags method of the experiment."
                     )
-                    logger.critical(msg)
-                    raise FedbiomedValueError(msg)
                 training_data = self._reqs.search(self._tags, self._nodes_filter)
             else:
-                msg = (
+                raise FedbiomedValueError(
                     f"{ErrorNumbers.FB410.value}: Can not set training data to `None`. "
                     "Please set from_tags=True or provide a valid training data"
                 )
-                logger.critical(msg)
-                raise FedbiomedValueError(msg)
 
-        if isinstance(training_data, FederatedDataSet):
-            self._fds = training_data
-        elif isinstance(training_data, dict):
-            self._fds = FederatedDataSet(training_data)
+        if isinstance(training_data, dict):
+            self._fds = self._fds.set_federated_dataset(training_data)
         else:
-            msg = (
+            raise FedbiomedTypeError(
                 ErrorNumbers.FB410.value
                 + f" `training_data` has incorrect type: {type(training_data)}"
             )
-            logger.critical(msg)
-            raise FedbiomedTypeError(msg)
 
         # check and ensure consistency
         self._tags = self._tags if from_tags else None

--- a/fedbiomed/researcher/federated_workflows/_federated_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_workflow.py
@@ -36,7 +36,7 @@ from fedbiomed.common.ipython import is_ipython
 from fedbiomed.common.logger import logger
 from fedbiomed.common.utils import __default_version__, raise_for_version_compatibility
 from fedbiomed.researcher.config import config
-from fedbiomed.researcher.datasets import FederatedDataSet
+from fedbiomed.researcher.datasets import FederatedDataset
 from fedbiomed.researcher.federated_workflows._federated_analytics import (
     FederatedAnalytics,
 )
@@ -147,7 +147,7 @@ class FederatedWorkflow(ABC):
         self,
         tags: Optional[List[str] | str] = None,
         nodes: Optional[List[str]] = None,
-        training_data: Optional[FederatedDataSet | Dict] = None,
+        training_data: Optional[FederatedDataset | Dict] = None,
         experimentation_folder: Union[str, None] = None,
         secagg: Union[bool, SecureAggregation] = False,
         save_breakpoints: bool = False,
@@ -164,8 +164,8 @@ class FederatedWorkflow(ABC):
                 Defaults to None (no filtering).
 
             training_data:
-                * If it is a FederatedDataSet object, use this value as training_data.
-                * else if it is a dict, create and use a FederatedDataSet object
+                * If it is a FederatedDataset object, use this value as training_data.
+                * else if it is a dict, create and use a FederatedDataset object
                     from the dict and use this value as training_data. The dict should use
                     node ids as keys, values being list of dicts (each dict representing a
                     dataset on a node).
@@ -203,7 +203,7 @@ class FederatedWorkflow(ABC):
         self.config = config
         # predefine all class variables, so no need to write try/except
         # block each time we use it
-        self._fds: Optional[FederatedDataSet] = FederatedDataSet(training_data)
+        self._fds: FederatedDataset = FederatedDataset(training_data)
 
         self._reqs: Requests = Requests(config=self.config)
         self._nodes_filter: Optional[List[str]] = (
@@ -320,9 +320,9 @@ class FederatedWorkflow(ABC):
             return self.all_federation_nodes()
 
     @exp_exceptions
-    def training_data(self) -> Union[FederatedDataSet, None]:
+    def training_data(self) -> Union[FederatedDataset, None]:
         """Retrieves the training data which is an instance of
-        [`FederatedDataset`][fedbiomed.researcher.datasets.FederatedDataSet]
+        [`FederatedDataset`][fedbiomed.researcher.datasets.FederatedDataset]
 
         This represents the dataset metadata available for the full federation.
 
@@ -585,7 +585,7 @@ class FederatedWorkflow(ABC):
         self,
         training_data: Union[Dict, None],
         from_tags: bool = False,
-    ) -> Union[FederatedDataSet, None]:
+    ) -> FederatedDataset:
         """Sets training data for federated training + verification on arguments type
 
 
@@ -604,8 +604,8 @@ class FederatedWorkflow(ABC):
 
         Args:
             training_data:
-                * If it is a FederatedDataSet object, use this value as training_data.
-                * else if it is a dict, create and use a FederatedDataSet object from the dict
+                * If it is a FederatedDataset object, use this value as training_data.
+                * else if it is a dict, create and use a FederatedDataset object from the dict
                   and use this value as training_data. The dict should use node ids as keys,
                   values being list of dicts (each dict representing a dataset on a node).
                 * else if it is None (no training data provided)
@@ -617,7 +617,7 @@ class FederatedWorkflow(ABC):
                 Not used when `training_data` is provided.
 
         Returns:
-            FederatedDataSet metadata
+            FederatedDataset metadata
 
         Raises:
             FedbiomedTypeError: bad training_data or from_tags type.
@@ -924,7 +924,7 @@ class FederatedWorkflow(ABC):
 
         # retrieve breakpoint training data
         bkpt_fds = saved_state.get("training_data")
-        bkpt_fds = FederatedDataSet(bkpt_fds)
+        bkpt_fds = FederatedDataset(bkpt_fds)
 
         # retrieve experimentation folder
         exp_folder = saved_state.get("experimentation_folder")

--- a/fedbiomed/researcher/federated_workflows/jobs/_training_job.py
+++ b/fedbiomed/researcher/federated_workflows/jobs/_training_job.py
@@ -11,7 +11,7 @@ from fedbiomed.common.optimizers import AuxVar, EncryptedAuxVar
 from fedbiomed.common.serializer import Serializer
 from fedbiomed.common.training_args import TrainingArgs
 from fedbiomed.common.training_plans import BaseTrainingPlan
-from fedbiomed.researcher.datasets import FederatedDataSet
+from fedbiomed.researcher.datasets import FederatedDataset
 from fedbiomed.researcher.requests import MessagesByNode
 
 from ._job import Job
@@ -30,7 +30,7 @@ class TrainingJob(Job):
         training_plan: BaseTrainingPlan,
         training_args: TrainingArgs,
         model_args: Optional[dict],
-        data: FederatedDataSet,
+        data: FederatedDataset,
         nodes_state_ids: Dict[str, str],
         aggregator_args: Dict[str, Dict[str, Any]],
         keep_files_dir: str,

--- a/fedbiomed/researcher/node_state_agent.py
+++ b/fedbiomed/researcher/node_state_agent.py
@@ -1,10 +1,11 @@
 # This file is originally part of Fed-BioMed
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 from fedbiomed.common.constants import ErrorNumbers
 from fedbiomed.common.exceptions import FedbiomedNodeStateAgentError
+from fedbiomed.researcher.datasets import FederatedDataset
 
 
 class NodeStateAgent:
@@ -13,7 +14,7 @@ class NodeStateAgent:
     Manages Node States collection, gathered from `Nodes` replies.
     """
 
-    def __init__(self, federated_dataset: List[str]) -> None:
+    def __init__(self, federated_dataset: FederatedDataset) -> None:
         """Constructor for NodeStateAgent.
 
         Initializes state ID of each node provided in `node_ids` to None (will maintain state,

--- a/fedbiomed/researcher/node_state_agent.py
+++ b/fedbiomed/researcher/node_state_agent.py
@@ -13,7 +13,7 @@ class NodeStateAgent:
     Manages Node States collection, gathered from `Nodes` replies.
     """
 
-    def __init__(self, node_ids: List[str]) -> None:
+    def __init__(self, federated_dataset: List[str]) -> None:
         """Constructor for NodeStateAgent.
 
         Initializes state ID of each node provided in `node_ids` to None (will maintain state,
@@ -22,8 +22,9 @@ class NodeStateAgent:
         Args:
             node_ids: list of node IDs of the nodes for which to maintain state ID
         """
+        self._fds = federated_dataset
         self._collection_state_ids: Dict[str, str] = {  # Mapping <node_id, state_id>
-            node_id: None for node_id in node_ids
+            node_id: None for node_id in self._fds.data().keys()
         }
 
     def get_last_node_states(self) -> Dict[str, str]:
@@ -34,9 +35,9 @@ class NodeStateAgent:
         Returns:
             Mapping of `<node_id, state_id>`
         """
-        return self._collection_state_ids
+        return self._update_collection_state_ids()
 
-    def update_node_states(self, all_node_ids: List[str], resp: Optional[Dict] = None):
+    def update_node_states(self, resp: Optional[Dict] = None):
         """Updates the state_id collection with respect to current nodes and latest Nodes replies.
 
         Adds node IDs contained in node_ids argument that was not part of the previous Round, and discards node_ids that
@@ -50,7 +51,8 @@ class NodeStateAgent:
             FedbiomedNodeStateAgentError: raised if Nodes replies have a missing entry that needs to be collected.
         """
         # first, we update _collection_state_id wrt new FederatedDataset (if it has been modified)
-        self._update_collection_state_ids(all_node_ids)
+        self._update_collection_state_ids()
+
         if resp is not None:
             for node_reply in resp.values():
                 # adds Node replies
@@ -63,13 +65,15 @@ class NodeStateAgent:
                 if node_id in self._collection_state_ids:
                     self._collection_state_ids[node_id] = state_id
 
-    def _update_collection_state_ids(self, node_ids: List[str]):
+    def _update_collection_state_ids(self):
         """Adds node_ids contained in self._data argument that was not part of the previous Round,
         and discards node_ids that do not belong to the current Round anymore.
 
         Args:
             node_ids: all possible nodes that can participate to the training.
         """
+        node_ids = self._fds.data().keys()
+
         for node_id in node_ids:
             if self._collection_state_ids.get(node_id, False) is False:
                 self._collection_state_ids[node_id] = None
@@ -77,6 +81,8 @@ class NodeStateAgent:
             if node_id not in node_ids:
                 # remove previous node_ids of collection_state_ids if _data has changed
                 self._collection_state_ids.pop(node_id)
+
+        return self._collection_state_ids
 
     def save_state_breakpoint(self) -> Dict:
         """NodeStateAgent's state, to be saved in a breakpoint.

--- a/notebooks/federated_analytics.ipynb
+++ b/notebooks/federated_analytics.ipynb
@@ -42,72 +42,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "badf7637",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "2025-12-18 09:18:57,584 fedbiomed INFO - Starting researcher service..."
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "2025-12-18 09:18:57,585 fedbiomed INFO - Waiting 3s for nodes to connect..."
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "2025-12-18 09:18:58,615 fedbiomed DEBUG - Node: NODE_dc886f2b-e4c7-48c9-bf4b-0ce6ca987356 polling for the tasks"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "2025-12-18 09:19:00,592 fedbiomed INFO - Updating training data. This action will update FederatedDataset, and the nodes that will participate to the experiment."
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "2025-12-18 09:19:00,649 fedbiomed DEBUG - Node: NODE_dc886f2b-e4c7-48c9-bf4b-0ce6ca987356 polling for the tasks"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "2025-12-18 09:19:00,652 fedbiomed INFO - Node selected for training -> Default Node Name\n",
-       "Node ID is -> NODE_dc886f2b-e4c7-48c9-bf4b-0ce6ca987356"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from fedbiomed.researcher.federated_workflows import Experiment\n",
     "\n",
-    "tags =  ['adni']\n",
+    "tags =  ['#UsedCars']\n",
     "\n",
     "exp = Experiment(tags=tags)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da553c3a-17ff-4369-876f-c67c8a028027",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exp.analytics.mean(col_names=[\"mpg\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7622f893-0f35-4896-a830-1deb25852ab3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exp.set_tags(tags=['adni'])"
    ]
   },
   {
@@ -130,27 +94,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "c45bb304",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "2025-12-18 09:19:33,153 fedbiomed DEBUG - Node: NODE_dc886f2b-e4c7-48c9-bf4b-0ce6ca987356 polling for the tasks"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "reply = exp.analytics.mean(col_names=['AGE', 'FAQ.bl'])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "0e6631d0-24c1-4ed5-9a52-d8673f914707",
    "metadata": {},
    "outputs": [],
@@ -160,165 +114,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "1cd7ffe3-c43e-41d4-a005-20ee05c137da",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'AGE': 72.81333333333333, 'FAQ.bl': 4.473333333333334}"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "2025-12-18 09:21:50,706 fedbiomed DEBUG - Node: NODE_15db82a3-d9e1-4be5-b4d1-1f1eeb90797d polling for the tasks"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "2025-12-18 09:22:15,268 fedbiomed WARNING - Node NODE_dc886f2b-e4c7-48c9-bf4b-0ce6ca987356 is disconnected. Request/task that are created for this node will be flushed"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "reply[0][node_id].output"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "id": "262335b1-0b3b-4622-89e1-9ea5c7392073",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "2025-12-18 09:24:22,454 fedbiomed INFO - Updating training data. This action will update FederatedDataset, and the nodes that will participate to the experiment."
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "2025-12-18 09:24:22,458 fedbiomed INFO - Node NODE_dc886f2b-e4c7-48c9-bf4b-0ce6ca987356 is disconnected. Discard message."
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "2025-12-18 09:24:22,516 fedbiomed DEBUG - Node: NODE_15db82a3-d9e1-4be5-b4d1-1f1eeb90797d polling for the tasks"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "2025-12-18 09:24:22,517 fedbiomed INFO - Node selected for training -> Default Node Name\n",
-       "Node ID is -> NODE_15db82a3-d9e1-4be5-b4d1-1f1eeb90797d"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "['#UsedCars']"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "tags = [\"#UsedCars\"]\n",
-    "exp.set_tags(tags)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "abba1aa9-2801-4f17-9a09-59aece41b71e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "2025-12-18 09:23:29,380 fedbiomed INFO - Node NODE_dc886f2b-e4c7-48c9-bf4b-0ce6ca987356 is disconnected. Discard message."
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "reply = exp.analytics.mean(col_names=['mpg'])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "77106783-9b6f-43cd-8a92-3ea8daa7caad",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'NODE_dc886f2b-e4c7-48c9-bf4b-0ce6ca987356': {'name': 'asdas',\n",
-       "  'data_type': 'csv',\n",
-       "  'tags': ['adni'],\n",
-       "  'description': 'saddasd',\n",
-       "  'shape': {'csv': [300, 20]},\n",
-       "  'dtypes': {'': 'Int64',\n",
-       "   'SEX': 'Float64',\n",
-       "   'AGE': 'Float64',\n",
-       "   'PTEDUCAT': 'Float64',\n",
-       "   'CDRSB.bl': 'Int64',\n",
-       "   'ADAS11.bl': 'Int64',\n",
-       "   'MMSE.bl': 'Float64',\n",
-       "   'RAVLT.immediate.bl': 'Float64',\n",
-       "   'RAVLT.learning.bl': 'Float64',\n",
-       "   'RAVLT.forgetting.bl': 'Float64',\n",
-       "   'FAQ.bl': 'Int64',\n",
-       "   'WholeBrain.bl': 'Float64',\n",
-       "   'Ventricles.bl': 'Float64',\n",
-       "   'Hippocampus.bl': 'Float64',\n",
-       "   'MidTemp.bl': 'Float64',\n",
-       "   'Entorhinal.bl': 'Float64',\n",
-       "   'APOE4': 'Int64',\n",
-       "   'ABETA.MEDIAN.bl': 'Float64',\n",
-       "   'PTAU.MEDIAN.bl': 'Float64',\n",
-       "   'TAU.MEDIAN.bl': 'Float64'},\n",
-       "  'dataset_id': 'dataset_2f44b161-8bdd-4f5a-8eb5-bd478ee2c0e5',\n",
-       "  'dataset_parameters': {}}}"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "exp.analytics._fds.data()\n"
    ]

--- a/notebooks/general-breakpoint-save-resume.ipynb
+++ b/notebooks/general-breakpoint-save-resume.ipynb
@@ -157,6 +157,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b60083bf-852b-45b9-9487-4aaa673a09d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exp._node_state_agent._collection_state_ids\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "0193d7a3",
    "metadata": {},
@@ -276,6 +286,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bce4c565-4612-4343-9312-83ff4cf103e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loaded_exp._node_state_agent._collection_state_ids\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "c66af119",
    "metadata": {},
@@ -384,7 +404,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.16"
   },
   "vscode": {
    "interpreter": {

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,7 +1,8 @@
 import unittest
+
 from fedbiomed.common.constants import TrainingPlans
 from fedbiomed.researcher.aggregators.aggregator import Aggregator
-from fedbiomed.researcher.datasets import FederatedDataSet
+from fedbiomed.researcher.datasets import FederatedDataset
 
 
 class TestAggregator(unittest.TestCase):
@@ -56,7 +57,7 @@ class TestAggregator(unittest.TestCase):
         )
 
     def test_4_set_fds(self):
-        fds = FederatedDataSet({})
+        fds = FederatedDataset({})
         self.aggregator.set_fds(fds)
         self.assertEqual(fds, self.aggregator._fds)
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,7 +1,7 @@
 import pytest
 
 from fedbiomed.common.exceptions import FedbiomedError
-from fedbiomed.researcher.datasets import FederatedDataSet
+from fedbiomed.researcher.datasets import FederatedDataset
 
 data = {
     "node-1": [{"dataset_id": "dataset-id-1", "shape": [100, 100]}],
@@ -12,7 +12,7 @@ data = {
 # before the tests
 @pytest.fixture
 def fds():
-    return FederatedDataSet(data)
+    return FederatedDataset(data)
 
 
 def test_federated_dataset_01_create_error():
@@ -27,7 +27,7 @@ def test_federated_dataset_01_create_error():
     for data in data_list:
         # test + check
         with pytest.raises(FedbiomedError):
-            FederatedDataSet(data)
+            FederatedDataset(data)
 
 
 def test_federated_dataset_02_data(fds):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,97 +1,75 @@
-import unittest
+import pytest
 
-from fedbiomed.common.exceptions import FedbiomedFederatedDataSetError
-
-
+from fedbiomed.common.exceptions import FedbiomedError
 from fedbiomed.researcher.datasets import FederatedDataSet
 
+data = {
+    "node-1": [{"dataset_id": "dataset-id-1", "shape": [100, 100]}],
+    "node-2": [{"dataset_id": "dataset-id-2", "shape": [120, 120], "test_ratio": 0.0}],
+}
 
-class TestFederatedDataset(unittest.TestCase):
+
+# before the tests
+@pytest.fixture
+def fds():
+    return FederatedDataSet(data)
+
+
+def test_federated_dataset_01_create_error():
+    """Testing creation with incorrect data"""
+    # prepare
+    data_list = [
+        3,
+        (2,),
+        [],
+    ]
+
+    for data in data_list:
+        # test + check
+        with pytest.raises(FedbiomedError):
+            FederatedDataSet(data)
+
+
+def test_federated_dataset_02_data(fds):
+    """Testing property .data()"""
+
+    updated_data = fds.data()
+    # federated dataset should have added a new entry `test_ratio` in the FederatedDataset
+    assert data == updated_data, "Can not get data properly from FederatedDataset"
+
+
+def test_federated_dataset_04_node_ids(fds):
+    """Testing node_ids getter/properties
+    FIXME: When refactoring properties as getters
     """
-    Test `FederatedDataset` class
-    Args:
-        unittest ([type]): [description]
+
+    node_ids = fds.node_ids()
+    assert node_ids == ["node-1", "node-2"], (
+        "Can not get node ids of FederatedDataset properly"
+    )
+
+
+def test_federated_dataset_05_sample_sizes(fds):
+    """Testing node_ids getter/properties
+    FIXME: When refactoring properties as getters
     """
-
-    # before the tests
-    def setUp(self):
-        self.data = {
-            "node-1": [{"dataset_id": "dataset-id-1", "shape": [100, 100]}],
-            "node-2": [
-                {"dataset_id": "dataset-id-2", "shape": [120, 120], "test_ratio": 0.0}
-            ],
-        }
-
-        self.fds = FederatedDataSet(self.data)
-
-    # after the tests
-    def tearDown(self):
-        pass
-
-    def test_federated_dataset_01_create_error(self):
-        """Testing creation with incorrect data"""
-        # prepare
-        data_list = [
-            3,
-            (2,),
-            [],
-            {3: {"dataset_id": "my_dataset"}},
-            {"my_node_with_no_dataset": []},
-            {"my_node_with_2_datasets": [{}, {}]},
-        ]
-
-        for data in data_list:
-            # test + check
-            with self.assertRaises(FedbiomedFederatedDataSetError):
-                FederatedDataSet(data)
-
-    def test_federated_dataset_02_data(self):
-        """Testing property .data()"""
-
-        updated_data = self.fds.data()
-        # federated dataset should have added a new entry `test_ratio` in the FederatedDataset
-        self.assertDictEqual(
-            self.data, updated_data, "Can not get data properly from FederatedDataset"
-        )
-
-    def test_federated_dataset_04_node_ids(self):
-        """Testing node_ids getter/properties
-        FIXME: When refactoring properties as getters
-        """
-
-        node_ids = self.fds.node_ids()
-        self.assertListEqual(
-            node_ids,
-            ["node-1", "node-2"],
-            "Can not get node ids of FederatedDataset properly",
-        )
-
-    def test_federated_dataset_05_sample_sizes(self):
-        """Testing node_ids getter/properties
-        FIXME: When refactoring properties as getters
-        """
-        # Nothing to do it is an empty method
-        sizes = [val["shape"][0] for (_, val) in self.data.items()]
-        sample_sizes = self.fds.sample_sizes()
-        self.assertListEqual(
-            sizes,
-            sample_sizes,
-            "Provided sample sizes and result of sample_sizes do not match",
-        )
-
-    def test_federated_dataset_06_shapes(self):
-        """Testing shapes property of FederatedDataset"""
-
-        node_1 = list(self.data.keys())[0]
-        node_2 = list(self.data.keys())[1]
-
-        size_1 = self.data[node_1]["shape"][0]
-        size_2 = self.data[node_2]["shape"][0]
-
-        shapes = self.fds.shapes()
-        self.assertEqual(shapes[node_1], size_1)
-        self.assertEqual(shapes[node_2], size_2)
+    # Nothing to do it is an empty method
+    sizes = [val["shape"][0] for (_, val) in data.items()]
+    sample_sizes = fds.sample_sizes()
+    assert sizes == sample_sizes, (
+        "Provided sample sizes and result of sample_sizes do not match"
+    )
 
 
-if __name__ == "__main__":  # pragma: no cover
-    unittest.main()
+def test_federated_dataset_06_shapes(fds):
+    """Testing shapes property of FederatedDataset"""
+
+    node_1 = list(data.keys())[0]
+    node_2 = list(data.keys())[1]
+
+    size_1 = data[node_1]["shape"][0]
+    size_2 = data[node_2]["shape"][0]
+
+    shapes = fds.shapes()
+    assert shapes[node_1] == size_1
+    assert shapes[node_2] == size_2

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -16,7 +16,7 @@ from fedbiomed.common.metrics import MetricTypes
 from fedbiomed.common.optimizers import AuxVar
 from fedbiomed.common.training_args import TrainingArgs
 from fedbiomed.researcher.aggregators.aggregator import Aggregator
-from fedbiomed.researcher.datasets import FederatedDataSet
+from fedbiomed.researcher.datasets import FederatedDataset
 from fedbiomed.researcher.federated_workflows import Experiment
 from fedbiomed.researcher.federated_workflows.jobs import TrainingJob
 from fedbiomed.researcher.monitor import Monitor
@@ -135,7 +135,7 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
             aggregator_name = "aggregator"
             is_set_fds_called = False
 
-            def set_fds(self, fds: FederatedDataSet) -> FederatedDataSet:
+            def set_fds(self, fds: FederatedDataset) -> FederatedDataset:
                 if not self.is_set_fds_called:
                     self.is_set_fds_called = True
                 return super().set_fds(fds)
@@ -236,7 +236,7 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
         exp._fds = None
         with self.assertRaises(SystemExit):
             exp.run_once()
-        exp._fds = FederatedDataSet(_training_data)
+        exp._fds = FederatedDataset(_training_data)
         # -------------------------------------------------------------
 
         # Run experiment ----------------------------------------------

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,33 +1,28 @@
 import unittest
 from itertools import product
-from unittest.mock import create_autospec, MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 from declearn.model.api import Vector
-
-from fedbiomed.common.exceptions import FedbiomedValueError, FedbiomedExperimentError
-from fedbiomed.common.training_args import TrainingArgs
-from fedbiomed.common.metrics import MetricTypes
-
-from fedbiomed.researcher.aggregators.aggregator import Aggregator
-from fedbiomed.researcher.datasets import FederatedDataSet
-
-from fedbiomed.researcher.strategies.default_strategy import DefaultStrategy
-from fedbiomed.researcher.monitor import Monitor
-from fedbiomed.researcher.node_state_agent import NodeStateAgent
+from declearn.optimizer.modules import AuxVar
 from testsupport.base_mocks import MockRequestModule
 from testsupport.fake_training_plan import (
-    FakeTorchTrainingPlan,
     FakeSKLearnTrainingPlan,
+    FakeTorchTrainingPlan,
 )
 
-
-from declearn.optimizer.modules import AuxVar
-
 import fedbiomed
+from fedbiomed.common.exceptions import FedbiomedExperimentError
+from fedbiomed.common.metrics import MetricTypes
 from fedbiomed.common.optimizers import AuxVar
+from fedbiomed.common.training_args import TrainingArgs
+from fedbiomed.researcher.aggregators.aggregator import Aggregator
+from fedbiomed.researcher.datasets import FederatedDataSet
 from fedbiomed.researcher.federated_workflows import Experiment
 from fedbiomed.researcher.federated_workflows.jobs import TrainingJob
+from fedbiomed.researcher.monitor import Monitor
+from fedbiomed.researcher.node_state_agent import NodeStateAgent
 from fedbiomed.researcher.secagg._secure_aggregation import _SecureAggregation
+from fedbiomed.researcher.strategies.default_strategy import DefaultStrategy
 
 
 class TestExperiment(unittest.TestCase, MockRequestModule):
@@ -70,7 +65,11 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
         )  # set by default
 
         # Test all possible combinations of init arguments
-        _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataSet)
+        _training_data = {
+            "node-1": [{"dataset_id": "dataset-id-1", "shape": [100, 100]}],
+            "node-2": [{"dataset_id": "dataset-id-2", "shape": [120, 120]}],
+        }
+
         _secagg = MagicMock(spec=fedbiomed.researcher.secagg.SecureAggregation)
         _aggregator = MagicMock(spec=fedbiomed.researcher.aggregators.Aggregator)
         _aggregator.aggregator_name = "mock aggregator"
@@ -108,15 +107,16 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
     def test_experiment_02_set_aggregator(self):
         """Tests setting the Experiment's aggregator and related side effects"""
         exp = Experiment()
-        _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataSet)
+        _training_data = {
+            "node-1": [{"dataset_id": "dataset-id-1", "shape": [100, 100]}]
+        }
         exp.set_training_data(_training_data)
-
         # test default case
         exp.set_aggregator()
         self.assertIsInstance(
             exp.aggregator(), fedbiomed.researcher.aggregators.FedAverage
         )
-        self.assertEqual(exp.aggregator()._fds, _training_data)
+        self.assertEqual(exp.aggregator()._fds, exp._fds)
 
         # setting through an object instance
         _aggregator = MagicMock(spec=fedbiomed.researcher.aggregators.Aggregator)
@@ -155,7 +155,7 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
         exp.set_aggregator(_aggregator)
         exp.set_training_data(_training_data)
         _aggregator.set_fds.assert_called_with(exp.training_data())
-        self.assertEqual(_aggregator.set_fds.call_count, 2)
+        self.assertEqual(_aggregator.set_fds.call_count, 1)
 
     def test_experiment_03_set_strategy(self):
         """Tests setting the Experiment's node selection strategy and related side effects"""
@@ -197,7 +197,9 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
     #    @patch('fedbiomed.researcher.federated_workflows._experiment.TrainingJob')
     def test_experiment_04_run_once_base_case(self):
         """Tests run once method of experiment"""
-        _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataSet)
+        _training_data = {
+            "node-1": [{"dataset_id": "dataset-id-1", "shape": [100, 100]}]
+        }
         _aggregator = MagicMock(spec=fedbiomed.researcher.aggregators.Aggregator)
         _aggregator.aggregator_name = "mock-aggregator"
         _strategy = MagicMock(
@@ -234,7 +236,7 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
         exp._fds = None
         with self.assertRaises(SystemExit):
             exp.run_once()
-        exp._fds = _training_data
+        exp._fds = FederatedDataSet(_training_data)
         # -------------------------------------------------------------
 
         # Run experiment ----------------------------------------------
@@ -404,7 +406,9 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
     def test_experiment_06_run_once_special_cases(self):
         """Tests running experiment special casses"""
 
-        _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataSet)
+        _training_data = {
+            "node-1": [{"dataset_id": "dataset-id-1", "shape": [100, 100]}]
+        }
         _aggregator = MagicMock(spec=fedbiomed.researcher.aggregators.Aggregator)
         _aggregator.aggregator_name = "mock-aggregator"
         _aggregator.create_aggregator_args.return_value = ({}, {})
@@ -850,26 +854,12 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
         """Tests updating node state agent"""
 
         state_agent = MagicMock(spec=NodeStateAgent)
-        exp = Experiment()
+        exp = Experiment(training_data={"node-1": {"xx": "xx"}, "node-2": {"yy": "yy"}})
         exp._node_state_agent = state_agent
-
-        with patch.object(exp, "all_federation_nodes") as afn:
-            afn.return_value = ["node-1", "node-2"]
-            exp._update_nodes_states_agent(before_training=True, training_replies=None)
-            state_agent.update_node_states.assert_called_once()
-
-        # Test if training replies None while before_training=False
-        with self.assertRaises(FedbiomedValueError):
-            exp._update_nodes_states_agent(False, None)
-
         # Test normal case
         state_agent.reset_mock()
-        with patch.object(exp, "all_federation_nodes") as afn:
-            afn.return_value = ["node-1", "node-2"]
-            exp._update_nodes_states_agent(False, {"hello": "world"})
-            state_agent.update_node_states.assert_called_once_with(
-                ["node-1", "node-2"], {"hello": "world"}
-            )
+        exp._update_nodes_states_agent({"hello": "world"})
+        state_agent.update_node_states.assert_called_once_with({"hello": "world"})
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_federated_analytics.py
+++ b/tests/test_federated_analytics.py
@@ -5,21 +5,21 @@ import numpy as np
 import pytest
 
 from fedbiomed.common.exceptions import FedbiomedExperimentError
-from fedbiomed.researcher.datasets import FederatedDataSet
+from fedbiomed.researcher.datasets import FederatedDataset
 from fedbiomed.researcher.federated_workflows import FederatedAnalytics
 from fedbiomed.researcher.requests import Requests
 
 
 @pytest.fixture
 def mock_fds():
-    fds = MagicMock(spec=FederatedDataSet)
+    fds = MagicMock(spec=FederatedDataset)
     fds.node_ids.return_value = ["node-1", "node-2"]
     return fds
 
 
 @pytest.fixture
 def empty_fds():
-    fds = MagicMock(spec=FederatedDataSet)
+    fds = MagicMock(spec=FederatedDataset)
     fds.node_ids.return_value = []
     return fds
 

--- a/tests/test_federated_workflow.py
+++ b/tests/test_federated_workflow.py
@@ -7,7 +7,7 @@ from testsupport.fake_researcher_secagg import FakeSecAgg
 import fedbiomed
 from fedbiomed.common.constants import SecureAggregationSchemes, __breakpoints_version__
 from fedbiomed.common.exceptions import FedbiomedSecureAggregationError
-from fedbiomed.researcher.datasets import FederatedDataSet
+from fedbiomed.researcher.datasets import FederatedDataset
 from fedbiomed.researcher.federated_workflows import FederatedWorkflow
 from fedbiomed.researcher.secagg import SecureAggregation
 
@@ -35,7 +35,7 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
         self.assertIsNone(exp.tags())  # by default, tags set to None
         self.assertIsNone(exp.nodes())  # by default, nodes set to None
         self.assertIsInstance(
-            exp.training_data(), FederatedDataSet
+            exp.training_data(), FederatedDataset
         )  # by default, training data is initialized to something
         self.assertIsNotNone(
             exp.experimentation_folder()
@@ -47,7 +47,7 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
         self.assertFalse(exp.secagg.active)
 
         # Test all possible combinations of init arguments
-        _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataSet)
+        _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataset)
         _training_data.data.return_value = {
             "node-1": {"dataset_id": "dataset-id-1", "shape": [100, 100]}
         }
@@ -354,7 +354,7 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
         self, mock_bkpt_file, mock_json_dump, mock_open
     ):
         # define attributes that will be saved in breakpoint
-        _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataSet)
+        _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataset)
         _training_data.data.return_value = {"training": {"data": "data"}}
         exp = FederatedWorkflow(
             training_data=_training_data,
@@ -473,7 +473,7 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
         """Tests retrieving nodes"""
 
         ff = FederatedWorkflow()
-        ff._fds = FederatedDataSet({"node-1": {}, "node-2": {}})
+        ff._fds = FederatedDataset({"node-1": {}, "node-2": {}})
         nodes = ff.all_federation_nodes()
         self.assertListEqual(["node-1", "node-2"], nodes)
 
@@ -482,7 +482,7 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
 
         ff = FederatedWorkflow()
         ff._nodes_filter = ["node-1"]
-        ff._fds = FederatedDataSet({"node-1": {}, "node-2": {}})
+        ff._fds = FederatedDataset({"node-1": {}, "node-2": {}})
 
         # Check filtered nodes
         nodes = ff.filtered_federation_nodes()

--- a/tests/test_federated_workflow.py
+++ b/tests/test_federated_workflow.py
@@ -5,7 +5,7 @@ from testsupport.base_mocks import MockRequestModule
 from testsupport.fake_researcher_secagg import FakeSecAgg
 
 import fedbiomed
-from fedbiomed.common.constants import __breakpoints_version__, SecureAggregationSchemes
+from fedbiomed.common.constants import SecureAggregationSchemes, __breakpoints_version__
 from fedbiomed.common.exceptions import FedbiomedSecureAggregationError
 from fedbiomed.researcher.datasets import FederatedDataSet
 from fedbiomed.researcher.federated_workflows import FederatedWorkflow
@@ -34,8 +34,8 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
         exp = FederatedWorkflow()
         self.assertIsNone(exp.tags())  # by default, tags set to None
         self.assertIsNone(exp.nodes())  # by default, nodes set to None
-        self.assertIsNone(
-            exp.training_data()
+        self.assertIsInstance(
+            exp.training_data(), FederatedDataSet
         )  # by default, training data is initialized to something
         self.assertIsNotNone(
             exp.experimentation_folder()
@@ -48,6 +48,9 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
 
         # Test all possible combinations of init arguments
         _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataSet)
+        _training_data.data.return_value = {
+            "node-1": {"dataset_id": "dataset-id-1", "shape": [100, 100]}
+        }
         _secagg = MagicMock(spec=fedbiomed.researcher.secagg.SecureAggregation)
         parameters_and_possible_values = {
             "tags": (None, None, ["one-tag", "another-tag"]),
@@ -88,7 +91,7 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
             save_breakpoints=True,
         )
         self.assertListEqual(exp.nodes(), ["alice", "bob"])
-        self.assertEqual(exp.training_data(), _training_data)
+        self.assertDictEqual(exp.training_data().data(), _training_data.data())
         self.assertTrue(isinstance(exp.secagg, SecureAggregation))
         self.assertTrue(exp.secagg.active)
         self.assertTrue(exp.save_breakpoints())
@@ -162,7 +165,7 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
         with self.assertRaises(SystemExit):
             exp.set_training_data("not-none", from_tags=False)
 
-        self.assertIsNone(exp.training_data())
+        self.assertEqual(exp.training_data().data(), {})
 
         self.fake_search_reply = {
             "node1": [{"my-metadata": "is-the-best", "tags": ["some-tag"]}]
@@ -174,9 +177,9 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
             exp.training_data().data(),
             {"node1": {"my-metadata": "is-the-best", "tags": ["some-tag"]}},
         )
-        _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataSet)
+        _training_data = {"node-1": {"dataset_id": "dataset-id-1", "shape": [100, 100]}}
         exp.set_training_data(_training_data)
-        self.assertEqual(exp.training_data(), _training_data)
+        self.assertDictEqual(exp.training_data().data(), _training_data)
 
     def test_federated_workflow_05_set_experimentation_folder(self):
         exp = FederatedWorkflow()
@@ -232,7 +235,7 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
 
         # resetting tags to None when training data is not None -> simply set tags to None
         exp._tags = None
-        exp.set_training_data(FederatedDataSet(self.fake_search_reply))
+        exp.set_training_data(self.fake_search_reply)
         self.assertIsNone(exp.tags())
         self.assertDictEqual(exp.training_data().data(), self.fake_search_reply)
 
@@ -241,7 +244,7 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
             exp.set_training_data(None, from_tags=True)
 
         # set tags when training data is not None -> reset training data based on new tags
-        exp.set_training_data(FederatedDataSet(self.fake_search_reply))
+        exp.set_training_data(self.fake_search_reply)
         self.fake_search_reply = {
             "node2": [{"my-metadata": "is-the-bestest", "tags": ["other-tags"]}]
         }
@@ -352,7 +355,7 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
     ):
         # define attributes that will be saved in breakpoint
         _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataSet)
-        _training_data.data.return_value = {"training": "data"}
+        _training_data.data.return_value = {"training": {"data": "data"}}
         exp = FederatedWorkflow(
             training_data=_training_data,
         )
@@ -363,7 +366,7 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
             {
                 "id": exp.id,
                 "breakpoint_version": str(__breakpoints_version__),
-                "training_data": {"training": "data"},
+                "training_data": {"training": {"data": "data"}},
                 "experimentation_folder": exp.experimentation_folder(),
                 "tags": exp.tags(),
                 "nodes": exp.nodes(),

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -12,7 +12,7 @@ from fedbiomed.common.optimizers import AuxVar, EncryptedAuxVar
 from fedbiomed.common.training_args import TrainingArgs
 from fedbiomed.common.training_plans import BaseTrainingPlan
 from fedbiomed.researcher.config import config
-from fedbiomed.researcher.datasets import FederatedDataSet
+from fedbiomed.researcher.datasets import FederatedDataset
 from fedbiomed.researcher.federated_workflows.jobs import (
     Job,
     TrainingJob,
@@ -37,7 +37,7 @@ class TestJob(unittest.TestCase):
 
         # Globally create mock for Model and FederatedDataset
         self.model = create_autospec(BaseTrainingPlan, instance=False)
-        self.fds = MagicMock(spec=FederatedDataSet)
+        self.fds = MagicMock(spec=FederatedDataset)
         self.fds.data = MagicMock(return_value={})
         self.model = FakeTorchTrainingPlan
         self.model.save_code = MagicMock()
@@ -127,7 +127,7 @@ class TestJob(unittest.TestCase):
                         training_plan=mock_tp,
                         training_args=TrainingArgs({}, only_required=False),
                         model_args=None,
-                        data=self.fds,  # mocked FederatedDataSet class
+                        data=self.fds,  # mocked FederatedDataset class
                         nodes_state_ids=fake_node_state_ids,
                         nodes=["alice", "bob"],
                         aggregator_args={},
@@ -292,7 +292,7 @@ class TestJob(unittest.TestCase):
                         training_plan=mock_tp,
                         training_args=TrainingArgs({}, only_required=False),
                         model_args=None,
-                        data=self.fds,  # mocked FederatedDataSet class
+                        data=self.fds,  # mocked FederatedDataset class
                         nodes_state_ids=fake_node_state_ids,
                         nodes=["alice", "bob"],
                         aggregator_args={},
@@ -615,7 +615,7 @@ class TestJob(unittest.TestCase):
                 training_plan=mock_tp,
                 training_args=TrainingArgs({}, only_required=False),
                 model_args=None,
-                data=self.fds,  # mocked FederatedDataSet class
+                data=self.fds,  # mocked FederatedDataset class
                 nodes_state_ids=fake_node_state_ids,
                 nodes=["node-1", "node-2"],
                 aggregator_args={},

--- a/tests/test_node_state_agent.py
+++ b/tests/test_node_state_agent.py
@@ -2,13 +2,13 @@ import unittest
 
 from fedbiomed.common.exceptions import FedbiomedNodeStateAgentError
 from fedbiomed.researcher.node_state_agent import NodeStateAgent
-from tests.test_experiment import FederatedDataSet
+from tests.test_experiment import FederatedDataset
 
 
 class TestNodeStateAgent(unittest.TestCase):
     def setUp(self) -> None:
         self.node_ids = ["node_id_1234", "node_id_5678", "node_id_9012"]
-        self.federated_dataset = FederatedDataSet(
+        self.federated_dataset = FederatedDataset(
             {
                 self.node_ids[0]: {"data": "sample_data"},
                 self.node_ids[1]: {"data": "sample_data"},
@@ -22,7 +22,7 @@ class TestNodeStateAgent(unittest.TestCase):
             "node_id_4321",
             "node_id_0987",
         ]
-        self.federated_dataset_2 = FederatedDataSet(
+        self.federated_dataset_2 = FederatedDataset(
             {
                 self.node_ids_2[0]: {"data": "sample_data"},
                 self.node_ids_2[1]: {"data": "sample_data"},

--- a/tests/test_node_state_agent.py
+++ b/tests/test_node_state_agent.py
@@ -1,42 +1,60 @@
 import unittest
 
 from fedbiomed.common.exceptions import FedbiomedNodeStateAgentError
-
 from fedbiomed.researcher.node_state_agent import NodeStateAgent
+from tests.test_experiment import FederatedDataSet
 
 
 class TestNodeStateAgent(unittest.TestCase):
     def setUp(self) -> None:
-        self.node_ids_1 = ["node_id_1234", "node_id_5678", "node_id_9012"]
+        self.node_ids = ["node_id_1234", "node_id_5678", "node_id_9012"]
+        self.federated_dataset = FederatedDataSet(
+            {
+                self.node_ids[0]: {"data": "sample_data"},
+                self.node_ids[1]: {"data": "sample_data"},
+                self.node_ids[2]: {"data": "sample_data"},
+            }
+        )
+
+        self.node_ids_2 = [
+            "node_id_1234",
+            "node_id_5678",
+            "node_id_4321",
+            "node_id_0987",
+        ]
+        self.federated_dataset_2 = FederatedDataSet(
+            {
+                self.node_ids_2[0]: {"data": "sample_data"},
+                self.node_ids_2[1]: {"data": "sample_data"},
+                self.node_ids_2[2]: {"data": "sample_data"},
+                self.node_ids_2[3]: {"data": "sample_data"},
+            }
+        )
 
     def test_node_state_1_agent_get_last_node_states(self):
         # build several NodeStateAgents
         # case NodeStateAgent is built with no nodes
-        test_nsa_1 = NodeStateAgent([])
+        test_nsa_1 = NodeStateAgent(self.federated_dataset)
         res_1 = test_nsa_1.get_last_node_states()
 
-        self.assertEqual(res_1, {})
+        self.assertEqual(res_1, {k: None for k in self.node_ids})
 
         # case NodeStateAgent is built with some nodes
 
-        node_ids = ["node_id_1234", "node_id_5678", "node_id_9012"]
-        test_nsa_2 = NodeStateAgent(node_ids)
+        test_nsa_2 = NodeStateAgent(self.federated_dataset_2)
         res_2 = test_nsa_2.get_last_node_states()
 
-        expected_res = {k: None for k in node_ids}
+        expected_res = {k: None for k in self.node_ids_2}
         self.assertDictEqual(expected_res, res_2)
 
     def test_node_state_agent_4_upate_node_state(self):
-        node_ids_2 = ["node_id_1234", "node_id_5678", "node_id_4321", "node_id_0987"]
-
-        nsa = NodeStateAgent(self.node_ids_1)
+        nsa = NodeStateAgent(self.federated_dataset)
         # case where node replies are none
 
-        nsa.update_node_states(node_ids_2)
-
+        self.federated_dataset.set_federated_dataset(self.federated_dataset_2.data())
+        nsa.update_node_states()
         res = nsa.get_last_node_states()
-
-        expected_res = {k: None for k in node_ids_2}
+        expected_res = {k: None for k in self.node_ids_2}
         self.assertDictEqual(
             res, expected_res
         )  # we check here that keys and initialization has been done
@@ -48,9 +66,9 @@ class TestNodeStateAgent(unittest.TestCase):
             "node_id_5678": {"node_id": "node_id_5678", "state_id": "node_state_5678"},
         }
 
-        nsa.update_node_states(node_ids_2, resp)
+        nsa.update_node_states()
         res = nsa.get_last_node_states()
-        self.assertListEqual(list(res.keys()), node_ids_2)
+        self.assertListEqual(list(res.keys()), self.node_ids_2)
 
         # finally, we update with a node_id that is not present in the FederatedDataset
 
@@ -64,18 +82,18 @@ class TestNodeStateAgent(unittest.TestCase):
         }
         resp = nodes_replies_content
 
-        nsa.update_node_states(node_ids_2, resp)
+        nsa.update_node_states(resp)
         res = nsa.get_last_node_states()
 
         nodes_replies_content_nodes_id = list(nodes_replies_content.keys())
         nodes_replies_content_nodes_id.remove("unknown-node_id")
-        self.assertListEqual(list(res.keys()), node_ids_2)
+        self.assertListEqual(list(res.keys()), self.node_ids_2)
         self.assertNotIn("unknown-node_id", res)
         for node_id in nodes_replies_content_nodes_id:
-            self.assertIn(node_id, node_ids_2)
+            self.assertIn(node_id, self.node_ids_2)
 
     def test_node_state_agent_5_update_node_state_failure(self):
-        nsa = NodeStateAgent(self.node_ids_1)
+        nsa = NodeStateAgent(self.federated_dataset)
 
         bad_resp = {
             "node_id_1234": {"node_id": "node_id_1234", "state_id": "node_state_1234"},
@@ -83,10 +101,10 @@ class TestNodeStateAgent(unittest.TestCase):
         }
 
         with self.assertRaises(FedbiomedNodeStateAgentError):
-            nsa.update_node_states(self.node_ids_1, bad_resp)
+            nsa.update_node_states(bad_resp)
 
     def test_node_state_agent_6_save_state_breakpoint(self):
-        nsa = NodeStateAgent(self.node_ids_1)
+        nsa = NodeStateAgent(self.federated_dataset)
 
         nsa_bkpt = nsa.save_state_breakpoint()
         res = nsa.get_last_node_states()
@@ -102,7 +120,7 @@ class TestNodeStateAgent(unittest.TestCase):
             },
         }
 
-        nsa = NodeStateAgent(self.node_ids_1)
+        nsa = NodeStateAgent(self.federated_dataset)
         nsa.load_state_breakpoint(nodes_states_bkpt)
 
         reloaded_nodes_states_bkpt = nsa.save_state_breakpoint()
@@ -110,11 +128,11 @@ class TestNodeStateAgent(unittest.TestCase):
         self.assertDictEqual(nodes_states_bkpt, reloaded_nodes_states_bkpt)
 
     def test_node_state_agent_8_save_and_load_bkpt(self):
-        nsa = NodeStateAgent(self.node_ids_1)
+        nsa = NodeStateAgent(self.federated_dataset)
         last_nodes_states_before_saving = nsa.get_last_node_states()
 
         nodes_states_bkpt = nsa.save_state_breakpoint()
-        nsa2 = NodeStateAgent(self.node_ids_1)
+        nsa2 = NodeStateAgent(self.federated_dataset)
         nsa2.load_state_breakpoint(nodes_states_bkpt)
 
         last_nodes_states_after_saving = nsa2.get_last_node_states()

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -15,7 +15,7 @@ from fedbiomed.common.training_args import TrainingArgs
 from fedbiomed.common.training_plans import TorchTrainingPlan
 from fedbiomed.researcher.aggregators.fedavg import FedAverage
 from fedbiomed.researcher.aggregators.scaffold import Scaffold
-from fedbiomed.researcher.datasets import FederatedDataSet
+from fedbiomed.researcher.datasets import FederatedDataset
 
 
 class TestScaffold(unittest.TestCase):
@@ -28,7 +28,7 @@ class TestScaffold(unittest.TestCase):
         self.model = Linear(10, 3)
         self.n_nodes = 4
         self.node_ids = [f"node_{i}" for i in range(self.n_nodes)]
-        self.fds = FederatedDataSet({node: {} for node in self.node_ids})
+        self.fds = FederatedDataset({node: {} for node in self.node_ids})
         self.models = {
             node_id: Linear(10, 3).state_dict()
             for i, node_id in enumerate(self.node_ids)
@@ -278,7 +278,7 @@ class TestScaffold(unittest.TestCase):
     def test_7_save_state_breakpoint(self, uuid_patch):
         uuid_patch.return_value = FakeUuid()
         server_lr = 0.5
-        fds = FederatedDataSet({node_id: {} for node_id in self.node_ids})
+        fds = FederatedDataset({node_id: {} for node_id in self.node_ids})
         bkpt_path = "/path/to/my/breakpoint"
         scaffold = Scaffold(server_lr, fds=fds)
         scaffold.init_correction_states(self.model.state_dict())
@@ -301,7 +301,7 @@ class TestScaffold(unittest.TestCase):
     def test_8_load_state_breakpoint(self):
         """Test that 'load_state_breakpoint' triggers the proper amount of calls."""
         server_lr = 0.5
-        fds = FederatedDataSet({node_id: {} for node_id in self.node_ids})
+        fds = FederatedDataset({node_id: {} for node_id in self.node_ids})
         bkpt_path = "/path/to/my/breakpoint"
         scaffold = Scaffold(server_lr, fds=fds)
 
@@ -334,7 +334,7 @@ class TestScaffold(unittest.TestCase):
         get_model_params_mock = MagicMock()
         get_model_params_mock.__len__ = MagicMock(return_value=n_model_layer)
         training_plan.get_model_params.return_value = get_model_params_mock
-        fds = FederatedDataSet({node_id: {} for node_id in self.node_ids})
+        fds = FederatedDataset({node_id: {} for node_id in self.node_ids})
         scaffold = Scaffold(fds=fds)
         for n_round in range(n_rounds):
             node_lr = scaffold.set_nodes_learning_rate_after_training(
@@ -344,7 +344,7 @@ class TestScaffold(unittest.TestCase):
             self.assertDictEqual(node_lr, test_node_lr)
 
         # same test with a mix of present and absent nodes in training_replies
-        fds = FederatedDataSet({node_id: {} for node_id in self.node_ids + ["node_99"]})
+        fds = FederatedDataset({node_id: {} for node_id in self.node_ids + ["node_99"]})
         optim_w = MagicMock(spec=NativeTorchOptimizer)
         optim_w.get_learning_rate = MagicMock(return_value=lr)
         training_plan.optimizer = MagicMock(return_value=optim_w)
@@ -430,7 +430,7 @@ class TestIntegrationScaffold(unittest.TestCase):
         self.model = self.FakeModelTorch.ComplexModel()
         self.n_nodes = 4
         self.node_ids = [f"node_{i}" for i in range(self.n_nodes)]
-        self.fds = FederatedDataSet({node: {} for node in self.node_ids})
+        self.fds = FederatedDataset({node: {} for node in self.node_ids})
         self.models = {
             node_id: copy.deepcopy(self.model.state_dict())
             for i, node_id in enumerate(self.node_ids)

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -1,20 +1,21 @@
+import copy
+import random
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
+
+import torch
+import torch.nn as nn
+from testsupport.fake_uuid import FakeUuid
+from torch.nn import Linear
+
 from fedbiomed.common.exceptions import FedbiomedAggregatorError
 from fedbiomed.common.optimizers.generic_optimizers import NativeTorchOptimizer
 from fedbiomed.common.training_args import TrainingArgs
 from fedbiomed.common.training_plans import TorchTrainingPlan
 from fedbiomed.researcher.aggregators.fedavg import FedAverage
-from fedbiomed.researcher.datasets import FederatedDataSet
-from testsupport.fake_uuid import FakeUuid
-import torch
-import torch.nn as nn
-from torch.nn import Linear
 from fedbiomed.researcher.aggregators.scaffold import Scaffold
-
-import copy
-import random
+from fedbiomed.researcher.datasets import FederatedDataSet
 
 
 class TestScaffold(unittest.TestCase):

--- a/tests/test_training_plan_workflow.py
+++ b/tests/test_training_plan_workflow.py
@@ -1,11 +1,13 @@
 import os
-import unittest
 import tempfile
-
-from unittest.mock import MagicMock, patch
-
+import unittest
+from unittest.mock import ANY, MagicMock, patch
 
 from testsupport.base_mocks import MockRequestModule
+from testsupport.fake_training_plan import (
+    FakeSKLearnTrainingPlan,
+    FakeTorchTrainingPlan,
+)
 
 import fedbiomed
 from fedbiomed.common.exceptions import FedbiomedExperimentError
@@ -13,19 +15,12 @@ from fedbiomed.common.training_args import TrainingArgs
 from fedbiomed.common.training_plans import (
     BaseTrainingPlan,
 )
+from fedbiomed.researcher.config import config
 from fedbiomed.researcher.federated_workflows import TrainingPlanWorkflow
 from fedbiomed.researcher.federated_workflows.jobs import (
     TrainingPlanApproveJob,
     TrainingPlanCheckJob,
 )
-from testsupport.fake_training_plan import (
-    FakeTorchTrainingPlan,
-    FakeSKLearnTrainingPlan,
-)
-
-from unittest.mock import ANY
-
-from fedbiomed.researcher.config import config
 
 
 class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
@@ -84,6 +79,7 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
 
         # Test all possible combinations of init arguments
         _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataSet)
+        _training_data.data.return_value = {"node1": {"some": "data"}}
         _secagg = MagicMock(spec=fedbiomed.researcher.secagg.SecureAggregation)
         parameters_and_possible_values = {
             "tags": (None, None, ["one-tag", "another-tag"]),
@@ -120,6 +116,7 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
         # Special corner cases that deserve additional testing
         # TrainingPlanWorkflow can also be constructed by providing parameters to the constructor
         _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataSet)
+        _training_data.data.return_value = {"alice": {"some": "data"}}
         _training_data.node_ids.return_value = [
             "alice",
             "bob",
@@ -208,7 +205,7 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
         mock_approval_job = MagicMock(spec=TrainingPlanApproveJob)
         mock_job.return_value = mock_approval_job
         _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataSet)
-
+        _training_data.data.return_value = {"node1": {"some": "data"}}
         exp = TrainingPlanWorkflow(
             training_plan_class=FakeTorchTrainingPlan, training_data=_training_data
         )
@@ -225,7 +222,7 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
         mock_approval_job = MagicMock(spec=TrainingPlanCheckJob)
         mock_job.return_value = mock_approval_job
         _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataSet)
-
+        _training_data.data.return_value = {"node1": {"some": "data"}}
         exp = TrainingPlanWorkflow(
             training_plan_class=FakeTorchTrainingPlan, training_data=_training_data
         )

--- a/tests/test_training_plan_workflow.py
+++ b/tests/test_training_plan_workflow.py
@@ -78,7 +78,7 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
         self.assertIsNotNone(exp.training_args())
 
         # Test all possible combinations of init arguments
-        _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataSet)
+        _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataset)
         _training_data.data.return_value = {"node1": {"some": "data"}}
         _secagg = MagicMock(spec=fedbiomed.researcher.secagg.SecureAggregation)
         parameters_and_possible_values = {
@@ -115,7 +115,7 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
 
         # Special corner cases that deserve additional testing
         # TrainingPlanWorkflow can also be constructed by providing parameters to the constructor
-        _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataSet)
+        _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataset)
         _training_data.data.return_value = {"alice": {"some": "data"}}
         _training_data.node_ids.return_value = [
             "alice",
@@ -204,7 +204,7 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
         mock_job = patch_job.start()
         mock_approval_job = MagicMock(spec=TrainingPlanApproveJob)
         mock_job.return_value = mock_approval_job
-        _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataSet)
+        _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataset)
         _training_data.data.return_value = {"node1": {"some": "data"}}
         exp = TrainingPlanWorkflow(
             training_plan_class=FakeTorchTrainingPlan, training_data=_training_data
@@ -221,7 +221,7 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
         mock_job = patch_job.start()
         mock_approval_job = MagicMock(spec=TrainingPlanCheckJob)
         mock_job.return_value = mock_approval_job
-        _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataSet)
+        _training_data = MagicMock(spec=fedbiomed.researcher.datasets.FederatedDataset)
         _training_data.data.return_value = {"node1": {"some": "data"}}
         exp = TrainingPlanWorkflow(
             training_plan_class=FakeTorchTrainingPlan, training_data=_training_data

--- a/tests/testsupport/fake_dataset.py
+++ b/tests/testsupport/fake_dataset.py
@@ -1,11 +1,11 @@
-"""This file contains dummy Classes for unit testing. It fakes FederatedDataSet class
+"""This file contains dummy Classes for unit testing. It fakes FederatedDataset class
 (from fedbiomed.common.dataset)
 """
 
 from typing import Any
 
 
-class FederatedDataSetMock:
+class FederatedDatasetMock:
     """Provides an interface that behave like the FederatedDataset,
     with a constructor and a `data` method
     """
@@ -15,7 +15,7 @@ class FederatedDataSetMock:
         self._node_ids = []
 
     def data(self) -> Any:
-        """Returns data values stored in FederatedDataSetMock
+        """Returns data values stored in FederatedDatasetMock
 
         Returns:
             Any: values stored in class

--- a/tests/testsupport/fake_experiment.py
+++ b/tests/testsupport/fake_experiment.py
@@ -8,7 +8,7 @@ from fedbiomed.common.training_args import TrainingArgs
 from fedbiomed.researcher.federated_workflows._experiment import SecureAggregation
 
 # need those types defined
-FederatedDataSet = TypeVar("FederatedDataSet")
+FederatedDataset = TypeVar("FederatedDataset")
 Aggregator = TypeVar("Aggregator")
 Optimizer = TypeVar("Optimizer")
 Strategy = TypeVar("Strategy")
@@ -26,7 +26,7 @@ class ExperimentMock:
         self,
         tags: Union[List[str], str, None] = None,
         nodes: Union[List[str], None] = None,
-        training_data: Union[FederatedDataSet, dict, None] = None,
+        training_data: Union[FederatedDataset, dict, None] = None,
         aggregator: Union[Aggregator, Type[Aggregator], None] = None,
         agg_optimizer: Optional[Optimizer] = None,
         node_selection_strategy: Union[Strategy, Type[Strategy], None] = None,


### PR DESCRIPTION
**PR description**

This PR reimplements `FederatedDataset` management logic. It instantiates `FederatedDataset` once in the `__init__` uses it in other classes to make sure consistency between the classes that depends on `FederatedDataset`. 

Additionally, it updates node state manager to use `FederatedDataset` directly

Implementation is tested with 
- 101 notebook
- advance experiment configuration
- breakpoints
- advance optimizers

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`