### PR TITLE
Feature/361 security logs transport layer

### DIFF
--- a/fedbiomed/common/logger.py
+++ b/fedbiomed/common/logger.py
@@ -683,11 +683,16 @@ class FedLogger(metaclass=SingletonMeta):
         # Merge extra dicts properly to support is_security flag
         extra = kwargs.pop("extra", {})
         extra.update({"researcher_id": researcher_id, "broadcast": broadcast})
+
+        # Ensure caller attribution points to the real call site, not this wrapper.
+        # Users may override by explicitly passing stacklevel=...
+        stacklevel = kwargs.pop("stacklevel", 2)
         self._logger.info(
             msg,
             *args,
             **kwargs,
             extra=extra,
+            stacklevel=stacklevel,
         )
 
     def debug(self, msg, *args, broadcast=False, researcher_id=None, **kwargs):
@@ -695,11 +700,14 @@ class FedLogger(metaclass=SingletonMeta):
         # Merge extra dicts properly to support is_security flag
         extra = kwargs.pop("extra", {})
         extra.update({"researcher_id": researcher_id, "broadcast": broadcast})
+
+        stacklevel = kwargs.pop("stacklevel", 2)
         self._logger.debug(
             msg,
             *args,
             **kwargs,
             extra=extra,
+            stacklevel=stacklevel,
         )
 
     def warning(self, msg, *args, broadcast=False, researcher_id=None, **kwargs):
@@ -707,11 +715,14 @@ class FedLogger(metaclass=SingletonMeta):
         # Merge extra dicts properly to support is_security flag
         extra = kwargs.pop("extra", {})
         extra.update({"researcher_id": researcher_id, "broadcast": broadcast})
+
+        stacklevel = kwargs.pop("stacklevel", 2)
         self._logger.warning(
             msg,
             *args,
             **kwargs,
             extra=extra,
+            stacklevel=stacklevel,
         )
 
     def critical(self, msg, *args, broadcast=False, researcher_id=None, **kwargs):
@@ -719,11 +730,14 @@ class FedLogger(metaclass=SingletonMeta):
         # Merge extra dicts properly to support is_security flag
         extra = kwargs.pop("extra", {})
         extra.update({"researcher_id": researcher_id, "broadcast": broadcast})
+
+        stacklevel = kwargs.pop("stacklevel", 2)
         self._logger.critical(
             msg,
             *args,
             **kwargs,
             extra=extra,
+            stacklevel=stacklevel,
         )
 
     def error(self, msg, *args, broadcast=False, researcher_id=None, **kwargs):
@@ -731,11 +745,14 @@ class FedLogger(metaclass=SingletonMeta):
         # Merge extra dicts properly to support is_security flag
         extra = kwargs.pop("extra", {})
         extra.update({"researcher_id": researcher_id, "broadcast": broadcast})
+
+        stacklevel = kwargs.pop("stacklevel", 2)
         self._logger.error(
             msg,
             *args,
             **kwargs,
             extra=extra,
+            stacklevel=stacklevel,
         )
 
     def __getattr__(self, s: Any):

--- a/fedbiomed/transport/client.py
+++ b/fedbiomed/transport/client.py
@@ -314,6 +314,11 @@ class GrpcClient:
 
                 # Connect to channels and create stubs
                 await self._channels.connect()
+                logger.info(
+                    f"Successfully connected to researcher server at "
+                    f"{self._researcher.host}:{self._researcher.port}",
+                    extra={"is_security": True},
+                )
 
                 break
             else:

