### PR TITLE
Add Security Logging for CRUD operations in Certificate Manager. Add unit tests.

### DIFF
--- a/fedbiomed/common/certificate_manager.py
+++ b/fedbiomed/common/certificate_manager.py
@@ -20,6 +20,7 @@ from fedbiomed.common.constants import (
 )
 from fedbiomed.common.db import DBTable
 from fedbiomed.common.exceptions import FedbiomedCertificateError
+from fedbiomed.common.logger import logger
 from fedbiomed.common.utils import read_file
 
 
@@ -34,7 +35,7 @@ class CertificateManager:
         """Constructs certificate manager
 
         Args:
-            db: The name of the DB file to connect through TinyDB
+            db_path: The name of the DB file to connect through TinyDB
         """
 
         self._db: Union[Table, None] = None
@@ -76,29 +77,52 @@ class CertificateManager:
         Raises:
             FedbiomedCertificateError: party is already registered
         """
-        certificate_ = self.get(party_id=party_id)
-        if not certificate_:
-            return self._db.insert(
-                {
-                    "certificate": certificate,
-                    "party_id": party_id,
-                    "component": component,
-                }
-            )
+        try:
+            certificate_ = self.get(party_id=party_id)
+            if not certificate_:
+                result = self._db.insert(
+                    {
+                        "certificate": certificate,
+                        "party_id": party_id,
+                        "component": component,
+                    }
+                )
+                logger.security_event(
+                    operation="certificate_insert",
+                    status="success",
+                    component=component,
+                    party_id=party_id,
+                )
+                return result
 
-        if upsert:
-            return self._db.upsert(
-                {
-                    "certificate": certificate,
-                    "component": component,
-                    "party_id": party_id,
-                },
-                self._query.party_id == party_id,
+            if upsert:
+                result = self._db.upsert(
+                    {
+                        "certificate": certificate,
+                        "component": component,
+                        "party_id": party_id,
+                    },
+                    self._query.party_id == party_id,
+                )
+                logger.security_event(
+                    operation="certificate_insert",
+                    status="success",
+                    component=component,
+                    party_id=party_id,
+                )
+                return result
+            raise FedbiomedCertificateError(
+                f"{ErrorNumbers.FB619.value}: Party {party_id} already registered. "
+                "Please use `upsert=True` or '--upsert' option through CLI"
             )
-        raise FedbiomedCertificateError(
-            f"{ErrorNumbers.FB619.value}: Party {party_id} already registered. "
-            "Please use `upsert=True` or '--upsert' option through CLI"
-        )
+        except FedbiomedCertificateError:
+            logger.security_event(
+                operation="certificate_insert",
+                status="failure",
+                component=component,
+                party_id=party_id,
+            )
+            raise
 
     def get(self, party_id: str) -> Union[dict, None]:
         """Gets certificate/public key  of given party
@@ -109,9 +133,21 @@ class CertificateManager:
         Returns:
             Certificate, dict like TinyDB document
         """
-
-        v = self._db.get(self._query.party_id == party_id)
-        return v
+        try:
+            v = self._db.get(self._query.party_id == party_id)
+            logger.security_event(
+                operation="certificate_get",
+                status="success",
+                party_id=party_id,
+            )
+            return v
+        except Exception:
+            logger.security_event(
+                operation="certificate_get",
+                status="failure",
+                party_id=party_id,
+            )
+            raise
 
     def delete(self, party_id) -> List[int]:
         """Deletes given party from table
@@ -122,8 +158,21 @@ class CertificateManager:
         Returns:
             The document IDs of deleted certificates
         """
-
-        return self._db.remove(self._query.party_id == party_id)
+        try:
+            result = self._db.remove(self._query.party_id == party_id)
+            logger.security_event(
+                operation="certificate_delete",
+                status="success",
+                party_id=party_id,
+            )
+            return result
+        except Exception:
+            logger.security_event(
+                operation="certificate_delete",
+                status="failure",
+                party_id=party_id,
+            )
+            raise
 
     def list(self, verbose: bool = False) -> List[dict]:
         """Lists registered certificates.
