### PR TITLE
Removes keep_files_dir argument from TrainingPlanApprove/Check/Job

### DIFF
--- a/fedbiomed/researcher/federated_workflows/_training_plan_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_training_plan_workflow.py
@@ -463,7 +463,6 @@ class TrainingPlanWorkflow(FederatedWorkflow, ABC):
             researcher_id=self._researcher_id,
             requests=self._reqs,
             nodes=self.training_data().node_ids(),
-            keep_files_dir=self.experimentation_path(),
             experiment_id=self._experiment_id,
             training_plan=self.training_plan(),
         )
@@ -495,7 +494,6 @@ class TrainingPlanWorkflow(FederatedWorkflow, ABC):
             researcher_id=self._researcher_id,
             requests=self._reqs,
             nodes=self.training_data().node_ids(),
-            keep_files_dir=self.experimentation_path(),
             training_plan=self.training_plan(),
             description=description,
         )


### PR DESCRIPTION
**PR description**

Fixes the bug introduced after `keep_files_dir` argument removed from base Job class.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`