### PR TITLE
Feature/361 security logs db operations

### DIFF
--- a/fedbiomed/node/dataset_manager/_db_tables.py
+++ b/fedbiomed/node/dataset_manager/_db_tables.py
@@ -20,6 +20,15 @@ class BaseTable(TinyTableConnector):
     # Dataclass is expected to have from_dict and to_dict methods
     _dataclass: Type = None
 
+    def _get_operation_prefix(self) -> str:
+        """Get operation prefix based on table name for security logging."""
+        table_mapping = {
+            "Datasets": "dataset",
+            "Dlps": "dlp",
+            "Dlbs": "dlb",
+        }
+        return table_mapping.get(self._table_name, "table")
+
     def _validate_and_convert_to_dict(self, data: dict) -> dict:
         """Generic validation using the table's dataclass"""
         try:
@@ -30,18 +39,88 @@ class BaseTable(TinyTableConnector):
             model_name = self._dataclass.__name__
             raise FedbiomedError(f"{model_name} validation failed: {str(e)}") from e
 
+    def _security_ids(
+        self, payload: Optional[dict] = None, id_value: Optional[str] = None
+    ) -> dict:
+        """Build a consistent set of identifier fields for security logging.
+
+        Notes:
+        - Always includes the table primary ID field (self._id_name) when id_value is provided.
+        - Also includes dataset_id and dlp_id when present in payload.
+        """
+        ids: dict = {}
+        if payload:
+            if "dataset_id" in payload:
+                ids["dataset_id"] = payload["dataset_id"]
+            if "dlp_id" in payload:
+                ids["dlp_id"] = payload["dlp_id"]
+
+        if id_value is not None and self._id_name:
+            ids[self._id_name] = id_value
+
+        return ids
+
     def insert(self, entry: dict) -> int:
-        """Insert an entry with validation"""
+        """Insert an entry with validation and security logging"""
         validated_entry = self._validate_and_convert_to_dict(entry)
-        return super().insert(validated_entry)
+        operation_prefix = self._get_operation_prefix()
+        try:
+            result = super().insert(validated_entry)
+        except Exception as e:
+            logger.security_event(
+                operation=f"{operation_prefix}_create",
+                status="failure",
+                level="error",
+                error=str(e),
+                **self._security_ids(validated_entry),
+                entry_name=validated_entry.get("name")
+                or validated_entry.get("dlp_name"),
+            )
+            raise
+
+        logger.security_event(
+            operation=f"{operation_prefix}_create",
+            status="success",
+            level="info",
+            **self._security_ids(validated_entry, id_value=result),
+            entry_name=validated_entry.get("name") or validated_entry.get("dlp_name"),
+        )
+        return result
 
     def get_validated_entry(self, entry_id: str) -> Optional[Any]:
         """Get entry by ID and return as validated model instance"""
         data = self.get_by_id(entry_id)
         return None if not data else self._dataclass.from_dict(data)
 
+    def all(self) -> List[dict]:
+        """Get all entries with security logging."""
+        result = super().all()
+
+        operation_prefix = self._get_operation_prefix()
+        logger.security_event(
+            operation=f"{operation_prefix}_list",
+            status="success",
+            level="info",
+            record_count=len(result),
+        )
+        return result
+
+    def get_by_id(self, id_value: str) -> Optional[dict]:
+        """Get entry by ID with security logging."""
+        result = super().get_by_id(id_value)
+
+        operation_prefix = self._get_operation_prefix()
+        logger.security_event(
+            operation=f"{operation_prefix}_read",
+            status="success" if result else "not_found",
+            level="info",
+            **self._security_ids(result, id_value=id_value),
+            entry_name=(result or {}).get("name") or (result or {}).get("dlp_name"),
+        )
+        return result
+
     def update_by_id(self, id_value, update):
-        """Update an entry by its ID with validation
+        """Update an entry by its ID with validation and security logging
 
         Args:
              id_value: the ID of the entry to update