@@ -134,16 +183,27 @@ class CertificateManager:
         Returns:
             List of certificate objects registered in DB
         """
-        certificates = self._db.all()
+        try:
+            certificates = self._db.all()
 
-        if verbose:
-            to_print = copy.deepcopy(certificates)
-            for doc in to_print:
-                doc.pop("certificate")
+            if verbose:
+                to_print = copy.deepcopy(certificates)
+                for doc in to_print:
+                    doc.pop("certificate")
 
-            print(tabulate(to_print, headers="keys"))
+                print(tabulate(to_print, headers="keys"))
 
-        return certificates
+            logger.security_event(
+                operation="certificate_list",
+                status="success",
+            )
+            return certificates
+        except Exception:
+            logger.security_event(
+                operation="certificate_list",
+                status="failure",
+            )
+            raise
 
     def register_certificate(
         self,
@@ -165,28 +225,43 @@ class CertificateManager:
         Raises:
             FedbiomedCertificateError: If certificate file is not existing in file system
         """
-
-        if not os.path.isfile(certificate_path):
-            raise FedbiomedCertificateError(
-                f"{ErrorNumbers.FB619.value}: Certificate path does not represents a file."
-            )
-
-        # Read certificate content
-        certificate_content = read_file(certificate_path)
-
-        # Save certificate in database
+        # Determine component type early so it's available in exception handler
         component = (
             ComponentType.NODE.name
             if party_id.startswith(NODE_PREFIX)
             else ComponentType.RESEARCHER.name
         )
 
-        return self.insert(
-            certificate=certificate_content,
-            party_id=party_id,
-            component=component,
-            upsert=upsert,
-        )
+        try:
+            if not os.path.isfile(certificate_path):
+                raise FedbiomedCertificateError(
+                    f"{ErrorNumbers.FB619.value}: Certificate path does not represents a file."
+                )
+
+            # Read certificate content
+            certificate_content = read_file(certificate_path)
+
+            result = self.insert(
+                certificate=certificate_content,
+                party_id=party_id,
+                component=component,
+                upsert=upsert,
+            )
+            logger.security_event(
+                operation="certificate_register",
+                status="success",
+                component=component,
+                party_id=party_id,
+            )
+            return result
+        except FedbiomedCertificateError:
+            logger.security_event(
+                operation="certificate_register",
+                status="failure",
+                component=component,
+                party_id=party_id,
+            )
+            raise
 
     @staticmethod
     def _write_certificate_file(path: str, certificate: str) -> None:

--- a/fedbiomed/common/certificate_manager.py
+++ b/fedbiomed/common/certificate_manager.py
@@ -228,7 +228,7 @@ class CertificateManager:
         # Determine component type early so it's available in exception handler
         component = (
             ComponentType.NODE.name
-            if party_id.startswith(NODE_PREFIX)
+            if party_id.lower().startswith(NODE_PREFIX)
             else ComponentType.RESEARCHER.name
         )
 

--- a/tests/test_certificate_manager.py
+++ b/tests/test_certificate_manager.py
@@ -285,6 +285,118 @@ class TestCertificateManager(unittest.TestCase):
                     component_id="component-id",
                 )
 
