### PR TITLE
Fix license header in source code files

### DIFF
--- a/fedbiomed/__init__.py
+++ b/fedbiomed/__init__.py
@@ -1,1 +1,4 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 __version__ = "v6.2.0"

--- a/fedbiomed/common/analytics/_image_analytics.py
+++ b/fedbiomed/common/analytics/_image_analytics.py
@@ -1,3 +1,6 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Dict
 
 from ._analytics_strategy import AnalyticsStrategy

--- a/fedbiomed/common/cli.py
+++ b/fedbiomed/common/cli.py
@@ -1,4 +1,6 @@
+# This file is originally part of Fed-BioMed
 # SPDX-License-Identifier: Apache-2.0
+
 
 """Common CLI Modules
 

--- a/fedbiomed/common/dataset/_custom_dataset.py
+++ b/fedbiomed/common/dataset/_custom_dataset.py
@@ -1,3 +1,6 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import abstractmethod
 from typing import Any, Dict, Tuple
 

--- a/fedbiomed/common/dataset_controller/_custom_controller.py
+++ b/fedbiomed/common/dataset_controller/_custom_controller.py
@@ -1,3 +1,6 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 from fedbiomed.common.dataset_controller._controller import Controller
 
 

--- a/fedbiomed/common/dataset_controller/_tabular_controller.py
+++ b/fedbiomed/common/dataset_controller/_tabular_controller.py
@@ -1,3 +1,6 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 from pathlib import Path
 from typing import Dict, Iterable, Union
 

--- a/fedbiomed/common/secagg/_additive_ss.py
+++ b/fedbiomed/common/secagg/_additive_ss.py
@@ -1,3 +1,6 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 import random
 from math import log2
 from typing import List, Optional, Union

--- a/fedbiomed/common/secagg/_dh.py
+++ b/fedbiomed/common/secagg/_dh.py
@@ -1,3 +1,6 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Callable
 
 from cryptography.hazmat.backends import default_backend

--- a/fedbiomed/common/secagg/_jls.py
+++ b/fedbiomed/common/secagg/_jls.py
@@ -1,3 +1,6 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Joye-Libert secure aggregation scheme (JL) and its threshold-variant (TJL)
 

--- a/fedbiomed/common/secagg/_lom.py
+++ b/fedbiomed/common/secagg/_lom.py
@@ -1,3 +1,6 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 import secrets
 from typing import Dict, List

--- a/fedbiomed/node/dataset_manager/_db_tables.py
+++ b/fedbiomed/node/dataset_manager/_db_tables.py
@@ -1,3 +1,6 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any, List, Optional, Type, Union
 
 from fedbiomed.common.constants import DatasetTypes, ErrorNumbers

--- a/fedbiomed/node/history_monitor.py
+++ b/fedbiomed/node/history_monitor.py
@@ -1,8 +1,7 @@
-"""
 # This file is originally part of Fed-BioMed
 # SPDX-License-Identifier: Apache-2.0
 
-
+"""
 Send information from node to researcher during the training
 """
 

--- a/fedbiomed/node/secagg/__init__.py
+++ b/fedbiomed/node/secagg/__init__.py
@@ -1,3 +1,6 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 from ._secagg_round import SecaggRound
 from ._secagg_setups import (
     SecaggBaseSetup,

--- a/fedbiomed/node/secagg/_secagg_round.py
+++ b/fedbiomed/node/secagg/_secagg_round.py
@@ -1,7 +1,6 @@
-"""
-This file is originally part of Fed-BioMed
-SPDX-License-Identifier: Apache-2.0
-"""
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional

--- a/fedbiomed/researcher/federated_workflows/_federated_analytics.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_analytics.py
@@ -1,3 +1,6 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 import uuid
 from typing import Any, Dict, Optional, Union
 

--- a/fedbiomed/researcher/federated_workflows/_training_plan_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_training_plan_workflow.py
@@ -1,7 +1,5 @@
-"""
-This file is originally part of Fed-BioMed
-SPDX-License-Identifier: Apache-2.0
-"""
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
 
 import inspect
 import os

--- a/fedbiomed/researcher/federated_workflows/jobs/_fa_request_job.py
+++ b/fedbiomed/researcher/federated_workflows/jobs/_fa_request_job.py
@@ -1,3 +1,6 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Dict
 
 from fedbiomed.common.constants import AnalyticsTypes

--- a/fedbiomed/researcher/secagg/_secagg_context.py
+++ b/fedbiomed/researcher/secagg/_secagg_context.py
@@ -1,8 +1,7 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 """
-This file is originally part of Fed-BioMed
-SPDX-License-Identifier: Apache-2.0
-
-
 Secure aggregation context setup module  to be executed on the
 server/researcher side
 

--- a/fedbiomed/transport/__init__.py
+++ b/fedbiomed/transport/__init__.py
@@ -1,3 +1,6 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Transport module to manage communication between researcher and
 node components based on gRPC

--- a/fedbiomed/transport/client.py
+++ b/fedbiomed/transport/client.py
@@ -1,3 +1,6 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 import abc
 import asyncio
 import socket

--- a/fedbiomed/transport/controller.py
+++ b/fedbiomed/transport/controller.py
@@ -1,3 +1,6 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 import asyncio
 import threading
 from typing import Callable, Dict, List, Optional

--- a/fedbiomed/transport/node_agent.py
+++ b/fedbiomed/transport/node_agent.py
@@ -1,3 +1,6 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 import asyncio
 import copy
 import time

--- a/fedbiomed/transport/server.py
+++ b/fedbiomed/transport/server.py
@@ -1,3 +1,6 @@
+# This file is originally part of Fed-BioMed
+# SPDX-License-Identifier: Apache-2.0
+
 import asyncio
 import os
 import threading


### PR DESCRIPTION
format

**PR description**

Fix license header in source code files, when it is missing or when it does not have standard format

No associated issue.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`