### PR TITLE
Feature/361 security logs training plan security manager

### DIFF
--- a/fedbiomed/node/training_plan_security_manager.py
+++ b/fedbiomed/node/training_plan_security_manager.py
@@ -291,10 +291,31 @@ class TrainingPlanSecurityManager:
         try:
             self._db.insert(training_plan_record)
         except Exception as err:
+            logger.security_event(
+                operation="training_plan_register",
+                status="failure",
+                node_id=self._node_id,
+                node_name=self._node_name,
+                researcher_id=researcher_id,
+                training_plan_id=training_plan_id,
+                training_plan_name=name,
+                error=str(err),
+            )
             raise FedbiomedTrainingPlanSecurityManagerError(
                 ErrorNumbers.FB606.value + " : database insertion failed with"
                 f" following error: {str(err)}"
             ) from err
+
+        logger.security_event(
+            operation="training_plan_register",
+            status="success",
+            node_id=self._node_id,
+            node_name=self._node_name,
+            researcher_id=researcher_id,
+            training_plan_id=training_plan_id,
+            training_plan_name=name,
+            training_plan_type=training_plan_type,
+        )
         return training_plan_id
 
     def check_hashes_for_registered_training_plans(self):
@@ -573,6 +594,16 @@ class TrainingPlanSecurityManager:
                 logger.error(
                     f"Cannot add training plan in database due to error : {err}"
                 )
+                logger.security_event(
+                    operation="training_plan_approval_request_received",
+                    status="failure",
+                    node_id=self._node_id,
+                    node_name=self._node_name,
+                    researcher_id=request.researcher_id,
+                    request_id=request.request_id,
+                    training_plan_id=training_plan_name,
+                    error=str(err),
+                )
                 reply.update(
                     {
                         "message": "Cannot add training plan into database due to error",
@@ -582,6 +613,16 @@ class TrainingPlanSecurityManager:
                 return ApprovalReply(**reply)
 
             else:
+                logger.security_event(
+                    operation="training_plan_approval_request_received",
+                    status="success",
+                    node_id=self._node_id,
+                    node_name=self._node_name,
+                    researcher_id=request.researcher_id,
+                    request_id=request.request_id,
+                    training_plan_id=training_plan_name,
+                    training_plan_status=TrainingPlanApprovalStatus.PENDING.value,
+                )
                 reply["success"] = True
                 logger.debug("Training plan successfully received by Node for approval")
 
@@ -595,6 +636,19 @@ class TrainingPlanSecurityManager:
                         "Please wait for Node approval."
                     }
                 )
+                existing_tp = self.get_training_plan_from_database(training_plan)
+                logger.security_event(
+                    operation="training_plan_approval_request_received",
+                    status="already_pending",
+                    node_id=self._node_id,
+                    node_name=self._node_name,
+                    researcher_id=request.researcher_id,
+                    request_id=request.request_id,
+                    training_plan_id=existing_tp.get("training_plan_id")
+                    if existing_tp
+                    else None,
+                    message="Training plan already pending approval",
+                )
             elif self.check_training_plan_status(
                 training_plan, TrainingPlanApprovalStatus.APPROVED
             )[0]:
@@ -604,9 +658,35 @@ class TrainingPlanSecurityManager:
                         "to train on this training plan."
                     }
                 )
+                existing_tp = self.get_training_plan_from_database(training_plan)
+                logger.security_event(
+                    operation="training_plan_approval_request_received",
+                    status="already_approved",
+                    node_id=self._node_id,
+                    node_name=self._node_name,
+                    researcher_id=request.researcher_id,
+                    request_id=request.request_id,
+                    training_plan_id=existing_tp.get("training_plan_id")
+                    if existing_tp
+                    else None,
+                    message="Training plan already approved",
+                )
             else:
                 reply.update(
                     {"message": "Training plan already exists in database. Aborting"}
+                )
+                existing_tp = self.get_training_plan_from_database(training_plan)
+                logger.security_event(
+                    operation="training_plan_approval_request_received",
+                    status="duplicate",
+                    node_id=self._node_id,
+                    node_name=self._node_name,
+                    researcher_id=request.researcher_id,
+                    request_id=request.request_id,
+                    training_plan_id=existing_tp.get("training_plan_id")
+                    if existing_tp
+                    else None,
+                    message="Training plan already exists in database",
                 )
 
             reply.update({"success": True})
