### PR TITLE
Add Security Logs to the config operations in the Common Config.py file.

### DIFF
--- a/fedbiomed/common/config.py
+++ b/fedbiomed/common/config.py
@@ -159,7 +159,7 @@ class Config(metaclass=ABCMeta):
                 fedbiomed_version=__version__,
             )
             raise FedbiomedConfigurationError(
-                f"{ErrorNumbers.FB600.value}: cannot read config file:  {self.path}"
+                f"{ErrorNumbers.FB600.value}: cannot read config file:  {self.config_path}"
             ) from e
 
     def get(self, section, key, **kwargs) -> str:
@@ -231,7 +231,7 @@ class Config(metaclass=ABCMeta):
                 fedbiomed_version=__version__,
             )
             raise FedbiomedConfigurationError(
-                f"{ErrorNumbers.FB600.value}: cannot save config file:  {self.path}"
+                f"{ErrorNumbers.FB600.value}: cannot save config file:  {self.config_path}"
             ) from exp
 
     def generate(self, id: Optional[str] = None) -> None:

--- a/fedbiomed/common/config.py
+++ b/fedbiomed/common/config.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from packaging.version import Version
 
+from fedbiomed import __version__
 from fedbiomed.common.constants import (
     CERTS_FOLDER_NAME,
     CONFIG_FOLDER_NAME,
@@ -17,6 +18,7 @@ from fedbiomed.common.constants import (
     ErrorNumbers,
 )
 from fedbiomed.common.exceptions import FedbiomedConfigurationError
+from fedbiomed.common.logger import logger
 from fedbiomed.common.utils import (
     create_fedbiomed_setup_folders,
     raise_for_version_compatibility,
@@ -70,6 +72,10 @@ class Config(metaclass=ABCMeta):
             root: Root directory for the component.
         """
         self._cfg = configparser.ConfigParser()
+        # Set up security logging for config operations
+        # This ensures security events are captured even before Node/Researcher initialization
+        logger.set_security_logs(root_path=root)
+        logger.setLevel("INFO")
         self.load(root)
 
     @classmethod
@@ -98,6 +104,15 @@ class Config(metaclass=ABCMeta):
 
         self.root = root
         self.config_path = os.path.join(self.root, "etc", self._CONFIG_FILE_NAME)
+        # import pdb; pdb.set_trace()
+        logger.security_event(
+            operation="config_load_start",
+            status="initiated",
+            config_path=self.config_path,
+            config_root=self.root,
+            component_type=self.COMPONENT_TYPE,
+            fedbiomed_version=__version__,
+        )
         self.generate()
 
     def is_config_existing(self) -> bool:
@@ -114,16 +129,36 @@ class Config(metaclass=ABCMeta):
 
         Raises version compatibility error
         """
-        self._cfg.read(self.config_path)
+        try:
+            self._cfg.read(self.config_path)
 
-        # Validate config version
-        raise_for_version_compatibility(
-            self._cfg["default"]["version"],
-            self._CONFIG_VERSION,
-            f"Configuration file {self.config_path}: found version %s expected version %s",
-        )
+            # Validate config version
+            raise_for_version_compatibility(
+                self._cfg["default"]["version"],
+                self._CONFIG_VERSION,
+                f"Configuration file {self.config_path}: found version %s expected version %s",
+            )
 
-        return True
+            logger.security_event(
+                operation="config_read",
+                status="success",
+                config_path=self.config_path,
+                config_version=self._cfg["default"]["version"],
+                component_type=self.COMPONENT_TYPE,
+                fedbiomed_version=__version__,
+            )
+
+            return True
+        except Exception as e:
+            logger.security_event(
+                operation="config_read",
+                status="failure",
+                config_path=self.config_path,
+                error_message=str(e),
+                component_type=self.COMPONENT_TYPE,
+                fedbiomed_version=__version__,
+            )
+            raise
 
     def get(self, section, key, **kwargs) -> str:
         """Returns value for given key and section"""
@@ -157,6 +192,14 @@ class Config(metaclass=ABCMeta):
             value: the value of the attribute that was just set
         """
         self._cfg.set(section, key, value)
+        logger.security_event(
+            operation="config_set",
+            status="success",
+            config_section=section,
+            config_key=key,
+            component_type=self.COMPONENT_TYPE,
+            fedbiomed_version=__version__,
+        )
 
     def sections(self) -> list:
         """Returns sections of the config"""
@@ -169,7 +212,22 @@ class Config(metaclass=ABCMeta):
         try:
             with open(self.config_path, "w", encoding="UTF-8") as f:
                 self._cfg.write(f)
+            logger.security_event(
+                operation="config_write",
+                status="success",
+                config_path=self.config_path,
+                component_type=self.COMPONENT_TYPE,
+                fedbiomed_version=__version__,
+            )
         except configparser.Error as exp:
+            logger.security_event(
+                operation="config_write",
+                status="failure",
+                config_path=self.config_path,
+                error_message=str(exp),
+                component_type=self.COMPONENT_TYPE,
+                fedbiomed_version=__version__,
+            )
             raise FedbiomedConfigurationError(
                 f"{ErrorNumbers.FB600.value}: cannot save config file:  {self.path}"
             ) from exp
@@ -202,10 +260,30 @@ class Config(metaclass=ABCMeta):
 
             # Calls child class add_parameterss
             self.add_parameters()
+
+            logger.security_event(
+                operation="config_generate",
+                status="success",
+                config_path=self.config_path,
+                component_id=component_id,
+                component_type=self.COMPONENT_TYPE,
+                config_version=str(self._CONFIG_VERSION),
+                fedbiomed_version=__version__,
+            )
         else:
             self.read()
             # Provide migration
             self.migrate()
+
+            logger.security_event(
+                operation="config_load_existing",
+                status="success",
+                config_path=self.config_path,
+                component_id=self._cfg["default"]["id"],
+                component_type=self.COMPONENT_TYPE,
+                config_version=self._cfg["default"]["version"],
+                fedbiomed_version=__version__,
+            )
 
         self._update_vars()
 

--- a/fedbiomed/common/config.py
+++ b/fedbiomed/common/config.py
@@ -158,7 +158,9 @@ class Config(metaclass=ABCMeta):
                 component_type=self.COMPONENT_TYPE,
                 fedbiomed_version=__version__,
             )
-            raise
+            raise FedbiomedConfigurationError(
+                f"{ErrorNumbers.FB600.value}: cannot read config file:  {self.path}"
+            ) from e
 
     def get(self, section, key, **kwargs) -> str:
         """Returns value for given key and section"""

--- a/fedbiomed/common/logger.py
+++ b/fedbiomed/common/logger.py
@@ -446,8 +446,8 @@ class FedLogger(metaclass=SingletonMeta):
 
         entry = {
             "timestamp": _utc_timestamp(),
-            "node_id": self._security_defaults.get("component_id"),
-            "node_name": self._security_defaults.get("component_name"),
+            "component_id": self._security_defaults.get("component_id"),
+            "component_name": self._security_defaults.get("component_name"),
             "researcher_id": rid,
             "operation": op,
             "status": st,

--- a/fedbiomed/node/node.py
+++ b/fedbiomed/node/node.py
@@ -131,7 +131,7 @@ class Node:
 
         # Log node creation
         logger.security_event(
-            operation="node_created",
+            operation="node_initialized",
             status="success",
             researcher_id=None,
             node_name=self._node_name,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,146 @@
+import configparser
 import shutil
 import unittest
 from unittest.mock import patch
 
+import pytest
+from packaging.version import Version
+
 from fedbiomed.common.config import Config
-from fedbiomed.common.exceptions import FedbiomedVersionError
+from fedbiomed.common.exceptions import (
+    FedbiomedConfigurationError,
+)
 from fedbiomed.node.config import NodeConfig
 from fedbiomed.researcher.config import ResearcherConfig
+
+# -----------------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def patch_security_logger(mocker):
+    """Patch security logging hooks in the module where Config uses them."""
+    set_security_logs = mocker.patch("fedbiomed.common.config.logger.set_security_logs")
+    security_event = mocker.patch("fedbiomed.common.config.logger.security_event")
+    mocker.patch("fedbiomed.common.config.logger.setLevel")
+    return set_security_logs, security_event
+
+
+@pytest.fixture()
+def DummyConfig():
+    """Concrete Config for tests (avoid patching abstractmethods)."""
+
+    class _DummyConfig(Config):
+        _CONFIG_VERSION = Version("1.0")
+        COMPONENT_TYPE = "DUMMY"
+
+        def add_parameters(self):
+            self._cfg["dummy"] = {"x": "y"}
+
+        def migrate(self):
+            return
+
+    return _DummyConfig
+
+
+@pytest.fixture()
+def patch_cert_generation(mocker, tmp_path):
+    """Avoid crypto/fs side effects for Node/Researcher configs."""
+    mocker.patch(
+        "fedbiomed.node.config.generate_certificate",
+        lambda **kwargs: (str(tmp_path / "k.key"), str(tmp_path / "c.pem")),
+    )
+    mocker.patch(
+        "fedbiomed.researcher.config.generate_certificate",
+        lambda **kwargs: (str(tmp_path / "k.key"), str(tmp_path / "c.pem")),
+    )
+
+
+###################################
+##### Tests for security logging
+###################################
+
+
+def test_security_logging_called_on_init_load_generate(
+    tmp_path, mocker, patch_security_logger, DummyConfig
+):
+    set_security_logs, security_event = patch_security_logger
+
+    mocker.patch.object(DummyConfig, "is_config_existing", return_value=False)
+    DummyConfig(root=str(tmp_path))
+
+    # logger.set_security_logs(root_path=...) called
+    set_security_logs.assert_called()
+    assert set_security_logs.call_args.kwargs["root_path"] == str(tmp_path)
+
+    # config_load_start initiated
+    assert any(
+        c.kwargs.get("operation") == "config_load_start"
+        and c.kwargs.get("status") == "initiated"
+        for c in security_event.call_args_list
+    )
+
+    # config_generate success
+    assert any(
+        c.kwargs.get("operation") == "config_generate"
+        and c.kwargs.get("status") == "success"
+        for c in security_event.call_args_list
+    )
+
+
+def test_security_logging_config_set_emits_event(
+    tmp_path, mocker, patch_security_logger, DummyConfig
+):
+    _, security_event = patch_security_logger
+    mocker.patch.object(DummyConfig, "is_config_existing", return_value=False)
+
+    cfg = DummyConfig(root=str(tmp_path))
+    cfg.set("dummy", "x", "z")
+
+    assert any(
+        c.kwargs.get("operation") == "config_set"
+        and c.kwargs.get("status") == "success"
+        and c.kwargs.get("config_section") == "dummy"
+        and c.kwargs.get("config_key") == "x"
+        for c in security_event.call_args_list
+    )
+
+
+def test_security_logging_write_success_and_failure(
+    tmp_path, mocker, patch_security_logger, DummyConfig
+):
+    _, security_event = patch_security_logger
+    mocker.patch.object(DummyConfig, "is_config_existing", return_value=False)
+
+    mocker.patch("fedbiomed.common.config.create_fedbiomed_setup_folders")
+    mocker.patch("fedbiomed.common.config.open", mocker.mock_open())
+
+    cfg = DummyConfig(root=str(tmp_path))
+
+    # Success
+    cfg.write()
+    assert any(
+        c.kwargs.get("operation") == "config_write"
+        and c.kwargs.get("status") == "success"
+        for c in security_event.call_args_list
+    )
+
+    # Failure: ConfigParser.write raises configparser.Error
+    def boom(*args, **kwargs):
+        raise configparser.Error("boom")
+
+    mocker.patch.object(cfg._cfg, "write", side_effect=boom)
+
+    with pytest.raises(FedbiomedConfigurationError):
+        cfg.write()
+
+    assert any(
+        c.kwargs.get("operation") == "config_write"
+        and c.kwargs.get("status") == "failure"
+        and "error_message" in c.kwargs
+        for c in security_event.call_args_list
+    )
 
 
 class BaseConfigTest(unittest.TestCase):
@@ -48,7 +183,7 @@ class TestConfig(BaseConfigTest):
         config = Config(root="dummy-root")
         config._CONFIG_VERSION = "0.99"
 
-        with self.assertRaises(FedbiomedVersionError):
+        with self.assertRaises(FedbiomedConfigurationError):
             config.read()
 
         config_parser.return_value.read.assert_called_once()


### PR DESCRIPTION
Overwrites logger level on config to write security logs. Add Fedbiomed version to security logs in config operations. Minor fixes in names.