+    def test_11_certificate_manager_insert_security_logging(self):
+        """Tests security logging for insert method"""
+        certificate = "Dummy certificate"
+        party_id = "test-id"
+        component = "researcher"
+
+        with patch("fedbiomed.common.certificate_manager.logger") as mock_logger:
+            # Assume get returns empty (new certificate)
+            self.tiny_db_table_mock.return_value.get.return_value = None
+            self.cm.insert(
+                certificate=certificate,
+                party_id=party_id,
+                component=component,
+            )
+            # Verify security_event was called with success
+            mock_logger.security_event.assert_called_with(
+                operation="certificate_insert",
+                status="success",
+                component=component,
+                party_id=party_id,
+            )
+
+    def test_12_certificate_manager_insert_failure_security_logging(self):
+        """Tests security logging for insert failure"""
+        certificate = "Dummy certificate"
+        party_id = "test-id"
+        component = "researcher"
+
+        with patch("fedbiomed.common.certificate_manager.logger") as mock_logger:
+            # Assume get returns existing certificate (no upsert)
+            self.tiny_db_table_mock.return_value.get.return_value = {
+                "certificate": "xxx"
+            }
+            with self.assertRaises(FedbiomedCertificateError):
+                self.cm.insert(
+                    certificate=certificate,
+                    party_id=party_id,
+                    component=component,
+                )
+            # Verify security_event was called with failure
+            mock_logger.security_event.assert_called_with(
+                operation="certificate_insert",
+                status="failure",
+                component=component,
+                party_id=party_id,
+            )
+
+    def test_13_certificate_manager_get_security_logging(self):
+        """Tests security logging for get method"""
+        party_id = "Test-ID"
+        with patch("fedbiomed.common.certificate_manager.logger") as mock_logger:
+            self.cm.get(party_id)
+            # Verify security_event was called with success
+            mock_logger.security_event.assert_called_with(
+                operation="certificate_get",
+                status="success",
+                party_id=party_id,
+            )
+
+    def test_14_certificate_manager_delete_security_logging(self):
+        """Tests security logging for delete method"""
+        party_id = "Test-ID"
+        with patch("fedbiomed.common.certificate_manager.logger") as mock_logger:
+            self.cm.delete(party_id)
+            # Verify security_event was called with success
+            mock_logger.security_event.assert_called_with(
+                operation="certificate_delete",
+                status="success",
+                party_id=party_id,
+            )
+
+    def test_15_certificate_manager_list_security_logging(self):
+        """Tests security logging for list method"""
+        dummy_result = [{"certificate": "xxxx", "party_id": "xxxx"}]
+        self.tiny_db_table_mock.return_value.all.return_value = dummy_result
+
+        with patch("fedbiomed.common.certificate_manager.logger") as mock_logger:
+            result = self.cm.list()
+            # Verify security_event was called with success
+            mock_logger.security_event.assert_called_with(
+                operation="certificate_list",
+                status="success",
+            )
+            self.assertListEqual(result, dummy_result)
+
+    def test_16_certificate_manager_register_certificate_security_logging(self):
+        """Tests security logging for register_certificate method"""
+        arguments = {
+            "certificate_path": "dummy/path",
+            "party_id": "node_party-id",
+        }
+
+        with (
+            patch("os.path.isfile") as mock_isfile,
+            patch("fedbiomed.common.certificate_manager.read_file") as mock_read,
+            patch("fedbiomed.common.certificate_manager.logger") as mock_logger,
+        ):
+            mock_isfile.return_value = True
+            mock_read.return_value = "Test certificate"
+            self.tiny_db_table_mock.return_value.get.return_value = None
+            self.tiny_db_table_mock.return_value.insert.return_value = 456
+
+            self.cm.register_certificate(**arguments)
+            # Verify security_event was called with success
+            # Note: register_certificate calls insert which also logs, so we check the last call
+            calls = mock_logger.security_event.call_args_list
+            # Last call should be from register_certificate
+            self.assertEqual(calls[-1][1]["operation"], "certificate_register")
+            self.assertEqual(calls[-1][1]["status"], "success")
+            self.assertEqual(calls[-1][1]["component"], "NODE")
+            self.assertEqual(calls[-1][1]["party_id"], "node_party-id")
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
This PR is for implementing issue #1604 . It follows up issue #1603 on writing the security logs after the security logger functionalities are implemented.

It adds security logging for the CRUD operations on the Certificate Manager.