@@ -50,21 +129,89 @@ class BaseTable(TinyTableConnector):
         Raises:
             FedbiomedError: if validation fails or entry not found
         """
-        # Prevent changing the ID field
-        if self._id_name in update and update[self._id_name] != id_value:
-            raise FedbiomedError(
-                f"{ErrorNumbers.FB632.value}: Cannot change the field '{self._id_name}'"
+        operation_prefix = self._get_operation_prefix()
+
+        try:
+            # Prevent changing the ID field
+            if self._id_name in update and update[self._id_name] != id_value:
+                raise FedbiomedError(
+                    f"{ErrorNumbers.FB632.value}: Cannot change the field '{self._id_name}'"
+                )
+
+            # Fetch existing entry. If not found, raise error
+            entry = super().get_by_id(id_value)
+            if entry is None:
+                raise FedbiomedError(f"No entry found with {self._id_name}={id_value}")
+
+            # Merge and validate updated entry
+            entry.update(update)
+            updated_entry = self._validate_and_convert_to_dict(entry)
+            result = super().update_by_id(id_value, updated_entry)
+        except Exception as e:
+            logger.security_event(
+                operation=f"{operation_prefix}_update",
+                status="failure",
+                level="error",
+                error=str(e),
+                modified_fields=list(update.keys())
+                if isinstance(update, dict)
+                else None,
+                **self._security_ids(
+                    entry if "entry" in locals() else None, id_value=id_value
+                ),
+                entry_name=(entry or {}).get("name")
+                if "entry" in locals() and entry
+                else None,
             )
+            raise
 
-        # Fetch existing entry. If not found, raise error
-        entry = self.get_by_id(id_value)
-        if entry is None:
-            raise FedbiomedError(f"No entry found with {self._id_name}={id_value}")
+        logger.security_event(
+            operation=f"{operation_prefix}_update",
+            status="success",
+            level="info",
+            modified_fields=list(update.keys()),
+            **self._security_ids(updated_entry, id_value=id_value),
+            entry_name=updated_entry.get("name") or updated_entry.get("dlp_name"),
+        )
+        return result
 
-        # Merge and validate updated entry
-        entry.update(update)
-        updated_entry = self._validate_and_convert_to_dict(entry)
-        return super().update_by_id(id_value, updated_entry)
+    def delete_by_id(self, id_value: str):
+        """Delete an entry by ID with security logging.
+
+        Args:
+            id_value: ID of the entry to delete
+
+        Raises:
+            FedbiomedError: if deletion fails
+        """
+        operation_prefix = self._get_operation_prefix()
+
+        # Get entry info before deletion for logging
+        entry = super().get_by_id(id_value)
+
+        try:
+            result = super().delete_by_id(id_value)
+        except Exception as e:
+            logger.security_event(
+                operation=f"{operation_prefix}_delete",
+                status="failure",
+                level="error",
+                error=str(e),
+                **self._security_ids(entry, id_value=id_value),
+                entry_name=(entry or {}).get("name") or (entry or {}).get("dlp_name"),
+                data_type=(entry or {}).get("data_type"),
+            )
+            raise
+
+        logger.security_event(
+            operation=f"{operation_prefix}_delete",
+            status="success",
+            level="info",
+            **self._security_ids(entry, id_value=id_value),
+            entry_name=(entry or {}).get("name") or (entry or {}).get("dlp_name"),
+            data_type=(entry or {}).get("data_type"),
+        )
+        return result
 
 
 class DatasetTable(BaseTable):
@@ -73,7 +220,8 @@ class DatasetTable(BaseTable):
     _dataclass = DatasetEntry
 
     def insert(self, entry: dict) -> int:
-        """Insert a dataset entry with validation"""
+        """Insert a dataset entry with validation and security logging"""
+        # Dataset-specific validation: check for conflicting tags
         conflicting_datasets = self.search_conflicting_tags(entry["tags"])
         if conflicting_datasets:
             _msg = (
@@ -81,9 +229,21 @@ class DatasetTable(BaseTable):
                 f"tags conflicting with your entry. Conflicting dataset names: "
                 f"{', '.join([_['name'] for _ in conflicting_datasets])}."
             )
-            logger.critical(_msg)
+            # Merged logging: both critical console message and security log
+            logger.critical(
+                _msg,
+                extra={
+                    "is_security": True,
+                    "operation": "dataset_create",
+                    "status": "failure",
+                    "error": "conflicting_tags",
+                    "attempted_tags": entry.get("tags"),
+                    "conflicting_datasets": [d["name"] for d in conflicting_datasets],
+                },
+            )
             raise FedbiomedError(_msg)
 
+        # Call parent insert which now includes security logging
         return super().insert(entry)
 
     def search_by_tags(self, tags: Union[tuple, list]) -> list:
@@ -121,7 +281,7 @@ class DatasetTable(BaseTable):
         Raises:
             FedbiomedError: conflicting tags with existing dataset
         """