--- a/fedbiomed/transport/client.py
+++ b/fedbiomed/transport/client.py
@@ -466,7 +466,10 @@ class Listener:
                         logger.error(
                             "Unexpected error raised by researcher gRPC server in "
                             f"{self.__class__.__name__}: {exp}. "
-                            f"Will retry connect in {GRPC_CLIENT_CONN_RETRY_TIMEOUT} seconds"
+                            f"Will retry connect in {GRPC_CLIENT_CONN_RETRY_TIMEOUT} seconds "
+                            f"to the channel {self._channels._channels} "
+                            f"with stubs {self._channels._stubs}",
+                            extra={"is_security": True},
                         )
                         await self._handle_after_process(
                             ClientStatus.FAILED,
@@ -477,7 +480,10 @@ class Listener:
             except (Exception, GeneratorExit) as exp:
                 logger.error(
                     f"Unexpected error raised by node gRPC client in {self.__class__.__name__}: "
-                    f"{type(exp).__name__} : {exp}",
+                    f"{type(exp).__name__} : {exp} "
+                    f"to the channel {self._channels._channels} "
+                    f"with stubs {self._channels._stubs}",
+                    extra={"is_security": True},
                     exc_info=True,
                 )
                 await self._handle_after_process(

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -587,11 +587,19 @@ class TestLogger(unittest.TestCase):
                 self.assertEqual(info_entry["message"], "Info msg")
                 self.assertEqual(info_entry["level"], "INFO")
                 self.assertEqual(info_entry["operation"], "test_op")
+                self.assertEqual(
+                    info_entry.get("caller_function"),
+                    "test_logger_14_is_security_flag_behavior",
+                )
 
                 error_entry = json.loads(lines[1])
                 self.assertEqual(error_entry["message"], "Error msg")
                 self.assertEqual(error_entry["level"], "ERROR")
                 self.assertEqual(error_entry["researcher_id"], "researcher_1")
+                self.assertEqual(
+                    error_entry.get("caller_function"),
+                    "test_logger_14_is_security_flag_behavior",
+                )
 
             finally:
                 security_handler = logger._handlers.get("SECURITY_FILE")

--- a/tests/test_transport_client.py
+++ b/tests/test_transport_client.py
@@ -89,6 +89,9 @@ class TestTaskListener(unittest.IsolatedAsyncioTestCase):
         self.update_id = AsyncMock()
         self.callback = MagicMock()
         self.channels = MagicMock()
+        # Deterministic placeholders for assertions on logged message content
+        self.channels._channels = "CHANNELS"
+        self.channels._stubs = "STUBS"
         self.channels.connect = AsyncMock()
         self.task_listener = TaskListener(
             channels=self.channels,
@@ -134,8 +137,9 @@ class TestTaskListener(unittest.IsolatedAsyncioTestCase):
         # Cancel the task for next test
         task.cancel()
 
+    @patch("fedbiomed.transport.client.logger._logger.error")
     @patch("fedbiomed.transport.client.asyncio.sleep")
-    async def test_task_listener_02_listen_grpc_exceptions(self, sleep):
+    async def test_task_listener_02_listen_grpc_exceptions(self, sleep, log_error):
         request_stub = MagicMock()
         self.channels.stub = AsyncMock()
         self.channels.stub.return_value = request_stub
@@ -193,10 +197,18 @@ class TestTaskListener(unittest.IsolatedAsyncioTestCase):
             await task
         sleep.assert_called_once()
         self.assertEqual(request_stub.GetTaskUnary.call_count, 2)
+        log_error.assert_called_once()
+        log_args, log_kwargs = log_error.call_args
+        self.assertEqual(len(log_args), 1)
+        self.assertIn("CHANNELS", log_args[0])
+        self.assertIn("STUBS", log_args[0])
+        self.assertIn("extra", log_kwargs)
+        self.assertTrue(log_kwargs["extra"].get("is_security"))
         # Cancel and reset the task for next test
         task.cancel()
         request_stub.reset_mock()
         sleep.reset_mock()
+        log_error.reset_mock()
 
         # For all others gRPC errors
         request_stub.GetTaskUnary.side_effect = [
@@ -213,14 +225,23 @@ class TestTaskListener(unittest.IsolatedAsyncioTestCase):
             await task
         sleep.assert_called_once()
         self.assertEqual(request_stub.GetTaskUnary.call_count, 2)
+        log_error.assert_called_once()
+        log_args, log_kwargs = log_error.call_args
+        self.assertEqual(len(log_args), 1)
+        self.assertIn("CHANNELS", log_args[0])
+        self.assertIn("STUBS", log_args[0])
+        self.assertIn("extra", log_kwargs)
+        self.assertTrue(log_kwargs["extra"].get("is_security"))
 
         # Cancel and reset the task for next test
         task.cancel()
         request_stub.reset_mock()
         sleep.reset_mock()
+        log_error.reset_mock()
 
+    @patch("fedbiomed.transport.client.logger._logger.error")
     @patch("fedbiomed.transport.client.asyncio.sleep")
-    async def test_task_listener_03_listen_non_grpc_exceptions(self, sleep):
+    async def test_task_listener_03_listen_non_grpc_exceptions(self, sleep, log_error):
         request_stub = MagicMock()
         self.channels.stub = AsyncMock()
         self.channels.stub.return_value = request_stub
@@ -248,6 +269,17 @@ class TestTaskListener(unittest.IsolatedAsyncioTestCase):
                     signal = FedbiomedCommunicationError
                 with self.assertRaises(signal):
                     await task
+
+                # Logging assertions: security + exc_info + includes channel/stub details
+                self.assertGreaterEqual(log_error.call_count, 1)
+                log_args, log_kwargs = log_error.call_args
+                self.assertEqual(len(log_args), 1)
+                self.assertIn("CHANNELS", log_args[0])
+                self.assertIn("STUBS", log_args[0])
+                self.assertTrue(log_kwargs.get("exc_info"))
+                self.assertIn("extra", log_kwargs)
+                self.assertTrue(log_kwargs["extra"].get("is_security"))
+
                 self.assertEqual(
                     sleep.call_count, min(nb_errors, MAX_RETRIEVE_ERROR_RETRIES)
                 )
@@ -282,6 +314,7 @@ class TestTaskListener(unittest.IsolatedAsyncioTestCase):
                 task.cancel()
                 request_stub.reset_mock()
                 sleep.reset_mock()
+                log_error.reset_mock()
             self.task_listener._post_handle_raise.reset_mock()
 
 

--- a/tests/test_transport_client.py
+++ b/tests/test_transport_client.py
@@ -79,6 +79,42 @@ class TestGrpcClient(unittest.IsolatedAsyncioTestCase):
 
         pass
 
+    @patch("fedbiomed.transport.client.logger._logger.info")
+    @patch("fedbiomed.transport.client.x509.load_pem_x509_certificate", autospec=True)
+    @patch("fedbiomed.transport.client.ssl.get_server_certificate", autospec=True)
+    @patch("fedbiomed.transport.client.is_server_alive", autospec=True)
+    async def test_grpc_client_06__connect_security_log(
+        self,
+        is_server_alive,
+        get_server_certificate,
+        load_pem_x509_certificate,
+        log_info,
+    ):
+        is_server_alive.return_value = True
+        get_server_certificate.return_value = "DUMMY-CERT"
+
+        load_pem_x509_certificate.return_value = MagicMock(
+            subject=MagicMock(
+                get_attributes_for_oid=MagicMock(
+                    return_value=[MagicMock(value="test-researcher")]
+                )
+            )
+        )
+
+        # Avoid creating real grpc channels
+        self.client._channels.connect = AsyncMock()  # no spec
+
+        await self.client._connect()
+
+        self.client._channels.connect.assert_called_once()
+        security_calls = [
+            c
+            for c in log_info.call_args_list
+            if c.kwargs.get("extra", {}).get("is_security") is True
+        ]
+        self.assertEqual(len(security_calls), 1)
+        self.assertTrue(security_calls[0].args[0])
+
 
 class TestTaskListener(unittest.IsolatedAsyncioTestCase):
     def setUp(self):


### PR DESCRIPTION
IMPORTANT: This PR also fixes issue when caller frame info was not displaying correctly when the overridden logger functions were used.

This PR adds logs in Transport layer for: 

- Fedbiomed/transport/client.py::Listener::_listen() method -> Security logs on the errors in communications for cases where the error code/reason is not known. (Not for the cases Node Disconnection, Deadline/Timeout etc.)
- Fedbiomed/transport/client.py::GrpcClient::_connect() method -> Security logs when a connection is established to a researcher from the node side. (Not for the cases when the communication is not established)