@@ -643,13 +723,26 @@ class TrainingPlanSecurityManager:
                 training_plan_status = training_plan.get(
                     "training_plan_status", "Not Registered"
                 )
-                reply.update(
-                    {"training_plan_id": training_plan.get("training_plan_id", None)}
-                )
+                training_plan_id = training_plan.get("training_plan_id", None)
+                reply.update({"training_plan_id": training_plan_id})
             else:
                 training_plan_status = "Not Registered"
+                training_plan_id = None
 
             reply.update({"success": True, "status": training_plan_status})
+
+            logger.security_event(
+                operation="training_plan_status_request",
+                status="checked",
+                node_id=self._node_id,
+                node_name=self._node_name,
+                researcher_id=request.researcher_id,
+                request_id=request.request_id,
+                training_plan_id=training_plan_id,
+                training_plan_status=training_plan_status,
+                experiment_id=request.experiment_id,
+            )
+
             if self._tp_approval:
                 if training_plan_status == TrainingPlanApprovalStatus.APPROVED.value:
                     msg = "Training plan has been approved by the node, training can start"
@@ -672,6 +765,16 @@ class TrainingPlanSecurityManager:
         # Catch all exception to be able send reply back to researcher
         except Exception as exp:
             logger.error(exp)
+            logger.security_event(
+                operation="training_plan_status_request",
+                status="failure",
+                node_id=self._node_id,
+                node_name=self._node_name,
+                researcher_id=request.researcher_id,
+                request_id=request.request_id,
+                experiment_id=request.experiment_id,
+                error=str(exp),
+            )
             reply.update(
                 {
                     "success": False,
@@ -936,13 +1039,41 @@ class TrainingPlanSecurityManager:
             return True
 
         else:
-            self._db.update(
-                {
-                    "training_plan_status": training_plan_status.value,
-                    "date_last_action": datetime.now().strftime("%d-%m-%Y %H:%M:%S.%f"),
-                    "notes": notes,
-                },
-                self._database.training_plan_id == training_plan_id,
+            try:
+                self._db.update(
+                    {
+                        "training_plan_status": training_plan_status.value,
+                        "date_last_action": datetime.now().strftime(
+                            "%d-%m-%Y %H:%M:%S.%f"
+                        ),
+                        "notes": notes,
+                    },
+                    self._database.training_plan_id == training_plan_id,
+                )
+            except Exception as err:
+                logger.security_event(
+                    operation="training_plan_status_update",
+                    status="failure",
+                    node_id=self._node_id,
+                    node_name=self._node_name,
+                    researcher_id=training_plan.get("researcher_id"),
+                    training_plan_id=training_plan_id,
+                    training_plan_name=training_plan.get("name"),
+                    new_status=training_plan_status.value,
+                    error=str(err),
+                )
+                raise
+
+            logger.security_event(
+                operation="training_plan_status_update",
+                status="success",
+                node_id=self._node_id,
+                node_name=self._node_name,
+                researcher_id=training_plan.get("researcher_id"),
+                training_plan_id=training_plan_id,
+                training_plan_name=training_plan.get("name"),
+                previous_status=training_plan.get("training_plan_status"),
+                new_status=training_plan_status.value,
             )
             logger.info(
                 f"Training plan {training_plan_id} status changed to {training_plan_status.value} !"
@@ -1024,10 +1155,30 @@ class TrainingPlanSecurityManager:
             try:
                 self._db.remove(doc_ids=[doc.doc_id])
             except Exception as err:
+                logger.security_event(
+                    operation="training_plan_delete",
+                    status="failure",
+                    node_id=self._node_id,
+                    node_name=self._node_name,
+                    researcher_id=training_plan.get("researcher_id"),
+                    training_plan_id=training_plan_id,
+                    training_plan_name=training_plan.get("name"),
+                    error=str(err),
+                )
                 raise FedbiomedTrainingPlanSecurityManagerError(
                     ErrorNumbers.FB606.value
                     + f": cannot remove training plan from database. Details: {str(err)}"
                 ) from err
+
+            logger.security_event(
+                operation="training_plan_delete",
+                status="success",
+                node_id=self._node_id,
+                node_name=self._node_name,
+                researcher_id=training_plan.get("researcher_id"),
+                training_plan_id=training_plan_id,
+                training_plan_name=training_plan.get("name"),
+            )
         else:
             raise FedbiomedTrainingPlanSecurityManagerError(
                 ErrorNumbers.FB606.value

--- a/fedbiomed/node/training_plan_security_manager.py
+++ b/fedbiomed/node/training_plan_security_manager.py
@@ -259,7 +259,20 @@ class TrainingPlanSecurityManager:
         training_plan_hash, algorithm, source = self._create_hash(path)
 
         # Verify no such training plan is already registered
-        self._check_training_plan_not_existing(name, training_plan_hash, None)
+        try:
+            self._check_training_plan_not_existing(name, training_plan_hash, None)
+        except FedbiomedTrainingPlanSecurityManagerError as err:
+            logger.security_event(
+                operation="training_plan_register",
+                status="failure",
+                node_id=self._node_id,
+                node_name=self._node_name,
+                researcher_id=researcher_id,
+                training_plan_id=training_plan_id,
+                training_plan_name=name,
+                error=str(err),
+            )
+            raise
 
         # Training plan file creation date
         ctime = datetime.fromtimestamp(os.path.getctime(path)).strftime(
@@ -465,6 +478,26 @@ class TrainingPlanSecurityManager:
         """
 
         training_plan = self._db.get(self._database.name == training_plan_name)
+
+        if training_plan:
+            logger.security_event(
+                operation="training_plan_view",
+                status="success",
+                node_id=self._node_id,
+                node_name=self._node_name,
+                training_plan_name=training_plan_name,
+                training_plan_id=training_plan.get("training_plan_id"),
+                training_plan_type=training_plan.get("training_plan_type"),
+                training_plan_status=training_plan.get("training_plan_status"),
+            )
+        else:
+            logger.security_event(
+                operation="training_plan_view",
+                status="not_found",
+                node_id=self._node_id,
+                node_name=self._node_name,
+                training_plan_name=training_plan_name,
+            )
 
         return training_plan
 
@@ -964,7 +997,21 @@ class TrainingPlanSecurityManager:
         if training_plan["training_plan_type"] != TrainingPlanStatus.DEFAULT.value:
             hash, algorithm, source = self._create_hash(path)
             # Verify no such training plan already exists in DB
-            self._check_training_plan_not_existing(None, hash, algorithm)
+            try:
+                self._check_training_plan_not_existing(None, hash, algorithm)
+            except FedbiomedTrainingPlanSecurityManagerError as err:
+                logger.security_event(
+                    operation="training_plan_update",
+                    status="failure",
+                    node_id=self._node_id,
+                    node_name=self._node_name,
+                    researcher_id=training_plan.get("researcher_id"),
+                    training_plan_id=training_plan_id,
+                    training_plan_name=training_plan.get("name"),
+                    training_plan_type=training_plan.get("training_plan_type"),
+                    error=str(err),
+                )
+                raise
 
             # Get modification date
             mtime = datetime.fromtimestamp(os.path.getmtime(path))
@@ -985,12 +1032,46 @@ class TrainingPlanSecurityManager:
                     },
                     self._database.training_plan_id == training_plan_id,
                 )
+                logger.security_event(
+                    operation="training_plan_update",
+                    status="success",
+                    node_id=self._node_id,
+                    node_name=self._node_name,
+                    researcher_id=training_plan.get("researcher_id"),
+                    training_plan_id=training_plan_id,
+                    training_plan_name=training_plan.get("name"),
+                    training_plan_type=training_plan.get("training_plan_type"),
+                    new_hash=hash,
+                    new_algorithm=algorithm,
+                )
             except Exception as err:
+                logger.security_event(
+                    operation="training_plan_update",
+                    status="failure",
+                    node_id=self._node_id,
+                    node_name=self._node_name,
+                    researcher_id=training_plan.get("researcher_id"),
+                    training_plan_id=training_plan_id,
+                    training_plan_name=training_plan.get("name"),
+                    training_plan_type=training_plan.get("training_plan_type"),
+                    error=str(err),
+                )
                 raise FedbiomedTrainingPlanSecurityManagerError(
                     ErrorNumbers.FB606.value + ": update database failed. Details :"
                     f"{str(err)}"
                 ) from err
         else:
+            logger.security_event(
+                operation="training_plan_update",
+                status="failure",
+                node_id=self._node_id,
+                node_name=self._node_name,
+                researcher_id=training_plan.get("researcher_id"),
+                training_plan_id=training_plan_id,
+                training_plan_name=training_plan.get("name"),
+                training_plan_type=training_plan.get("training_plan_type"),
+                reason="attempted_update_default_training_plan",
+            )
             raise FedbiomedTrainingPlanSecurityManagerError(
                 ErrorNumbers.FB606.value
                 + "You cannot update default training plans. Please "
@@ -1242,6 +1323,16 @@ class TrainingPlanSecurityManager:
         try:
             training_plans = self._db.search(query)
         except Exception as err:
+            logger.security_event(
+                operation="training_plan_list",
+                status="failure",
+                node_id=self._node_id,
+                node_name=self._node_name,
+                sort_by=sort_by,
+                has_status_filter=select_status is not None,
+                has_search_filter=search is not None,
+                error=str(err),
+            )
             raise FedbiomedTrainingPlanSecurityManagerError(
                 f"{ErrorNumbers.FB606.value}: request failed when looking for a training plan into database with "
                 f"error: {err}"
@@ -1260,6 +1351,17 @@ class TrainingPlanSecurityManager:
                 )
             else:
                 logger.warning(f"Field {sort_by} is not available in dataset")
+
+        logger.security_event(
+            operation="training_plan_list",
+            status="success",
+            node_id=self._node_id,
+            node_name=self._node_name,
+            training_plans_count=len(training_plans),
+            sort_by=sort_by,
+            has_status_filter=select_status is not None,
+            has_search_filter=search is not None,
+        )
 
         if verbose:
             training_plans_verbose = training_plans.copy()

--- a/tests/test_training_plan_security_manager.py
+++ b/tests/test_training_plan_security_manager.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
+import pytest
 from tinydb.table import Document
 
 from fedbiomed.common.constants import (
@@ -714,6 +715,337 @@ class TestTrainingPlanSecurityManager(unittest.TestCase):
         # check
         self.assertEqual(doc2[key_notsensible], doc[key_notsensible])
         self.assertFalse(key_sensible in doc2)
+
+
+# ============ PYTEST STYLE TESTS FOR SECURITY LOGGING ============
+
+
+@pytest.fixture
+def temp_db_pytest():
+    """Pytest fixture for temporary database."""
+    temp_dir = tempfile.TemporaryDirectory()
+    db_path = os.path.join(temp_dir.name, "test-db.json")
+    yield db_path, temp_dir
+    temp_dir.cleanup()
+
+
+@pytest.fixture
+def tp_security_manager_pytest(temp_db_pytest):
+    """Pytest fixture for TrainingPlanSecurityManager with I/O-free hashing + mocked logging.
+
+    Notes:
+    - Do NOT patch `builtins.open` globally: TinyDB uses it for the DB JSON file.
+    - Instead, stub `_create_hash` to avoid reading training plan files.
+    - Mock `logger` in the module under test to avoid side effects (eg. system info collection).
+    """
+
+    import hashlib
+
+    db_path, _ = temp_db_pytest
+
+    with (
+        patch("fedbiomed.node.training_plan_security_manager.logger") as mock_logger,
+        patch(
+            "fedbiomed.node.training_plan_security_manager.os.path.getctime",
+            return_value=1000000,
+        ),
+        patch(
+            "fedbiomed.node.training_plan_security_manager.os.path.getmtime",
+            return_value=1000000,
+        ),
+        patch.object(
+            TrainingPlanSecurityManager,
+            "_create_hash",
+            autospec=True,
+        ) as mock_create_hash,
+    ):
+
+        def _create_hash_side_effect(_self, source: str, from_string: bool = False):
+            # When hashing a file path, avoid touching the filesystem.
+            # When hashing source code (from_string=True), keep determinism based on content.
+            if from_string:
+                content = source
+                source_out = source
+            else:
+                content = f"mock_tp_source:{source}"
+                source_out = content
+
+            digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+            return digest, "SHA256", source_out
+
+        mock_create_hash.side_effect = _create_hash_side_effect
+
+        manager = TrainingPlanSecurityManager(
+            db=db_path,
+            node_id="pytest-node-id",
+            node_name="pytest-node-name",
+            hashing="SHA256",
+            tp_approval=True,
+        )
+
+        # Attach mocks to manager for easy access in tests
+        manager.mock_security_event = mock_logger.security_event
+        manager.mock_logger = mock_logger
+        manager.mock_create_hash = mock_create_hash
+
+        yield manager
+
+        manager._tinydb.drop_table("TrainingPlans")
+        manager._tinydb.close()
+
+
+@pytest.fixture
+def test_training_plan_source():
+    """Pytest fixture for test training plan source code."""
+    return """
+from fedbiomed.common.training_plans import TorchTrainingPlan
+
+class TestTrainingPlan(TorchTrainingPlan):
+    def init_model(self, model_args):
+        return None
+
+    def training_step(self, batch):
+        pass
+"""
+
+
+def test_security_log_register_training_plan_success(tp_security_manager_pytest):
+    """Pytest: Verify training plan registration logs security event."""
+    manager = tp_security_manager_pytest
+
+    tp_id = manager.register_training_plan(
+        name="pytest_tp",
+        description="Pytest training plan",
+        path="/mock/path/tp.py",
+        researcher_id="pytest_researcher",
+    )
+
+    # Verify security_event call
+    manager.mock_security_event.assert_called()
+    call_kwargs = manager.mock_security_event.call_args.kwargs
+
+    assert call_kwargs["operation"] == "training_plan_register"
+    assert call_kwargs["status"] == "success"
+    assert call_kwargs["node_id"] == "pytest-node-id"
+    assert call_kwargs["node_name"] == "pytest-node-name"
+    assert call_kwargs["researcher_id"] == "pytest_researcher"
+    assert call_kwargs["training_plan_id"] == tp_id
+    assert call_kwargs["training_plan_name"] == "pytest_tp"
+
+
+def test_security_log_delete_training_plan_success(tp_security_manager_pytest):
+    """Pytest: Verify training plan deletion logs security event."""
+    manager = tp_security_manager_pytest
+
+    # Register first
+    tp_id = manager.register_training_plan(
+        name="pytest_tp_del",
+        description="Pytest training plan for deletion",
+        path="/mock/path/tp_del.py",
+        researcher_id="pytest_researcher",
+    )
+
+    manager.mock_security_event.reset_mock()
+
+    # Delete
+    manager.delete_training_plan(tp_id)
+
+    # Verify security_event call
+    manager.mock_security_event.assert_called()
+    call_kwargs = manager.mock_security_event.call_args.kwargs
+
+    assert call_kwargs["operation"] == "training_plan_delete"
+    assert call_kwargs["status"] == "success"
+    assert call_kwargs["node_id"] == "pytest-node-id"
+    assert call_kwargs["node_name"] == "pytest-node-name"
+    assert call_kwargs["training_plan_id"] == tp_id
+
+
+def test_security_log_approve_training_plan(
+    tp_security_manager_pytest, test_training_plan_source
+):
+    """Pytest: Verify training plan approval logs security event."""
+    manager = tp_security_manager_pytest
+
+    # Create a PENDING training plan first (registration via CLI creates APPROVED by default)
+    request = ApprovalRequest(
+        researcher_id="pytest_researcher",
+        request_id="pytest_req_approve_001",
+        training_plan=test_training_plan_source,
+        description="Pytest approval",
+    )
+    manager.reply_training_plan_approval_request(request)
+
+    tp_info = manager.get_training_plan_from_database(test_training_plan_source)
+    assert tp_info is not None
+    tp_id = tp_info["training_plan_id"]
+
+    manager.mock_security_event.reset_mock()
+
+    # Approve
+    manager.approve_training_plan(tp_id, extra_notes="Approved in pytest")
+
+    # Verify security_event call
+    manager.mock_security_event.assert_called()
+    call_kwargs = manager.mock_security_event.call_args.kwargs
+
+    assert call_kwargs["operation"] == "training_plan_status_update"
+    assert call_kwargs["status"] == "success"
+    assert call_kwargs["node_id"] == "pytest-node-id"
+    assert call_kwargs["node_name"] == "pytest-node-name"
+    assert call_kwargs["new_status"] == TrainingPlanApprovalStatus.APPROVED.value
+
+
+def test_security_log_reject_training_plan(tp_security_manager_pytest):
+    """Pytest: Verify training plan rejection logs security event."""
+    manager = tp_security_manager_pytest
+
+    # Register first
+    tp_id = manager.register_training_plan(
+        name="pytest_tp_reject",
+        description="Pytest training plan for rejection",
+        path="/mock/path/tp_reject.py",
+        researcher_id="pytest_researcher",
+    )
+
+    manager.mock_security_event.reset_mock()
+
+    # Reject
+    manager.reject_training_plan(tp_id, extra_notes="Rejected in pytest")
+
+    # Verify security_event call
+    manager.mock_security_event.assert_called()
+    call_kwargs = manager.mock_security_event.call_args.kwargs
+
+    assert call_kwargs["operation"] == "training_plan_status_update"
+    assert call_kwargs["status"] == "success"
+    assert call_kwargs["new_status"] == TrainingPlanApprovalStatus.REJECTED.value
+
+
+def test_security_log_approval_request_received(
+    tp_security_manager_pytest, test_training_plan_source
+):
+    """Pytest: Verify approval request logs security event with request_id."""
+    manager = tp_security_manager_pytest
+    request = ApprovalRequest(
+        researcher_id="pytest_researcher",
+        request_id="pytest_req_001",
+        training_plan=test_training_plan_source,
+        description="Pytest approval request",
+    )
+
+    manager.reply_training_plan_approval_request(request)
+
+    # Verify security_event call
+    manager.mock_security_event.assert_called()
+    call_kwargs = manager.mock_security_event.call_args.kwargs
+
+    assert call_kwargs["operation"] == "training_plan_approval_request_received"
+    assert call_kwargs["status"] == "success"
+    assert call_kwargs["node_id"] == "pytest-node-id"
+    assert call_kwargs["node_name"] == "pytest-node-name"
+    assert call_kwargs["researcher_id"] == "pytest_researcher"
+    assert call_kwargs["request_id"] == "pytest_req_001"
+    assert (
+        call_kwargs["training_plan_status"] == TrainingPlanApprovalStatus.PENDING.value
+    )
+
+
+def test_security_log_status_request(
+    tp_security_manager_pytest, test_training_plan_source
+):
+    """Pytest: Verify status request logs security event with experiment_id."""
+    manager = tp_security_manager_pytest
+    # Register and approve first
+    request = ApprovalRequest(
+        researcher_id="pytest_researcher",
+        request_id="pytest_req_001",
+        training_plan=test_training_plan_source,
+        description="Pytest approval",
+    )
+
+    manager.reply_training_plan_approval_request(request)
+    tp_info = manager.get_training_plan_from_database(test_training_plan_source)
+    manager.approve_training_plan(tp_info["training_plan_id"])
+
+    manager.mock_security_event.reset_mock()
+
+    # Send status request
+    status_request = TrainingPlanStatusRequest(
+        researcher_id="pytest_researcher",
+        request_id="pytest_status_001",
+        training_plan=test_training_plan_source,
+        experiment_id="pytest_exp_001",
+    )
+
+    manager.reply_training_plan_status_request(status_request)
+
+    # Verify security_event call
+    manager.mock_security_event.assert_called()
+    call_kwargs = manager.mock_security_event.call_args.kwargs
+
+    assert call_kwargs["operation"] == "training_plan_status_request"
+    assert call_kwargs["status"] == "checked"
+    assert call_kwargs["node_id"] == "pytest-node-id"
+    assert call_kwargs["node_name"] == "pytest-node-name"
+    assert call_kwargs["researcher_id"] == "pytest_researcher"
+    assert call_kwargs["request_id"] == "pytest_status_001"
+    assert call_kwargs["experiment_id"] == "pytest_exp_001"
+    assert (
+        call_kwargs["training_plan_status"] == TrainingPlanApprovalStatus.APPROVED.value
+    )
+
+
+@pytest.mark.parametrize(
+    "status,expected_message",
+    [
+        ("already_pending", "Training plan already pending approval"),
+        ("already_approved", "Training plan already approved"),
+    ],
+)
+def test_security_log_duplicate_approval_requests(
+    tp_security_manager_pytest,
+    test_training_plan_source,
+    status,
+    expected_message,
+):
+    """Pytest: Verify duplicate approval requests log correct status."""
+    manager = tp_security_manager_pytest
+    # Register and set appropriate status
+    request = ApprovalRequest(
+        researcher_id="pytest_researcher",
+        request_id="pytest_req_001",
+        training_plan=test_training_plan_source,
+        description="Pytest approval",
+    )
+
+    manager.reply_training_plan_approval_request(request)
+    tp_info = manager.get_training_plan_from_database(test_training_plan_source)
+
+    if status == "already_approved":
+        manager.approve_training_plan(tp_info["training_plan_id"])
+
+    manager.mock_security_event.reset_mock()
+
+    # Send another request
+    request2 = ApprovalRequest(
+        researcher_id="pytest_researcher_2",
+        request_id="pytest_req_002",
+        training_plan=test_training_plan_source,
+        description="Pytest approval 2",
+    )
+
+    manager.reply_training_plan_approval_request(request2)
+
+    # Verify security_event call
+    manager.mock_security_event.assert_called()
+    call_kwargs = manager.mock_security_event.call_args.kwargs
+
+    assert call_kwargs["operation"] == "training_plan_approval_request_received"
+    assert call_kwargs["status"] == status
+    assert call_kwargs["node_id"] == "pytest-node-id"
+    assert call_kwargs["node_name"] == "pytest-node-name"
+    assert call_kwargs["request_id"] == "pytest_req_002"
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
This PR is for implementing issue https://github.com/fedbiomed/fedbiomed/issues/1604. It follows up issue https://github.com/fedbiomed/fedbiomed/issues/1603 on writing the security logs after the security logger functionalities are implemented.

It adds security logging for the CRUD and Approve/Reject operations for Training Plans on the Training Plan Security Manager on the node side.