-        # Check that there are not existing dataset with conflicting tags
+        # Dataset-specific validation: check for conflicting tags
         if "tags" in modified_dataset:
             # the dataset to modify is ignored (can conflict with its previous tags)
             conflicting_datasets = [
@@ -135,9 +295,24 @@ class DatasetTable(BaseTable):
                     f"are conflicting with your new tags. Conflicting dataset names: "
                     f"{', '.join([_['name'] for _ in conflicting_datasets])}."
                 )
-                logger.critical(msg)
+                # Merged logging: both critical console message and security log
+                logger.critical(
+                    msg,
+                    extra={
+                        "is_security": True,
+                        "operation": "dataset_update",
+                        "status": "failure",
+                        "dataset_id": dataset_id,
+                        "error": "conflicting_tags",
+                        "attempted_tags": modified_dataset.get("tags"),
+                        "conflicting_datasets": [
+                            d["name"] for d in conflicting_datasets
+                        ],
+                    },
+                )
                 raise FedbiomedError(msg)
 
+        # Call parent update_by_id which now includes security logging
         return super().update_by_id(dataset_id, modified_dataset)
 
 
@@ -147,19 +322,29 @@ class DlpTable(BaseTable):
     _dataclass = DlpEntry
 
     def insert(self, entry: dict) -> int:
-        """Insert a DLP entry with validation
+        """Insert a DLP entry with validation and security logging
 
         Raises:
             FedbiomedError:
             - target_dataset_type value not valid
             - bad data loading plan name (size, not unique)
         """
+        # DLP-specific validation
         if entry["target_dataset_type"] not in [t.value for t in DatasetTypes]:
             _msg = (
                 f"{ErrorNumbers.FB632.value}: target_dataset_type should be of the "
                 "values defined in 'fedbiomed.common.constants.DatasetTypes'"
             )
-            logger.critical(_msg)
+            logger.critical(
+                _msg,
+                extra={
+                    "is_security": True,
+                    "operation": "dlp_create",
+                    "status": "failure",
+                    "error": "invalid_target_dataset_type",
+                    "attempted_type": entry.get("target_dataset_type"),
+                },
+            )
             raise FedbiomedError(_msg)
 
         if len(entry["dlp_name"]) < 4:
@@ -167,7 +352,16 @@ class DlpTable(BaseTable):
                 f"{ErrorNumbers.FB316.value}: Cannot save data loading plan, "
                 "DLP name needs to have at least 4 characters."
             )
-            logger.error(_msg)
+            logger.error(
+                _msg,
+                extra={
+                    "is_security": True,
+                    "operation": "dlp_create",
+                    "status": "failure",
+                    "error": "dlp_name_too_short",
+                    "attempted_name": entry.get("dlp_name"),
+                },
+            )
             raise FedbiomedError(_msg)
 
         if self.get_all_by_value("dlp_name", entry["dlp_name"]):
@@ -175,9 +369,19 @@ class DlpTable(BaseTable):
                 f"{ErrorNumbers.FB316.value}: Cannot save data loading plan, "
                 "DLP name needs to be unique."
             )
-            logger.error(_msg)
+            logger.error(
+                _msg,
+                extra={
+                    "is_security": True,
+                    "operation": "dlp_create",
+                    "status": "failure",
+                    "error": "dlp_name_not_unique",
+                    "attempted_name": entry.get("dlp_name"),
+                },
+            )
             raise FedbiomedError(_msg)
 
+        # Call parent insert which now includes security logging
         return super().insert(entry)
 
     def list_by_target_dataset_type(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,10 +1,30 @@
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from fedbiomed.common.constants import DatasetTypes
+from fedbiomed.common.db import TinyDBConnector
 from fedbiomed.common.exceptions import FedbiomedError
 from fedbiomed.node.dataset_manager._db_dataclasses import DatasetEntry
 from fedbiomed.node.dataset_manager._db_tables import DatasetTable, DlpTable
+
+
+def _reset_tinydb_singleton() -> None:
+    """Reset TinyDBConnector singleton to ensure test isolation.
+
+    TinyDBConnector is implemented as a process-wide singleton; without resetting,
+    tests that use different temp DB files can end up sharing the same TinyDB
+    instance, causing cross-test contamination.
+    """
+    inst = getattr(TinyDBConnector, "_instance", None)
+    if inst is not None:
+        db = getattr(inst, "_db", None)
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                pass
+    TinyDBConnector._instance = None
 
 
 class TestDatasetEntry(unittest.TestCase):
@@ -39,11 +59,13 @@ class TestDatasetEntry(unittest.TestCase):
 
 class TestDatasetTable(unittest.TestCase):
     def setUp(self):
+        _reset_tinydb_singleton()
         self.dbfile = tempfile.NamedTemporaryFile(delete=True)
         self.table = DatasetTable(self.dbfile.name)
 
     def tearDown(self):
         self.dbfile.close()
+        _reset_tinydb_singleton()
 
     def test_insert_and_conflict(self):
         entry = {
@@ -128,11 +150,13 @@ class TestDatasetTable(unittest.TestCase):
 
 class TestDlpTable(unittest.TestCase):
     def setUp(self):
+        _reset_tinydb_singleton()
         self.dbfile = tempfile.NamedTemporaryFile(delete=True)
         self.table = DlpTable(self.dbfile.name)
 
     def tearDown(self):
         self.dbfile.close()
+        _reset_tinydb_singleton()
 
     def test_insert_invalid_target_type(self):
         entry = {
@@ -198,6 +222,188 @@ class TestDlpTable(unittest.TestCase):
             self.table.list_by_target_dataset_type("invalid")
         result = self.table.list_by_target_dataset_type(DatasetTypes.TABULAR.value)
         self.assertTrue(any(d["dlp_name"] == "dlp_listed" for d in result))
+
+
+class TestSecurityLoggingDatasetTable(unittest.TestCase):
+    def setUp(self):
+        _reset_tinydb_singleton()
+        self.dbfile = tempfile.NamedTemporaryFile(delete=True)
+        self.table = DatasetTable(self.dbfile.name)
+
+    def tearDown(self):
+        self.dbfile.close()
+        _reset_tinydb_singleton()
+
+    def _assert_security_event_called(
+        self, mock_security_event, *, operation: str, status: str, **expected_fields
+    ):
+        calls = [c.kwargs for c in mock_security_event.call_args_list]
+        for kwargs in calls:
+            if kwargs.get("operation") != operation:
+                continue
+            if kwargs.get("status") != status:
+                continue
+            if all(kwargs.get(k) == v for k, v in expected_fields.items()):
+                return
+        self.fail(
+            f"Expected security_event(operation={operation!r}, status={status!r}, fields={expected_fields!r}) not found. "
+            f"Calls were: {calls!r}"
+        )
+
+    def test_security_log_insert_includes_dataset_id(self):
+        entry = {
+            "name": "sec_ds",
+            "data_type": "image",
+            "tags": ["tag1"],
+            "description": "A test dataset",
+            "path": "/path/to/data",
+            "shape": [10, 10],
+            "dtypes": {"data": "float32"},
+        }
+        with patch(
+            "fedbiomed.node.dataset_manager._db_tables.logger.security_event"
+        ) as sec:
+            dataset_id = self.table.insert(entry)
+            self._assert_security_event_called(
+                sec,
+                operation="dataset_create",
+                status="success",
+                dataset_id=dataset_id,
+                entry_name="sec_ds",
+            )
+
+    def test_security_log_insert_includes_dlp_id_when_present(self):
+        entry = {
+            "name": "sec_ds_dlp",
+            "data_type": "image",
+            "tags": ["tag1"],
+            "description": "A test dataset",
+            "path": "/path/to/data",
+            "shape": [10, 10],
+            "dtypes": {"data": "float32"},
+            "dlp_id": "dlp_123",
+        }
+        with patch(
+            "fedbiomed.node.dataset_manager._db_tables.logger.security_event"
+        ) as sec:
+            dataset_id = self.table.insert(entry)
+            self._assert_security_event_called(
+                sec,
+                operation="dataset_create",
+                status="success",
+                dataset_id=dataset_id,
+                dlp_id="dlp_123",
+                entry_name="sec_ds_dlp",
+            )
+
+    def test_security_log_all_emits_dataset_list(self):
+        entry = {
+            "name": "sec_list",
+            "data_type": "image",
+            "tags": ["t"],
+            "description": "A test dataset",
+            "path": "/path/to/data",
+            "shape": [10, 10],
+            "dtypes": {"data": "float32"},
+        }
+        with patch(
+            "fedbiomed.node.dataset_manager._db_tables.logger.security_event"
+        ) as sec:
+            self.table.insert(entry)
+            sec.reset_mock()
+            rows = self.table.all()
+            self.assertEqual(len(rows), 1)
+            self._assert_security_event_called(
+                sec,
+                operation="dataset_list",
+                status="success",
+                record_count=1,
+            )
+
+    def test_security_log_get_by_id_emits_dataset_read(self):
+        entry = {
+            "name": "sec_read",
+            "data_type": "image",
+            "tags": ["t"],
+            "description": "A test dataset",
+            "path": "/path/to/data",
+            "shape": [10, 10],
+            "dtypes": {"data": "float32"},
+        }
+        with patch(
+            "fedbiomed.node.dataset_manager._db_tables.logger.security_event"
+        ) as sec:
+            dataset_id = self.table.insert(entry)
+            sec.reset_mock()
+            _ = self.table.get_by_id(dataset_id)
+            self._assert_security_event_called(
+                sec,
+                operation="dataset_read",
+                status="success",
+                dataset_id=dataset_id,
+                entry_name="sec_read",
+            )
+
+    def test_security_log_get_by_id_not_found_emits_not_found(self):
+        with patch(
+            "fedbiomed.node.dataset_manager._db_tables.logger.security_event"
+        ) as sec:
+            _ = self.table.get_by_id("NON_EXISTENT")
+            self._assert_security_event_called(
+                sec,
+                operation="dataset_read",
+                status="not_found",
+                dataset_id="NON_EXISTENT",
+            )
+
+    def test_security_log_update_by_id_emits_dataset_update(self):
+        entry = {
+            "name": "sec_update",
+            "data_type": "image",
+            "tags": ["t"],
+            "description": "A test dataset",
+            "path": "/path/to/data",
+            "shape": [10, 10],
+            "dtypes": {"data": "float32"},
+        }
+        with patch(
+            "fedbiomed.node.dataset_manager._db_tables.logger.security_event"
+        ) as sec:
+            dataset_id = self.table.insert(entry)
+            sec.reset_mock()
+            self.table.update_by_id(dataset_id, {"description": "changed"})
+            self._assert_security_event_called(
+                sec,
+                operation="dataset_update",
+                status="success",
+                dataset_id=dataset_id,
+                entry_name="sec_update",
+            )
+
+    def test_security_log_delete_by_id_emits_dataset_delete(self):
+        entry = {
+            "name": "sec_delete",
+            "data_type": "image",
+            "tags": ["t"],
+            "description": "A test dataset",
+            "path": "/path/to/data",
+            "shape": [10, 10],
+            "dtypes": {"data": "float32"},
+        }
+        with patch(
+            "fedbiomed.node.dataset_manager._db_tables.logger.security_event"
+        ) as sec:
+            dataset_id = self.table.insert(entry)
+            sec.reset_mock()
+            self.table.delete_by_id(dataset_id)
+            self._assert_security_event_called(
+                sec,
+                operation="dataset_delete",
+                status="success",
+                dataset_id=dataset_id,
+                entry_name="sec_delete",
+                data_type="image",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR starts implementing issue #1604. It follows up issue #1603 on writing the security logs after the security logger functionalities are implemented.
