### PR TITLE
Feature/1266 debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,3 +186,29 @@ fedbiomed node -p my-second-node gui start --port 8383
 
 Please see `docs/developer/development-environment.md` to find out how to debug and lunch UI for development purposes.
 
+## Troubleshooting
+
+Fedbiomed includes a debug mode, which when enabled prints more verbose outputs, including the caller function and line number in the output. The debug mode can be enabled separately on Node or Researcher, for component specific outputs, or can be enabled for both.
+
+To enable per component, simply add `--debug` while starting the component, such as:
+
+```bash
+$ fedbiomed node start --debug
+```
+
+or 
+
+```bash
+$ fedbiomed researcher start --debug
+```
+
+To enable for both components, set the environment variable `'FBM_DEBUG'` to `1, 'yes' or True`, and then start the component as usual.
+
+```bash
+$ export FBM_DEBUG=1
+$ fedbiomed node start
+```
+
+The debug mode includes more detailed information in component initializations, training round starts and finishes, database operations (such as for datasets, training plans...) and the connection information between nodes-researcher and node-to-node.
+
+

--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -60,3 +60,28 @@ On Fedora, please use sudo dnf install tk-devel.
 Some Fed-BioMed secure aggregation modules uses `gmpy2` for big integer operation. This module requires to have `libgmp3-dev` and `libmpfr-dev` and `libmpc-dev` installed on Linux debian distributions (and equivalents on different Linux distributions). In case of missing `gmp.h`,  `mpfr.h`, or `mpc.h` module errors please install `apt-get install libgmp3-dev libmpfr-dev libmpc-dev`.
 
 On macOS please install: `brew link gmp mpfr mpc`.
+
+## Debug Mode
+
+Fedbiomed includes a debug mode, which when enabled prints more verbose outputs, including the caller function and line number in the output. The debug mode can be enabled separately on Node or Researcher, for component specific outputs, or can be enabled for both.
+
+To enable per component, simply add `--debug` while starting the component, such as:
+
+```bash
+$ fedbiomed node start --debug
+```
+
+or
+
+```bash
+$ fedbiomed researcher start --debug
+```
+
+To enable for both components, set the environment variable `'FBM_DEBUG'` to `1, 'yes' or True`, and then start the component as usual.
+
+```bash
+$ export FBM_DEBUG=1
+$ fedbiomed node start
+```
+
+The debug mode includes more detailed information in component initializations, training round starts and finishes, database operations (such as for datasets, training plans...) and the connection information between nodes-researcher and node-to-node.

--- a/fedbiomed/common/channel_manager.py
+++ b/fedbiomed/common/channel_manager.py
@@ -11,6 +11,7 @@ from tinydb import Query, TinyDB
 from fedbiomed.common.constants import ErrorNumbers, __n2n_channel_element_version__
 from fedbiomed.common.db import DBTable
 from fedbiomed.common.exceptions import FedbiomedNodeToNodeError
+from fedbiomed.common.logger import logger
 from fedbiomed.common.utils import __default_version__, raise_for_version_compatibility
 
 _TableName = "ChannelManager"
@@ -56,6 +57,8 @@ class ChannelManager:
             )
             raise FedbiomedNodeToNodeError(errmess) from e
 
+        logger.debug(f"Listed node-to-node channels: count={len(channels)}")
+
         return channels
 
     def get(self, distant_node_id: str) -> Union[dict, None]:
@@ -84,6 +87,10 @@ class ChannelManager:
                 f'for channel distant_node_id="{distant_node_id}" with error: {e}'
             )
             raise FedbiomedNodeToNodeError(errmess) from e
+
+        logger.debug(
+            f"Lookup node-to-node channel: distant_node_id={distant_node_id} found={element is not None}"
+        )
 
         if element:
             raise_for_version_compatibility(
@@ -124,3 +131,7 @@ class ChannelManager:
                 f"for distant_node_id={distant_node_id} with error: {e}"
             )
             raise FedbiomedNodeToNodeError(errmess) from e
+
+        logger.debug(
+            f"Saved node-to-node channel metadata: distant_node_id={distant_node_id}"
+        )

--- a/fedbiomed/common/cli.py
+++ b/fedbiomed/common/cli.py
@@ -119,6 +119,8 @@ class ComponentDirectoryAction(ABC, argparse.Action):
         self.set_component(component_dir)
 
         # this may be changed on command line or in the config_node.ini
+        # FIXME: alitolga: this may remain for debugging purposes until node and researcher components are started
+        # however I don't think the logger level should be set here, and instead be set when node and researcher get started.
         logger.setLevel("DEBUG")
 
 

--- a/fedbiomed/common/cli.py
+++ b/fedbiomed/common/cli.py
@@ -119,9 +119,6 @@ class ComponentDirectoryAction(ABC, argparse.Action):
         self.set_component(component_dir)
 
         # this may be changed on command line or in the config_node.ini
-        # FIXME: alitolga: this may remain for debugging purposes until node and researcher components are started
-        # however I don't think the logger level should be set here, and instead be set when node and researcher get started.
-        logger.setLevel("DEBUG")
 
 
 class CommonCLI:
@@ -139,6 +136,10 @@ class CommonCLI:
         self._certificate_manager: CertificateManager = CertificateManager()
         self._description: str = ""
         self._args = None
+        if os.environ.get("FBM_DEBUG", "").lower() in ("1", "true", "yes"):
+            logger.setLevel("DEBUG")
+        else:
+            logger.setLevel("INFO")
 
     @property
     def parser(self) -> argparse.ArgumentParser:

--- a/fedbiomed/common/config.py
+++ b/fedbiomed/common/config.py
@@ -75,7 +75,6 @@ class Config(metaclass=ABCMeta):
         # Set up security logging for config operations
         # This ensures security events are captured even before Node/Researcher initialization
         logger.set_security_logs(root_path=root)
-        logger.setLevel("INFO")
         self.load(root)
 
     @classmethod

--- a/fedbiomed/common/db.py
+++ b/fedbiomed/common/db.py
@@ -7,6 +7,7 @@ Interfaces with a tinyDB database for converting search results to dict.
 
 from __future__ import annotations
 
+from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from tinydb import Query, TinyDB
@@ -14,6 +15,8 @@ from tinydb.table import Document, Table
 
 from fedbiomed.common.exceptions import FedbiomedError
 from fedbiomed.common.logger import logger
+
+LOG_VALUE_MAX_LENGTH = 50
 
 
 def cast_(func):
@@ -58,8 +61,6 @@ def _security_log(operation: str, default_stacklevel: int = 3):
             Extracting/logging relevant information from args/kwargs for security events."""
 
             logging_stacklevel = kwargs.pop("stacklevel", default_stacklevel)
-
-            LOG_VALUE_MAX_LENGTH = 50
 
             # Reuse your helpers
             kwargs_stripped = _strip_forbidden_keys(kwargs)
@@ -180,6 +181,72 @@ def _truncate_for_logging(value: Any, max_len: int) -> Any:
     return value
 
 
+def _debug_db_operation(message: str, **fields: Any) -> None:
+    """Emit sanitized debug logging for database wrapper operations."""
+
+    sanitized = _truncate_for_logging(
+        _strip_forbidden_keys(fields), max_len=LOG_VALUE_MAX_LENGTH
+    )
+    logger.debug(f"{message}: {sanitized}")
+
+
+def _debug_result_summary(result: Any) -> Any:
+    """Build a compact debug summary for DB wrapper results."""
+
+    if isinstance(result, list):
+        return {"result_type": "list", "count": len(result)}
+    if isinstance(result, dict):
+        return {"result_type": "dict", "count": len(result)}
+    if result is None:
+        return {"result_type": "NoneType"}
+    return {"result_type": type(result).__name__, "value": result}
+
+
+def _debug_log(operation: str):
+    """Decorator for sanitized debug logging of database wrapper methods."""
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            bound_self = args[0] if args else None
+            call_args = args[1:] if len(args) > 1 else tuple()
+
+            context = {
+                "operation": operation,
+                "component": type(bound_self).__name__
+                if bound_self is not None
+                else None,
+                "table": getattr(
+                    bound_self, "_table_name", getattr(bound_self, "name", None)
+                ),
+                "id_name": getattr(bound_self, "_id_name", None),
+                "args": call_args,
+                "kwargs": kwargs,
+            }
+            _debug_db_operation(f"Starting {operation}", **context)
+
+            try:
+                result = func(*args, **kwargs)
+            except Exception as exc:
+                _debug_db_operation(
+                    f"Failed {operation}",
+                    **context,
+                    error=repr(exc),
+                )
+                raise
+
+            _debug_db_operation(
+                f"Completed {operation}",
+                **context,
+                result=_debug_result_summary(result),
+            )
+            return result
+
+        return wrapper
+
+    return decorator
+
+
 class DBTable(Table):
     """Extends TinyDB table to cast Document type to dict"""
 
@@ -226,6 +293,13 @@ class TinyDBConnector:
             cls._instance = super().__new__(cls)
             # Use DBTable as the default table class for this TinyDB instance
             cls._instance._db = TinyDB(db_path)
+            _debug_db_operation(
+                "Initialized TinyDB connector", db_path=db_path, reused_existing=False
+            )
+        else:
+            _debug_db_operation(
+                "Reusing TinyDB connector", db_path=db_path, reused_existing=True
+            )
         return cls._instance
 
     @property
@@ -233,6 +307,7 @@ class TinyDBConnector:
         """Return the shared TinyDB instance"""
         return self._db
 
+    @_debug_log("db_table")
     def table(self, name: str) -> DBTable:
         """Return a table with the given name, ensuring it is a DBTable instance."""
         # Get the table from the underlying DB instance, forcing cache_size=0
@@ -252,7 +327,15 @@ class TinyTableConnector:
 
         self._query = Query()
         self._table = TinyDBConnector(db_path=path).table(self._table_name)
+        _debug_db_operation(
+            "Initialized TinyTableConnector",
+            table=self._table_name,
+            id_name=self._id_name,
+            path=path,
+            connector_type=self.__class__.__name__,
+        )
 
+    @_debug_log("db_get_by_id")
     def get_by_id(self, id_value: str) -> Optional[dict]:
         """Get a document by its ID.
 
@@ -271,6 +354,7 @@ class TinyTableConnector:
         )
         return response[0] if response else None
 
+    @_debug_log("db_insert")
     def insert(self, entry: dict) -> int:
         """Insert a new document.
 
@@ -291,6 +375,7 @@ class TinyTableConnector:
         _ = self._table.insert(entry, stacklevel=4)
         return entry[self._id_name]
 
+    @_debug_log("db_all")
     def all(self) -> List[dict]:
         """Get all entries (or empty list if none found).
 
@@ -299,6 +384,7 @@ class TinyTableConnector:
         """
         return self._table.all(stacklevel=4)
 
+    @_debug_log("db_get_all_by_value")
     def get_all_by_value(self, by: str, value: Any) -> List[dict]:
         """Get all entries by a field value (or empty list if none found).
 
@@ -316,6 +402,7 @@ class TinyTableConnector:
             stacklevel=4,
         )
 
+    @_debug_log("db_get_all_by_condition")
     def get_all_by_condition(self, by: str, cond: Callable) -> List[dict]:
         """Search entries by a test condition on a field.
 
@@ -328,6 +415,7 @@ class TinyTableConnector:
         """
         return self._table.search(self._query[by].test(cond), stacklevel=4)
 
+    @_debug_log("db_delete_by_id")
     def delete_by_id(self, id_value: Union[str, list[str]]) -> List[int]:
         """Delete a document by its ID.
 
@@ -349,6 +437,7 @@ class TinyTableConnector:
             self._query[self._id_name].one_of(id_value), stacklevel=4
         )
 
+    @_debug_log("db_update_by_id")
     def update_by_id(self, id_value: str, update: Dict[str, Any]) -> dict:
         """Update a document by its ID.
 
@@ -365,5 +454,4 @@ class TinyTableConnector:
         _ = self._table.update(
             update, self._query[self._id_name] == id_value, stacklevel=4
         )
-
         return self.get_by_id(id_value)

--- a/fedbiomed/common/db.py
+++ b/fedbiomed/common/db.py
@@ -7,7 +7,6 @@ Interfaces with a tinyDB database for converting search results to dict.
 
 from __future__ import annotations
 
-from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from tinydb import Query, TinyDB
@@ -103,7 +102,8 @@ def _security_log(operation: str, default_stacklevel: int = 3):
                         stacklevel=logging_stacklevel,
                     )
                     logger.debug(
-                        f"Failed to {operation} in table {self.name} with error: {repr(e)}",
+                        f"Failed to {operation} in table {self.name} with error: {repr(e)}; "
+                        f"db_args={args_for_log}; db_kwargs={kwargs_for_log}",
                         extra={
                             "db_args": {**args_for_log},
                             "db_kwargs": {**kwargs_for_log},
@@ -122,7 +122,8 @@ def _security_log(operation: str, default_stacklevel: int = 3):
                     stacklevel=logging_stacklevel,
                 )
                 logger.debug(
-                    f"Successfully performed {operation} in table {self.name}, result: {result_for_log}",
+                    f"Successfully performed {operation} in table {self.name}, result: {result_for_log}; "
+                    f"db_args={args_for_log}; db_kwargs={kwargs_for_log}",
                     extra={
                         "db_args": {**args_for_log},
                         "db_kwargs": {**kwargs_for_log},
@@ -181,72 +182,6 @@ def _truncate_for_logging(value: Any, max_len: int) -> Any:
     return value
 
 
-def _debug_db_operation(message: str, **fields: Any) -> None:
-    """Emit sanitized debug logging for database wrapper operations."""
-
-    sanitized = _truncate_for_logging(
-        _strip_forbidden_keys(fields), max_len=LOG_VALUE_MAX_LENGTH
-    )
-    logger.debug(f"{message}: {sanitized}")
-
-
-def _debug_result_summary(result: Any) -> Any:
-    """Build a compact debug summary for DB wrapper results."""
-
-    if isinstance(result, list):
-        return {"result_type": "list", "count": len(result)}
-    if isinstance(result, dict):
-        return {"result_type": "dict", "count": len(result)}
-    if result is None:
-        return {"result_type": "NoneType"}
-    return {"result_type": type(result).__name__, "value": result}
-
-
-def _debug_log(operation: str):
-    """Decorator for sanitized debug logging of database wrapper methods."""
-
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            bound_self = args[0] if args else None
-            call_args = args[1:] if len(args) > 1 else tuple()
-
-            context = {
-                "operation": operation,
-                "component": type(bound_self).__name__
-                if bound_self is not None
-                else None,
-                "table": getattr(
-                    bound_self, "_table_name", getattr(bound_self, "name", None)
-                ),
-                "id_name": getattr(bound_self, "_id_name", None),
-                "args": call_args,
-                "kwargs": kwargs,
-            }
-            _debug_db_operation(f"Starting {operation}", **context)
-
-            try:
-                result = func(*args, **kwargs)
-            except Exception as exc:
-                _debug_db_operation(
-                    f"Failed {operation}",
-                    **context,
-                    error=repr(exc),
-                )
-                raise
-
-            _debug_db_operation(
-                f"Completed {operation}",
-                **context,
-                result=_debug_result_summary(result),
-            )
-            return result
-
-        return wrapper
-
-    return decorator
-
-
 class DBTable(Table):
     """Extends TinyDB table to cast Document type to dict"""
 
@@ -293,13 +228,6 @@ class TinyDBConnector:
             cls._instance = super().__new__(cls)
             # Use DBTable as the default table class for this TinyDB instance
             cls._instance._db = TinyDB(db_path)
-            _debug_db_operation(
-                "Initialized TinyDB connector", db_path=db_path, reused_existing=False
-            )
-        else:
-            _debug_db_operation(
-                "Reusing TinyDB connector", db_path=db_path, reused_existing=True
-            )
         return cls._instance
 
     @property
@@ -307,7 +235,6 @@ class TinyDBConnector:
         """Return the shared TinyDB instance"""
         return self._db
 
-    @_debug_log("db_table")
     def table(self, name: str) -> DBTable:
         """Return a table with the given name, ensuring it is a DBTable instance."""
         # Get the table from the underlying DB instance, forcing cache_size=0
@@ -327,15 +254,7 @@ class TinyTableConnector:
 
         self._query = Query()
         self._table = TinyDBConnector(db_path=path).table(self._table_name)
-        _debug_db_operation(
-            "Initialized TinyTableConnector",
-            table=self._table_name,
-            id_name=self._id_name,
-            path=path,
-            connector_type=self.__class__.__name__,
-        )
 
-    @_debug_log("db_get_by_id")
     def get_by_id(self, id_value: str) -> Optional[dict]:
         """Get a document by its ID.
 
@@ -354,7 +273,6 @@ class TinyTableConnector:
         )
         return response[0] if response else None
 
-    @_debug_log("db_insert")
     def insert(self, entry: dict) -> int:
         """Insert a new document.
 
@@ -375,7 +293,6 @@ class TinyTableConnector:
         _ = self._table.insert(entry, stacklevel=4)
         return entry[self._id_name]
 
-    @_debug_log("db_all")
     def all(self) -> List[dict]:
         """Get all entries (or empty list if none found).
 
@@ -384,7 +301,6 @@ class TinyTableConnector:
         """
         return self._table.all(stacklevel=4)
 
-    @_debug_log("db_get_all_by_value")
     def get_all_by_value(self, by: str, value: Any) -> List[dict]:
         """Get all entries by a field value (or empty list if none found).
 
@@ -402,7 +318,6 @@ class TinyTableConnector:
             stacklevel=4,
         )
 
-    @_debug_log("db_get_all_by_condition")
     def get_all_by_condition(self, by: str, cond: Callable) -> List[dict]:
         """Search entries by a test condition on a field.
 
@@ -415,7 +330,6 @@ class TinyTableConnector:
         """
         return self._table.search(self._query[by].test(cond), stacklevel=4)
 
-    @_debug_log("db_delete_by_id")
     def delete_by_id(self, id_value: Union[str, list[str]]) -> List[int]:
         """Delete a document by its ID.
 
@@ -437,7 +351,6 @@ class TinyTableConnector:
             self._query[self._id_name].one_of(id_value), stacklevel=4
         )
 
-    @_debug_log("db_update_by_id")
     def update_by_id(self, id_value: str, update: Dict[str, Any]) -> dict:
         """Update a document by its ID.
 

--- a/fedbiomed/common/logger.py
+++ b/fedbiomed/common/logger.py
@@ -628,7 +628,9 @@ class FedLogger(metaclass=SingletonMeta):
         self._internal_add_handler("GRPC", handler)
 
         # as a side effect this will set the minimal level to ERROR
-        self.setLevel(level, "GRPC")
+        # FIXME: alitolga: This could cause problems in the logging level,
+        # I believe the level should be set when node and researcher get started.
+        # self.setLevel(level, "GRPC")
 
         pass
 

--- a/fedbiomed/common/logger.py
+++ b/fedbiomed/common/logger.py
@@ -382,8 +382,12 @@ class FedLogger(metaclass=SingletonMeta):
         # Disable buffering to ensure immediate writes
         handler.stream.reconfigure(line_buffering=True)
 
+        handler_name = "SECURITY_FILE"
         # Register under its own key so it doesn't collide with FILE handler
-        self._internal_add_handler("SECURITY_FILE", handler, None)
+        if handler_name not in self._handlers:
+            self._logger.debug(" adding handler for: " + handler_name)
+            self._handlers[handler_name] = handler
+            self._logger.addHandler(handler)
 
     def security_event(
         self,

--- a/fedbiomed/common/logger.py
+++ b/fedbiomed/common/logger.py
@@ -517,8 +517,7 @@ class FedLogger(metaclass=SingletonMeta):
             if output in self._handlers:
                 self.removeHandler(self._handlers[output])
                 del self._handlers[output]
-                self._original_format.pop(output, None)
-                self._handler_prefix.pop(output, None)
+                del self._original_format[output]
                 self._logger.debug(" removing handler for: " + output)
             return
 

--- a/fedbiomed/common/logger.py
+++ b/fedbiomed/common/logger.py
@@ -64,6 +64,10 @@ DEFAULT_SECURITY_LOG_FILE = "security_audit.log"
 DEFAULT_LOG_LEVEL = logging.WARNING
 LOG_PREFIX = "%(prefix)s"
 DEFAULT_FORMAT = f"%(asctime)s %(name)s{LOG_PREFIX} %(levelname)s - %(message)s"
+DEBUG_FORMAT = (
+    f"%(asctime)s %(name)s{LOG_PREFIX} %(levelname)s "
+    "[%(module)s.%(funcName)s:%(lineno)d] - %(message)s"
+)
 
 # --- Security context (propagates across modules) ---
 SECURITY_CONTEXT: ContextVar[dict] = ContextVar(
@@ -296,6 +300,7 @@ class FedLogger(metaclass=SingletonMeta):
 
         # Store base format used by handlers
         self._original_format = {}
+        self._handler_prefix = {}
 
         # init the handlers list and add a console handler on startup
         self._handlers = {}
@@ -516,6 +521,8 @@ class FedLogger(metaclass=SingletonMeta):
             self._logger.addHandler(handler)
             self._handlers[output].setLevel(self._default_level)
             self._original_format[output] = format
+            self._handler_prefix[output] = ""
+            self._set_handler_formatter(output)
         else:
             self._logger.warning(output + " handler already present - ignoring")
 
@@ -568,9 +575,6 @@ class FedLogger(metaclass=SingletonMeta):
         handler = logging.FileHandler(filename=filename, mode="a")
         handler.setLevel(self._internal_level_translator(level))
 
-        formatter = logging.Formatter(format.replace(LOG_PREFIX, ""))
-        handler.setFormatter(formatter)
-
         self._internal_add_handler("FILE", handler, format)
 
     def add_console_handler(
@@ -588,9 +592,6 @@ class FedLogger(metaclass=SingletonMeta):
             handler = logging.StreamHandler()
 
         handler.setLevel(self._internal_level_translator(level))
-
-        formatter = logging.Formatter(format.replace(LOG_PREFIX, ""))
-        handler.setFormatter(formatter)
 
         # Prevent security audit logs from appearing in interactive console (e.g., IPython).
         handler.addFilter(_ExcludeSecurityFilter())
@@ -669,10 +670,12 @@ class FedLogger(metaclass=SingletonMeta):
 
             for h in self._handlers:
                 self._handlers[h].setLevel(level)
+                self._set_handler_formatter(h)
             return
 
         if htype in self._handlers:
             self._handlers[htype].setLevel(level)
+            self._set_handler_formatter(htype)
             return
 
         # htype provided but no handler for this type exists
@@ -685,14 +688,30 @@ class FedLogger(metaclass=SingletonMeta):
             prefix: Prefix to add to all log messages
         """
         for h in self._handlers:
-            if h == "SECURITY_FILE":
-                continue
-            if self._original_format[h] is not None:
-                self._handlers[h].setFormatter(
-                    logging.Formatter(
-                        self._original_format[h].replace(LOG_PREFIX, prefix),
-                    )
-                )
+            self._handler_prefix[h] = prefix
+            self._set_handler_formatter(h)
+
+    def _set_handler_formatter(self, output: str) -> None:
+        """Configure formatter for a handler based on its current level."""
+        if output not in self._handlers or output == "SECURITY_FILE":
+            return
+
+        if output == "GRPC":
+            return
+
+        base_format = self._original_format.get(output)
+        if base_format is None:
+            return
+
+        prefix = self._handler_prefix.get(output, "")
+        if self._handlers[output].level <= logging.DEBUG:
+            effective_format = DEBUG_FORMAT
+        else:
+            effective_format = base_format
+
+        self._handlers[output].setFormatter(
+            logging.Formatter(effective_format.replace(LOG_PREFIX, prefix))
+        )
 
     def info(self, msg, *args, broadcast=False, researcher_id=None, **kwargs):
         """Extends arguments of info message.

--- a/fedbiomed/common/logger.py
+++ b/fedbiomed/common/logger.py
@@ -388,6 +388,8 @@ class FedLogger(metaclass=SingletonMeta):
             self._logger.debug(" adding handler for: " + handler_name)
             self._handlers[handler_name] = handler
             self._logger.addHandler(handler)
+            self._original_format[handler_name] = None
+            self._handler_prefix[handler_name] = ""
 
     def security_event(
         self,
@@ -515,7 +517,8 @@ class FedLogger(metaclass=SingletonMeta):
             if output in self._handlers:
                 self.removeHandler(self._handlers[output])
                 del self._handlers[output]
-                del self._original_format[output]
+                self._original_format.pop(output, None)
+                self._handler_prefix.pop(output, None)
                 self._logger.debug(" removing handler for: " + output)
             return
 

--- a/fedbiomed/common/privacy/_dp_controller.py
+++ b/fedbiomed/common/privacy/_dp_controller.py
@@ -14,6 +14,7 @@ from torch.utils.data import DataLoader
 
 from fedbiomed.common.constants import ErrorNumbers
 from fedbiomed.common.exceptions import FedbiomedDPControllerError
+from fedbiomed.common.logger import logger
 from fedbiomed.common.optimizers.generic_optimizers import NativeTorchOptimizer
 from fedbiomed.common.training_args import DPArgsValidator
 from fedbiomed.common.validator import ValidateError
@@ -31,6 +32,11 @@ class DPController:
         self._privacy_engine = PrivacyEngine()
         self._dp_args = dp_args or {}
         self._is_active = dp_args is not None
+        logger.debug(
+            "Initializing DP controller: active=%s provided_args=%s",
+            self._is_active,
+            sorted(self._dp_args.keys()),
+        )
         # Configure/validate dp arguments
         if self._is_active:
             self._configure_dp_args()
@@ -47,8 +53,22 @@ class DPController:
         Returns:
             Differential privacy applied Optimizer and data loader
         """
+        # Before training is called once per node per round.
+        # The effects remain throughout the batch steps inside that round
+        #
+        # dp_type=local: Per-batch dp, inside the local training loop of a single round
+        # This is done per batch thanks to the Opacus `PrivacyEngine` `make_private` function that is attached to the model, optimizer and data loader.
+        #
+        # dp_type=central: Noise is added once after training, in the `after_training` function.
+        # before_training() still runs once at the start of the round, but with sigma=0.0 after normalization, so the training-time noise path is disabled, and it only does clipping.
 
         if self._is_active:
+            logger.debug(
+                "Applying DP before training: optimizer_type=%s loader_type=%s dp_type=%s",
+                type(optimizer.optimizer).__name__,
+                type(loader).__name__,
+                self._dp_args.get("type"),
+            )
             if not isinstance(optimizer.optimizer, torch.optim.Optimizer):
                 raise FedbiomedDPControllerError(
                     f"{ErrorNumbers.FB616.value}: "
@@ -70,6 +90,11 @@ class DPController:
                         max_grad_norm=float(self._dp_args["clip"]),
                     )
                 )
+                logger.debug(
+                    "DP privacy engine attached successfully: dp_type=%s loader_type=%s",
+                    self._dp_args.get("type"),
+                    type(loader).__name__,
+                )
             except Exception as e:
                 raise FedbiomedDPControllerError(
                     f"{ErrorNumbers.FB616.value}: "
@@ -86,6 +111,11 @@ class DPController:
             `params` fixed model parameters after applying differential privacy
         """
         if self._is_active:
+            logger.debug(
+                "Applying DP after training: dp_type=%s parameter_count=%d",
+                self._dp_args.get("type"),
+                len(params),
+            )
             params = self._postprocess_dp(params)
         return params
 
@@ -100,9 +130,16 @@ class DPController:
             raise FedbiomedDPControllerError(
                 f"{ErrorNumbers.FB616.value}: DP arguments are not valid: {e}"
             ) from e
+        logger.debug(
+            "Validated DP arguments: dp_type=%s clip=%s sigma_set=%s",
+            self._dp_args.get("type"),
+            self._dp_args.get("clip"),
+            "sigma" in self._dp_args,
+        )
         if self._dp_args["type"] == "central":
             self._dp_args["sigma_CDP"] = self._dp_args["sigma"]
             self._dp_args["sigma"] = 0.0
+            logger.debug("Configured central DP arguments: sigma moved to sigma_CDP")
 
     def validate_and_fix_model(self, model: Module) -> Module:
         """Validate and Fix model to be DP-compliant.
@@ -114,6 +151,7 @@ class DPController:
             Fixed or validated model
         """
         if self._is_active and not ModuleValidator.is_valid(model):
+            logger.debug("DP model validation failed, attempting automatic fix")
             try:
                 model = ModuleValidator.fix(model)
             except Exception as e:
@@ -121,6 +159,9 @@ class DPController:
                     f"{ErrorNumbers.FB616.value}: "
                     f"Error while making model DP-compliant: {e}"
                 ) from e
+            logger.debug("DP model automatic fix applied successfully")
+        elif self._is_active:
+            logger.debug("DP model validation passed without modification")
         return model
 
     def _assess_budget_locally(self, loader: DataLoader) -> Tuple[float, float]:
@@ -158,10 +199,18 @@ class DPController:
         Returns:
             Contains (post processed) parameters
         """
+        # dp_type=central: Noise is added here once after training.
+        # dp_type=local: Noise is added per batch during training.
+        logger.debug(
+            "Postprocessing DP parameters: dp_type=%s parameter_count=%d",
+            self._dp_args.get("type"),
+            len(params),
+        )
         # Rename parameters when needed.
         params = {key.replace("_module.", ""): param for key, param in params.items()}
         # When using central DP, postprocess the parameters.
         if self._dp_args["type"] == "central":
+            logger.debug("Applying central DP noise during postprocessing")
             sigma = self._dp_args["sigma_CDP"]
             for key, param in params.items():
                 noise = sigma * self._dp_args["clip"] * torch.randn_like(param)

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -166,10 +166,10 @@ class BaseTrainingPlan(metaclass=ABCMeta):
             f"class={self.__class__.__name__} "
             f"node_id={self._node_id} "
             f"initialize_optimizer={initialize_optimizer} "
-            f"training_args_keys={sorted(self._training_args.keys())} "
-            f"loader_args_keys={sorted(self._loader_args.keys())} "
-            f"optimizer_args_keys={sorted(self._optimizer_args.keys())} "
-            f"aggregator_args_keys={sorted(self._aggregator_args.keys())} "
+            f"training_args_keys={sorted(self._training_args.keys()) if isinstance(self._training_args, dict) else None} "
+            f"loader_args_keys={sorted(self._loader_args.keys()) if isinstance(self._loader_args, dict) else None} "
+            f"optimizer_args_keys={sorted(self._optimizer_args.keys()) if isinstance(self._optimizer_args, dict) else None} "
+            f"aggregator_args_keys={sorted(self._aggregator_args.keys()) if isinstance(self._aggregator_args, dict) else None} "
             f"random_seed_set={rseed is not None}"
         )
 

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -161,6 +161,17 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         rseed = training_args.get("random_seed")
         random.seed(rseed)
         np.random.seed(rseed)
+        logger.debug(
+            "Base Training plan post_init completed: "
+            f"class={self.__class__.__name__} "
+            f"node_id={self._node_id} "
+            f"initialize_optimizer={initialize_optimizer} "
+            f"training_args_keys={sorted(self._training_args.keys())} "
+            f"loader_args_keys={sorted(self._loader_args.keys())} "
+            f"optimizer_args_keys={sorted(self._optimizer_args.keys())} "
+            f"aggregator_args_keys={sorted(self._aggregator_args.keys())} "
+            f"random_seed_set={rseed is not None}"
+        )
 
     def _add_dependency(self, dep: List[str]) -> None:
         """Add new dependencies to the TrainingPlan.
@@ -198,6 +209,13 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         """
         self.training_data_loader = train_data_loader
         self.testing_data_loader = test_data_loader
+        logger.debug(
+            "Training plan data loaders configured: "
+            f"train_loader_type={type(train_data_loader).__name__ if train_data_loader is not None else None} "
+            f"train_dataset_size={len(train_data_loader.dataset) if train_data_loader is not None and hasattr(train_data_loader, 'dataset') else None} "
+            f"test_loader_type={type(test_data_loader).__name__ if test_data_loader is not None else None} "
+            f"test_dataset_size={len(test_data_loader.dataset) if test_data_loader is not None and hasattr(test_data_loader, 'dataset') else None}"
+        )
 
     def init_dependencies(self) -> List[str]:
         """Default method where dependencies are returned
@@ -384,6 +402,11 @@ class BaseTrainingPlan(metaclass=ABCMeta):
 
     def _preprocess(self) -> None:
         """Executes registered data pre-processors."""
+        logger.debug(
+            "Training plan preprocess start: "
+            f"count={len(self.pre_processes)} "
+            f"names={list(self.pre_processes.keys())}"
+        )
         for name, process in self.pre_processes.items():
             method = process["method"]
             process_type = process["process_type"]
@@ -394,6 +417,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
                     f"Process type `{process_type}` is not implemented."
                     f"Preprocessor '{name}' will therefore be ignored."
                 )
+        logger.debug("Training plan preprocess completed")
 
     def _process_data_loader(self, method: Callable[..., Any]) -> None:
         """Handle a data-loader pre-processing action.
@@ -419,6 +443,11 @@ class BaseTrainingPlan(metaclass=ABCMeta):
             logger.critical(msg)
             raise FedbiomedTrainingPlanError(msg)
         # Try running the preprocessor.
+        logger.debug(
+            "Executing training data loader preprocess: "
+            f"method={method.__name__} "
+            f"loader_type={type(self.training_data_loader).__name__ if self.training_data_loader is not None else None}"
+        )
         try:
             data_loader = method(self.training_data_loader)
         except Exception as exc:
@@ -563,6 +592,13 @@ class BaseTrainingPlan(metaclass=ABCMeta):
 
         n_samples = len(self.testing_data_loader.dataset)
         n_batches = max(len(self.testing_data_loader), 1)
+        logger.debug(
+            "Training plan validation start: "
+            f"before_train={before_train} "
+            f"metric={metric.name if metric is not None else None} "
+            f"batches={n_batches} "
+            f"samples={n_samples}"
+        )
 
         # Set up a batch-wise metrics-computation function.
         # Either use an optionally-implemented custom training routine.
@@ -628,6 +664,12 @@ class BaseTrainingPlan(metaclass=ABCMeta):
                         batch_samples=num_samples_observed_till_now,
                         num_batches=n_batches,
                     )
+        logger.debug(
+            "Training plan validation completed: "
+            f"before_train={before_train} "
+            f"batches={n_batches} "
+            f"samples={n_samples}"
+        )
 
     @staticmethod
     def _infer_batch_size(
@@ -672,6 +714,11 @@ class BaseTrainingPlan(metaclass=ABCMeta):
             The trained parameters to aggregate.
         """
         exclude_buffers = not self._training_args["share_persistent_buffers"]
+        logger.debug(
+            "Collecting training plan parameters after training: "
+            f"flatten={flatten} "
+            f"exclude_buffers={exclude_buffers}"
+        )
         if flatten:
             return self._model.flatten(exclude_buffers=exclude_buffers)
         return self.get_model_params(exclude_buffers=exclude_buffers)

--- a/fedbiomed/common/training_plans/_sklearn_models.py
+++ b/fedbiomed/common/training_plans/_sklearn_models.py
@@ -62,6 +62,13 @@ class SKLearnTrainingPlanPartialFit(SKLearnTrainingPlan, metaclass=ABCMeta):
 
         # set number of training loop iterations
         iterations_accountant = MiniBatchTrainingIterationsAccountant(self)
+        logger.debug(
+            "Sklearn partial-fit training start: "
+            f"model_cls={self._model_cls.__name__} "
+            f"epochs={self.training_args().get('epochs')} "
+            f"num_updates={self.training_args().get('num_updates')} "
+            f"batch_maxnum={self.training_args().get('batch_maxnum')}"
+        )
         # Gather reporting parameters.
         report = False
         if (history_monitor is not None) and hasattr(self.model(), "verbose"):
@@ -81,11 +88,23 @@ class SKLearnTrainingPlanPartialFit(SKLearnTrainingPlan, metaclass=ABCMeta):
             # this context manager is used to disable and then enable the sklearn internal optimizer (in case we
             # are using declern optimizer)
             for _epoch in iterations_accountant.iterate_epochs():
+                logger.debug(
+                    "Sklearn epoch start: "
+                    f"model_cls={self._model_cls.__name__} "
+                    f"epoch={_epoch}"
+                )
                 training_data_iter: Iterator = iter(self.training_data_loader)
                 # Iterate over data batches.
                 for _batch in iterations_accountant.iterate_batches():
                     inputs, target = next(training_data_iter)
                     batch_size = self._infer_batch_size(inputs)
+                    if _batch == 1:
+                        logger.debug(
+                            "Sklearn first batch: "
+                            f"model_cls={self._model_cls.__name__} "
+                            f"epoch={_epoch} "
+                            f"batch_size={batch_size}"
+                        )
                     iterations_accountant.increment_sample_counters(batch_size)
                     loss = self._train_over_batch(inputs, target, report)
                     # Optionally report on the batch training loss.
@@ -128,10 +147,20 @@ class SKLearnTrainingPlanPartialFit(SKLearnTrainingPlan, metaclass=ABCMeta):
                             total_samples=num_samples_max,
                             batch_samples=batch_size,
                         )
+                logger.debug(
+                    "Sklearn epoch completed: "
+                    f"model_cls={self._model_cls.__name__} "
+                    f"epoch={_epoch}"
+                )
         # Reset model verbosity to its initial value.
         if report:
             self._model.set_params(verbose=verbose)
 
+        logger.debug(
+            "Sklearn partial-fit training completed: "
+            f"model_cls={self._model_cls.__name__} "
+            f"num_samples_trained={iterations_accountant.num_samples_observed_in_total}"
+        )
         return iterations_accountant.num_samples_observed_in_total
 
     def _train_over_batch(

--- a/fedbiomed/common/training_plans/_sklearn_training_plan.py
+++ b/fedbiomed/common/training_plans/_sklearn_training_plan.py
@@ -122,6 +122,14 @@ class SKLearnTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         self._model.set_params(**params)
         # Set up additional parameters (normally created by `self._model.fit`).
         self._model.set_init_params(model_args)
+        logger.debug(
+            "Sklearn training plan post_init: "
+            f"model_cls={self._model_cls.__name__} "
+            f"model_args_keys={sorted((model_args or {}).keys())} "
+            f"batch_maxnum={self._batch_maxnum} "
+            f"optimizer_wrapper={type(self._optimizer).__name__ if self._optimizer is not None else None} "
+            f"initialize_optimizer={initialize_optimizer}"
+        )
 
     def set_data_loaders(
         self,
@@ -210,6 +218,12 @@ class SKLearnTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
 
         # then build optimizer wrapper given model and optimizer
         self._optimizer = optim_builder.build(self._type, self._model, optimizer)
+        logger.debug(
+            "Sklearn optimizer configured: "
+            f"model_cls={self._model_cls.__name__} "
+            f"optimizer_type={type(optimizer).__name__ if optimizer is not None else None} "
+            f"wrapper_type={type(self._optimizer).__name__ if self._optimizer is not None else None}"
+        )
 
     def init_optimizer(self) -> Optional[FedOptimizer]:
         """Creates and configures optimizer. By default, returns None (meaning native inner scikit
@@ -238,6 +252,15 @@ class SKLearnTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
                 "Optimizer is None, please run `post_init` beforehand"
             )
 
+        logger.debug(
+            "Sklearn training routine start: "
+            f"model_cls={self._model_cls.__name__} "
+            f"train_loader_type={type(self.training_data_loader).__name__ if self.training_data_loader is not None else None} "
+            f"train_dataset_size={len(self.training_data_loader.dataset) if self.training_data_loader is not None and hasattr(self.training_data_loader, 'dataset') else None} "
+            f"history_monitor={history_monitor is not None} "
+            f"node_args_keys={sorted((node_args or {}).keys())}"
+        )
+
         # Run preprocesses
         self._preprocess()
 
@@ -252,7 +275,13 @@ class SKLearnTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
             )
         # Run the model-specific training routine.
         try:
-            return self._training_routine(history_monitor)
+            num_samples_trained = self._training_routine(history_monitor)
+            logger.debug(
+                "Sklearn training routine completed: "
+                f"model_cls={self._model_cls.__name__} "
+                f"num_samples_trained={num_samples_trained}"
+            )
+            return num_samples_trained
         except Exception as exc:
             msg = f"{ErrorNumbers.FB605.value}: error while fitting the model: {exc}"
             logger.critical(msg)

--- a/fedbiomed/common/training_plans/_sklearn_training_plan.py
+++ b/fedbiomed/common/training_plans/_sklearn_training_plan.py
@@ -252,6 +252,16 @@ class SKLearnTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
                 "Optimizer is None, please run `post_init` beforehand"
             )
 
+        # Warn if GPU-use was expected (as it is not supported).
+        if node_args is not None and node_args.get("gpu_only", False):
+            self._optimizer.send_to_device(
+                False
+            )  # disable GPU, avoid `declearn` triggering warning messages
+            logger.warning(
+                "Node would like to force GPU usage, but sklearn training "
+                "plan does not support it. Training on CPU."
+            )
+
         logger.debug(
             "Sklearn training routine start: "
             f"model_cls={self._model_cls.__name__} "
@@ -264,15 +274,6 @@ class SKLearnTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         # Run preprocesses
         self._preprocess()
 
-        # Warn if GPU-use was expected (as it is not supported).
-        if node_args is not None and node_args.get("gpu_only", False):
-            self._optimizer.send_to_device(
-                False
-            )  # disable GPU, avoid `declearn` triggering warning messages
-            logger.warning(
-                "Node would like to force GPU usage, but sklearn training "
-                "plan does not support it. Training on CPU."
-            )
         # Run the model-specific training routine.
         try:
             num_samples_trained = self._training_routine(history_monitor)

--- a/fedbiomed/common/training_plans/_torchnn.py
+++ b/fedbiomed/common/training_plans/_torchnn.py
@@ -175,6 +175,18 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         self.set_aggregator_args(aggregator_args or {})
         # Configure the model and optimizer.
 
+        logger.debug(
+            "Torch training plan post_init: model_args=%s epochs=%s num_updates=%s use_gpu=%s dry_run=%s dp_active=%s aggregator=%s initialize_optimizer=%s",
+            sorted((model_args or {}).keys()),
+            self._epochs,
+            self._num_updates,
+            self._use_gpu,
+            self._dry_run,
+            training_args.dp_arguments() is not None,
+            self.aggregator_name,
+            initialize_optimizer,
+        )
+
         self._configure_model_and_optimizer(initialize_optimizer)
 
     @abstractmethod
@@ -264,6 +276,11 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
 
         # Get model defined by user -----------------------------------------------------------------------------
         init_model_spec = get_method_spec(self.init_model)
+        logger.debug(
+            "Configuring torch model: init_model_args=%s model_arg_keys=%s",
+            list(init_model_spec.keys()),
+            sorted((self._model_args or {}).keys()),
+        )
         if not init_model_spec:
             model = self.init_model()
         elif len(init_model_spec.keys()) == 1:
@@ -281,6 +298,12 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         # Validate and fix model
         model = self._dp_controller.validate_and_fix_model(model)
         self._model = TorchModel(model)
+        logger.debug(
+            "Torch model configured: model_type=%s dp_active=%s initialize_optimizer=%s",
+            type(model).__name__,
+            getattr(self._dp_controller, "_is_active", False),
+            initialize_optimizer,
+        )
 
         # Get optimizer defined by researcher ------------------------
         # FIXME: This is implemented to solve the issue while setting model
@@ -292,6 +315,11 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         # on the researcher.
         if initialize_optimizer:
             init_optim_spec = get_method_spec(self.init_optimizer)
+            logger.debug(
+                "Configuring torch optimizer: init_optimizer_args=%s optimizer_arg_keys=%s",
+                list(init_optim_spec.keys()),
+                sorted((self._optimizer_args or {}).keys()),
+            )
             if not init_optim_spec:
                 optimizer = self.init_optimizer()
             elif len(init_optim_spec.keys()) == 1:
@@ -310,6 +338,11 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
             optim_builder = OptimizerBuilder()
             #  build the optimizer wrapper
             self._optimizer = optim_builder.build(self._type, self._model, optimizer)
+            logger.debug(
+                "Torch optimizer configured: optimizer_type=%s wrapper_type=%s",
+                type(optimizer).__name__,
+                type(self._optimizer).__name__,
+            )
 
     def _set_device(self, use_gpu: Union[bool, None], node_args: dict):
         """Set device (CPU, GPU) that will be used for training, based on `node_args`
@@ -455,12 +488,36 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         # set correct type for node args
         node_args = {} if not isinstance(node_args, dict) else node_args
 
+        logger.debug(
+            "Starting torch training routine: loader_type=%s dataset_type=%s dp_active=%s aggregator=%s epochs=%s num_updates=%s batch_maxnum=%s dry_run=%s",
+            type(self.training_data_loader).__name__,
+            type(self.training_data_loader.dataset).__name__,
+            getattr(self._dp_controller, "_is_active", False),
+            self.aggregator_name,
+            self._epochs,
+            self._num_updates,
+            self._batch_maxnum,
+            self._dry_run,
+        )
+
         # send all model to device, ensures having all the requested tensors
         self._set_device(self._use_gpu, node_args)
         self._model.send_to_device(self._device)
 
+        logger.debug(
+            "Training model sent to device: device=%s model_type=%s",
+            self._device,
+            type(self.model()).__name__ if self.model() is not None else None,
+        )
+
         # Run preprocess when everything is ready before the training
         self._preprocess()
+
+        logger.debug(
+            "Training preprocess completed: loader_type=%s dataset_type=%s",
+            type(self.training_data_loader).__name__,
+            type(self.training_data_loader.dataset).__name__,
+        )
 
         # # initial aggregated model parameters
         # self._init_params = deepcopy(list(self.model().parameters()))
@@ -470,6 +527,12 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
             self._dp_controller.before_training(
                 optimizer=self._optimizer, loader=self.training_data_loader
             )
+        )
+
+        logger.debug(
+            "Training data loader ready after DP setup: loader_type=%s dataset_type=%s",
+            type(self.training_data_loader).__name__,
+            type(self.training_data_loader.dataset).__name__,
         )
 
         # set number of training loop iterations
@@ -539,6 +602,12 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
 
                 # Handle dry run mode
                 if self._dry_run:
+                    logger.debug(
+                        "Dry-run stopping training early: epoch=%s batch_index=%s observed_samples=%s",
+                        _epoch,
+                        _batch_idx,
+                        iterations_accountant.num_samples_observed_in_total,
+                    )
                     self._model.send_to_device(self._device_init)
                     torch.cuda.empty_cache()
                     return iterations_accountant.num_samples_observed_in_total
@@ -567,6 +636,11 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         # for attributes, values in self._model.model.__dict__.items():
         #     print("ATTRIBUTES", values)
         #     assert values == getattr(self._optimizer.model.model, attributes)
+        logger.debug(
+            "Completed torch training routine: observed_samples=%s final_device=%s",
+            iterations_accountant.num_samples_observed_in_total,
+            self._device_init,
+        )
         return iterations_accountant.num_samples_observed_in_total
 
     def _train_over_batch(
@@ -698,9 +772,20 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         Returns:
             The trained parameters to aggregate.
         """
+        logger.debug(
+            "Preparing after-training parameters: flatten=%s share_persistent_buffers=%s dp_active=%s has_postprocess=%s",
+            flatten,
+            self._share_persistent_buffers,
+            getattr(self._dp_controller, "_is_active", False),
+            hasattr(self, "postprocess"),
+        )
         # Either include non-parameter buffers to the outputs or not.
         # Note: this is mostly about sharing statistics from BatchNorm layers.
         params = super().after_training_params()
+        logger.debug(
+            "Collected raw training parameters: parameter_count=%s",
+            len(params),
+        )
         # Check whether postprocess method exists, and use it.
         if hasattr(self, "postprocess"):
             logger.debug("running model.postprocess() method")
@@ -715,9 +800,18 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
 
         # Run (optional) DP controller adjustments as well.
         params = self._dp_controller.after_training(params)
+        logger.debug(
+            "Applied DP/postprocess adjustments to parameters: parameter_count=%s flatten=%s",
+            len(params),
+            flatten,
+        )
         if flatten:
             params = self._model.flatten(
                 exclude_buffers=not self._share_persistent_buffers
+            )
+            logger.debug(
+                "Flattened training parameters for aggregation: flattened_count=%s",
+                len(params),
             )
         return params
 

--- a/fedbiomed/common/training_plans/_torchnn.py
+++ b/fedbiomed/common/training_plans/_torchnn.py
@@ -278,7 +278,7 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         init_model_spec = get_method_spec(self.init_model)
         logger.debug(
             "Configuring torch model: init_model_args=%s model_arg_keys=%s",
-            list(init_model_spec.keys()),
+            list(init_model_spec.keys()) if init_model_spec else [],
             sorted((self._model_args or {}).keys()),
         )
         if not init_model_spec:
@@ -317,7 +317,7 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
             init_optim_spec = get_method_spec(self.init_optimizer)
             logger.debug(
                 "Configuring torch optimizer: init_optimizer_args=%s optimizer_arg_keys=%s",
-                list(init_optim_spec.keys()),
+                list(init_optim_spec.keys()) if init_optim_spec else [],
                 sorted((self._optimizer_args or {}).keys()),
             )
             if not init_optim_spec:
@@ -491,7 +491,7 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         logger.debug(
             "Starting torch training routine: loader_type=%s dataset_type=%s dp_active=%s aggregator=%s epochs=%s num_updates=%s batch_maxnum=%s dry_run=%s",
             type(self.training_data_loader).__name__,
-            type(self.training_data_loader.dataset).__name__,
+            type(getattr(self.training_data_loader, "dataset", None)).__name__,
             getattr(self._dp_controller, "_is_active", False),
             self.aggregator_name,
             self._epochs,
@@ -507,7 +507,7 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         logger.debug(
             "Training model sent to device: device=%s model_type=%s",
             self._device,
-            type(self.model()).__name__ if self.model() is not None else None,
+            type(getattr(self._model, "model", None)).__name__,
         )
 
         # Run preprocess when everything is ready before the training
@@ -516,7 +516,7 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         logger.debug(
             "Training preprocess completed: loader_type=%s dataset_type=%s",
             type(self.training_data_loader).__name__,
-            type(self.training_data_loader.dataset).__name__,
+            type(getattr(self.training_data_loader, "dataset", None)).__name__,
         )
 
         # # initial aggregated model parameters
@@ -532,7 +532,7 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         logger.debug(
             "Training data loader ready after DP setup: loader_type=%s dataset_type=%s",
             type(self.training_data_loader).__name__,
-            type(self.training_data_loader.dataset).__name__,
+            type(getattr(self.training_data_loader, "dataset", None)).__name__,
         )
 
         # set number of training loop iterations

--- a/fedbiomed/node/cli.py
+++ b/fedbiomed/node/cli.py
@@ -127,7 +127,7 @@ def start_node(config, node_args):
             time.sleep(0.5)
             sys.exit(signum)
 
-    if _node._debug:
+    if getattr(_node, "_debug", False):
         logger.setLevel("DEBUG")
     else:
         logger.setLevel("INFO")

--- a/fedbiomed/node/cli.py
+++ b/fedbiomed/node/cli.py
@@ -483,6 +483,14 @@ class NodeControl(CLIArgumentParser):
             "This flag automatically activate GPU.",
         )
 
+        start.add_argument(
+            "--debug",
+            "-dbg",
+            action="store_true",
+            required=False,
+            help="Activate debug mode for the Node. Default is `False`",
+        )
+
     def start(self, args):
         """Starts the node"""
         intro()
@@ -492,6 +500,7 @@ class NodeControl(CLIArgumentParser):
             "gpu": (args.gpu is True) or (args.gpu_only is True),
             "gpu_num": args.gpu_num,
             "gpu_only": True if args.gpu_only else False,
+            "debug": True if args.debug else False,
         }
 
         # Node instance has to be re-instantiated in start_node

--- a/fedbiomed/node/cli.py
+++ b/fedbiomed/node/cli.py
@@ -127,7 +127,10 @@ def start_node(config, node_args):
             time.sleep(0.5)
             sys.exit(signum)
 
-    logger.setLevel("DEBUG")
+    if _node._debug:
+        logger.setLevel("DEBUG")
+    else:
+        logger.setLevel("INFO")
 
     try:
         signal.signal(signal.SIGTERM, _node_signal_handler)
@@ -485,7 +488,7 @@ class NodeControl(CLIArgumentParser):
 
         start.add_argument(
             "--debug",
-            "-dbg",
+            "-D",
             action="store_true",
             required=False,
             help="Activate debug mode for the Node. Default is `False`",

--- a/fedbiomed/node/dataset_manager/_dataset_manager.py
+++ b/fedbiomed/node/dataset_manager/_dataset_manager.py
@@ -15,6 +15,7 @@ from fedbiomed.common.constants import ErrorNumbers
 from fedbiomed.common.dataloadingplan import DataLoadingPlan
 from fedbiomed.common.dataset import get_controller
 from fedbiomed.common.exceptions import FedbiomedError
+from fedbiomed.common.logger import logger
 from fedbiomed.node.dataset_manager._db_tables import (
     DatasetTable,
     DlbTable,
@@ -58,9 +59,23 @@ class DatasetManager:
         dlp_metadata = self.dlp_table.get_by_id(dlp_id)
 
         if dlp_metadata is None:
+            logger.debug(
+                "Data loading plan with id %s not found in database.",
+                dlp_id,
+            )
             return None, []
 
+        logger.debug(
+            "Data loading plan with id %s found in database. Retrieving associated data loading blocks.",
+            dlp_id,
+        )
         dlb_ids = list(dlp_metadata["loading_blocks"].values())
+        logger.debug(
+            "Found %d data loading blocks associated with data loading plan id %s: dlb_ids=%s",
+            len(dlb_ids),
+            dlp_id,
+            dlb_ids,
+        )
         return dlp_metadata, self.dlb_table.get_all_by_value("dlb_id", dlb_ids)
 
     def read_csv(

--- a/fedbiomed/node/history_monitor.py
+++ b/fedbiomed/node/history_monitor.py
@@ -7,6 +7,7 @@ Send information from node to researcher during the training
 
 from typing import Callable, Dict, Union
 
+from fedbiomed.common.logger import logger
 from fedbiomed.common.message import FeedbackMessage, Scalar
 
 
@@ -24,7 +25,7 @@ class HistoryMonitor:
         """Simple constructor for the class.
 
         Args:
-            nod_id: Unique ID of this node
+            node_id: Unique ID of this node
             experiment_id: TODO
             researcher_id: TODO
             client: TODO
@@ -34,6 +35,13 @@ class HistoryMonitor:
         self.experiment_id = experiment_id
         self.researcher_id = researcher_id
         self.send = send
+
+        logger.debug(
+            "Initialized history monitor for: node=%s experiment=%s researcher=%s",
+            self._node_id,
+            self.experiment_id,
+            self.researcher_id,
+        )
 
     def add_scalar(
         self,

--- a/fedbiomed/node/node.py
+++ b/fedbiomed/node/node.py
@@ -72,6 +72,9 @@ class Node:
             config: Node configuration
             node_args: Command line arguments for node.
         """
+        self._debug = (
+            self.node_args.get("debug", False) if node_args is not None else False
+        )
 
         self._config = config
         self._node_id = self._config.get("default", "id")
@@ -464,6 +467,7 @@ class Node:
             round_number=msg.get_param("round"),
             dlp_and_loading_block_metadata=dlp_and_loading_block_metadata,
             aux_vars=msg.get_param("optim_aux_var"),
+            debug=self._debug,
         )
 
         # the round raises an error if it cannot initialize

--- a/fedbiomed/node/node.py
+++ b/fedbiomed/node/node.py
@@ -435,7 +435,7 @@ class Node:
         if data is None:
             return self.send_error(
                 extra_msg=(
-                    f"{ErrorNumbers.FB313.value}: Did not found proper data in local datasets "
+                    f"{ErrorNumbers.FB313.value}: Did not find proper data in local datasets "
                     f"on node={self._node_id} for dataset_id={dataset_id}"
                 ),
                 request_id=msg.request_id,

--- a/fedbiomed/node/node.py
+++ b/fedbiomed/node/node.py
@@ -7,6 +7,7 @@ Core code of the node component.
 
 import os
 import time
+import traceback
 from typing import Callable, Optional, Union
 
 from fedbiomed import __version__
@@ -427,11 +428,16 @@ class Node:
             researcher_id=msg.researcher_id,
             send=self._grpc_client.send,
         )
+        logger.debug(f"History monitor initialized for experiment {msg.experiment_id}")
 
         dataset_id = msg.get_param("dataset_id")
         data = self.dataset_manager.dataset_table.get_by_id(dataset_id)
 
         if data is None:
+            logger.error(
+                f"{ErrorNumbers.FB313.value}: Did not found proper data in local datasets "
+                f"on node={self._node_id} for dataset_id={dataset_id}"
+            )
             return self.send_error(
                 extra_msg="Did not found proper data in local datasets "
                 f"on node={self._node_id}",
@@ -439,11 +445,21 @@ class Node:
                 researcher_id=msg.researcher_id,
                 errnum=ErrorNumbers.FB313,
             )
+        logger.debug(
+            f"Dataset successfully fetched for dataset_id={dataset_id} on node={self._node_id}"
+        )
 
         dlp_and_loading_block_metadata = None
         if "dlp_id" in data:
             dlp_and_loading_block_metadata = self.dataset_manager.get_dlp_by_id(
                 data["dlp_id"]
+            )
+            logger.debug(
+                f"DLP and loading block metadata with dlp_id={data['dlp_id']} fetched for dataset_id={dataset_id} on node={self._node_id}"
+            )
+        else:
+            logger.debug(
+                f"No DLP and loading block metadata found for dataset_id={dataset_id} on node={self._node_id}"
             )
 
         round_ = Round(
@@ -467,12 +483,16 @@ class Node:
             round_number=msg.get_param("round"),
             dlp_and_loading_block_metadata=dlp_and_loading_block_metadata,
             aux_vars=msg.get_param("optim_aux_var"),
-            debug=self._debug,
         )
 
         # the round raises an error if it cannot initialize
-        err_msg = round_.initialize_arguments(msg.get_param("state_id"))
-        if err_msg is not None:
+        try:
+            err_msg = round_.initialize_arguments(msg.get_param("state_id"))
+        except Exception:
+            if err_msg is not None:
+                logger.error(
+                    f"{ErrorNumbers.FB300.value}: Could not initialize arguments for training round: {err_msg}"
+                )
             self._grpc_client.send(
                 ErrorMessage(
                     node_id=self._node_id,
@@ -480,6 +500,9 @@ class Node:
                     researcher_id=msg.researcher_id,
                     extra_msg="Could not initialize arguments",
                 )
+            )
+            logger.debug(
+                f"Training round initialize arguments error. Details are: {traceback.format_exc()}"
             )
 
         return round_

--- a/fedbiomed/node/node.py
+++ b/fedbiomed/node/node.py
@@ -75,7 +75,7 @@ class Node:
         """
         self.node_args = node_args or {}
         self._debug = bool(self.node_args.get("debug", False)) or os.environ.get(
-            "FBM_DEBUG_NODE", ""
+            "FBM_DEBUG", ""
         ).lower() in ("1", "true", "yes")
 
         self._config = config

--- a/fedbiomed/node/node.py
+++ b/fedbiomed/node/node.py
@@ -73,9 +73,10 @@ class Node:
             config: Node configuration
             node_args: Command line arguments for node.
         """
-        self._debug = (
-            self.node_args.get("debug", False) if node_args is not None else False
-        ) or os.environ.get("FBM_DEBUG_NODE", "").lower() in ("1", "true", "yes")
+        self.node_args = node_args or {}
+        self._debug = bool(self.node_args.get("debug", False)) or os.environ.get(
+            "FBM_DEBUG_NODE", ""
+        ).lower() in ("1", "true", "yes")
 
         self._config = config
         self._node_id = self._config.get("default", "id")
@@ -141,8 +142,6 @@ class Node:
             node_name=self._node_name,
             config_path=self._config.root,
         )
-
-        self.node_args = node_args
 
     @property
     def node_id(self):
@@ -434,13 +433,11 @@ class Node:
         data = self.dataset_manager.dataset_table.get_by_id(dataset_id)
 
         if data is None:
-            logger.error(
-                f"{ErrorNumbers.FB313.value}: Did not found proper data in local datasets "
-                f"on node={self._node_id} for dataset_id={dataset_id}"
-            )
             return self.send_error(
-                extra_msg="Did not found proper data in local datasets "
-                f"on node={self._node_id}",
+                extra_msg=(
+                    f"{ErrorNumbers.FB313.value}: Did not found proper data in local datasets "
+                    f"on node={self._node_id} for dataset_id={dataset_id}"
+                ),
                 request_id=msg.request_id,
                 researcher_id=msg.researcher_id,
                 errnum=ErrorNumbers.FB313,
@@ -489,21 +486,27 @@ class Node:
         try:
             err_msg = round_.initialize_arguments(msg.get_param("state_id"))
         except Exception:
-            if err_msg is not None:
-                logger.error(
-                    f"{ErrorNumbers.FB300.value}: Could not initialize arguments for training round: {err_msg}"
-                )
-            self._grpc_client.send(
-                ErrorMessage(
-                    node_id=self._node_id,
-                    errnum=ErrorNumbers.FB300,
-                    researcher_id=msg.researcher_id,
-                    extra_msg="Could not initialize arguments",
-                )
+            self.send_error(
+                errnum=ErrorNumbers.FB300,
+                extra_msg=f"{ErrorNumbers.FB300.value}: Could not initialize arguments",
+                researcher_id=msg.researcher_id,
+                request_id=msg.request_id,
             )
             logger.debug(
                 f"Training round initialize arguments error. Details are: {traceback.format_exc()}"
             )
+            return None
+
+        if err_msg is not None:
+            self.send_error(
+                errnum=ErrorNumbers.FB300,
+                extra_msg=(
+                    f"{ErrorNumbers.FB300.value}: Could not initialize arguments for training round: {err_msg}"
+                ),
+                researcher_id=msg.researcher_id,
+                request_id=msg.request_id,
+            )
+            return None
 
         return round_
 

--- a/fedbiomed/node/node.py
+++ b/fedbiomed/node/node.py
@@ -74,7 +74,7 @@ class Node:
         """
         self._debug = (
             self.node_args.get("debug", False) if node_args is not None else False
-        )
+        ) or os.environ.get("FBM_DEBUG_NODE", "").lower() in ("1", "true", "yes")
 
         self._config = config
         self._node_id = self._config.get("default", "id")

--- a/fedbiomed/node/node.py
+++ b/fedbiomed/node/node.py
@@ -188,6 +188,9 @@ class Node:
         Args:
             msg: Incoming message from Researcher.
         """
+        ### (OPTIONAL) DEBUG THE RECEIVED MESSAGE FROM THE RESEARCHER
+        ### WITH MORE DETAILS THAN THE CURRENT DEBUG MESSAGES
+
         message: Message
         try:
             message = Message.from_dict(msg)

--- a/fedbiomed/node/node.py
+++ b/fedbiomed/node/node.py
@@ -402,11 +402,22 @@ class Node:
             secagg = SecaggSetup(**setup_arguments)()
             reply: SecaggReply = secagg.setup()
         except Exception as error_message:
-            logger.error(error_message)
+            error_text = repr(error_message)
+            logger.error(
+                "Secure aggregation setup failed on node=%s req=%s researcher=%s error=%s",
+                self._node_id,
+                request.request_id,
+                request.researcher_id,
+                error_text,
+            )
+            logger.debug(
+                "Secure aggregation setup traceback: %s",
+                traceback.format_exc(),
+            )
             return self.send_error(
                 request_id=request.request_id,
                 researcher_id=request.researcher_id,
-                extra_msg=str(error_message),
+                extra_msg=error_text,
             )
 
         reply.request_id = request.request_id

--- a/fedbiomed/node/node.py
+++ b/fedbiomed/node/node.py
@@ -739,7 +739,10 @@ class Node:
         """
         researcher_host = self._config.get("researcher", "ip")
         researcher_port = self._config.get("researcher", "port")
-        connected = self.is_connected()
+        try:
+            connected = self.is_connected()
+        except Exception:
+            connected = False
 
         try:
             logger.debug(

--- a/fedbiomed/node/node.py
+++ b/fedbiomed/node/node.py
@@ -741,6 +741,7 @@ class Node:
                 researcher_host,
                 researcher_port,
                 len(extra_msg),
+                stack_info=True,
             )
 
             # Log error to console and security audit log in one call

--- a/fedbiomed/node/node.py
+++ b/fedbiomed/node/node.py
@@ -190,6 +190,9 @@ class Node:
         """
         ### (OPTIONAL) DEBUG THE RECEIVED MESSAGE FROM THE RESEARCHER
         ### WITH MORE DETAILS THAN THE CURRENT DEBUG MESSAGES
+        logger.debug(
+            "Received message from researcher, deserializing to Message object..."
+        )
 
         message: Message
         try:

--- a/fedbiomed/node/node.py
+++ b/fedbiomed/node/node.py
@@ -188,12 +188,6 @@ class Node:
         Args:
             msg: Incoming message from Researcher.
         """
-        ### (OPTIONAL) DEBUG THE RECEIVED MESSAGE FROM THE RESEARCHER
-        ### WITH MORE DETAILS THAN THE CURRENT DEBUG MESSAGES
-        logger.debug(
-            "Received message from researcher, deserializing to Message object..."
-        )
-
         message: Message
         try:
             message = Message.from_dict(msg)
@@ -206,19 +200,15 @@ class Node:
                 researcher_id=resid,
             )
         else:
-            no_print = [
-                "aggregator_args",
-                "optim_aux_var",
-                "params",
-                "training_plan",
-                "overlay",
-            ]
-            msg_print = {
-                key: value
-                for key, value in message.get_dict().items()
-                if key not in no_print
-            }
-            logger.debug("Message received: " + str(msg_print))
+            logger.debug(
+                "Received researcher message type=%s req=%s researcher=%s experiment=%s dataset=%s round=%s",
+                message.__name__,
+                getattr(message, "request_id", None),
+                getattr(message, "researcher_id", None),
+                getattr(message, "experiment_id", None),
+                getattr(message, "dataset_id", None),
+                getattr(message, "round", None),
+            )
 
             # Set security context for all logs related to this message
             with logger.security_context(
@@ -241,6 +231,12 @@ class Node:
                         | FARequest.__name__
                         | PreprocRequest.__name__
                     ):
+                        logger.debug(
+                            "Queueing node task type=%s req=%s experiment=%s",
+                            message.__name__,
+                            getattr(message, "request_id", None),
+                            getattr(message, "experiment_id", None),
+                        )
                         self.add_task(message)
                     case SecaggDeleteRequest.__name__:
                         self._task_secagg_delete(message)
@@ -433,8 +429,6 @@ class Node:
             researcher_id=msg.researcher_id,
             send=self._grpc_client.send,
         )
-        logger.debug(f"History monitor initialized for experiment {msg.experiment_id}")
-
         dataset_id = msg.get_param("dataset_id")
         data = self.dataset_manager.dataset_table.get_by_id(dataset_id)
 
@@ -449,7 +443,15 @@ class Node:
                 errnum=ErrorNumbers.FB313,
             )
         logger.debug(
-            f"Dataset successfully fetched for dataset_id={dataset_id} on node={self._node_id}"
+            "Preparing training round req=%s experiment=%s round=%s dataset=%s training_plan=%s training=%s state_id=%s has_aux_var=%s",
+            msg.request_id,
+            msg.experiment_id,
+            msg.round,
+            dataset_id,
+            msg.get_param("training_plan_class"),
+            bool(msg.get_param("training")),
+            msg.get_param("state_id"),
+            msg.get_param("optim_aux_var") is not None,
         )
 
         dlp_and_loading_block_metadata = None
@@ -457,13 +459,8 @@ class Node:
             dlp_and_loading_block_metadata = self.dataset_manager.get_dlp_by_id(
                 data["dlp_id"]
             )
-            logger.debug(
-                f"DLP and loading block metadata with dlp_id={data['dlp_id']} fetched for dataset_id={dataset_id} on node={self._node_id}"
-            )
         else:
-            logger.debug(
-                f"No DLP and loading block metadata found for dataset_id={dataset_id} on node={self._node_id}"
-            )
+            logger.debug("No data loading plan metadata for dataset=%s", dataset_id)
 
         round_ = Round(
             root_dir=self._config.root,
@@ -555,6 +552,14 @@ class Node:
                                     ),
                                     round_number=item.round,
                                 )
+                                logger.debug(
+                                    "Starting node training req=%s experiment=%s round=%s dataset=%s plan=%s",
+                                    item.request_id,
+                                    item.experiment_id,
+                                    item.round,
+                                    round_.dataset.get("dataset_id"),
+                                    item.get_param("training_plan_class"),
+                                )
                                 msg = round_.run_model_training(
                                     tp_approval=self._config.getbool(
                                         "security", "training_plan_approval"
@@ -586,6 +591,15 @@ class Node:
                                     ),
                                     round_number=item.round,
                                     duration_seconds=round(duration_seconds, 2),
+                                )
+                                logger.debug(
+                                    "Finished node training req=%s experiment=%s round=%s reply_type=%s success=%s duration_s=%.2f",
+                                    item.request_id,
+                                    item.experiment_id,
+                                    item.round,
+                                    msg.__class__.__name__,
+                                    getattr(msg, "success", None),
+                                    duration_seconds,
                                 )
                                 del round_
 
@@ -712,7 +726,23 @@ class Node:
                 regardless of specific researcher.
             request_id: Optional request i to reply as error to a request.
         """
+        researcher_host = self._config.get("researcher", "ip")
+        researcher_port = self._config.get("researcher", "port")
+        connected = self.is_connected()
+
         try:
+            logger.debug(
+                "Preparing error reply errnum=%s req=%s researcher=%s broadcast=%s connected=%s destination=%s:%s msg_len=%d",
+                errnum.name,
+                request_id,
+                researcher_id,
+                broadcast,
+                connected,
+                researcher_host,
+                researcher_port,
+                len(extra_msg),
+            )
+
             # Log error to console and security audit log in one call
             logger.error(
                 extra_msg,
@@ -740,5 +770,17 @@ class Node:
                 ),
                 broadcast=broadcast,
             )
+
+            logger.debug(
+                "Error reply dispatched errnum=%s req=%s researcher=%s broadcast=%s connected=%s",
+                errnum.name,
+                request_id,
+                researcher_id,
+                broadcast,
+                connected,
+            )
         except Exception as e:
-            logger.error(f"{ErrorNumbers.FB601.value}: Cannot send error message: {e}")
+            logger.error(
+                f"{ErrorNumbers.FB601.value}: Cannot send error message: {e}",
+                exc_info=True,
+            )

--- a/fedbiomed/node/node_state_manager.py
+++ b/fedbiomed/node/node_state_manager.py
@@ -295,7 +295,7 @@ class NodeStateManager:
         path = os.path.join(base_dir, file_name)
         logger.debug(
             f"Generated node state file path: experiment_id={experiment_id} "
-            f"round={round_nb} element={element.name} path={path}"
+            f"round={round_nb} element={getattr(element, 'name', repr(element))} path={path}"
         )
         return path
 

--- a/fedbiomed/node/node_state_manager.py
+++ b/fedbiomed/node/node_state_manager.py
@@ -111,6 +111,9 @@ class NodeStateManager:
         Raises:
             FedbiomedNodeStateManagerError: no matching state in the database
         """
+        logger.debug(
+            f"Loading node state: experiment_id={experiment_id} state_id={state_id}"
+        )
         state = self._load_state(experiment_id, state_id)
 
         if state is None:
@@ -121,6 +124,10 @@ class NodeStateManager:
             )
 
         # from this point, state should be a dictionary
+        logger.debug(
+            f"Loaded node state metadata: experiment_id={experiment_id} "
+            f"state_id={state_id} keys={sorted(state.keys())}"
+        )
         self._check_version(state.get("version_node_id"))
         return state
 
@@ -149,6 +156,10 @@ class NodeStateManager:
         }
 
         state.update(header)
+        logger.debug(
+            f"Saving node state metadata: experiment_id={experiment_id} "
+            f"state_id={self._state_id} keys={sorted(state.keys())}"
+        )
         self._save_state(self._state_id, state)
         return self._state_id
 
@@ -180,7 +191,14 @@ class NodeStateManager:
             raise FedbiomedNodeStateManagerError(
                 f"{ErrorNumbers.FB323.value}: Failing to load node state in DataBase"
             ) from e
-        logger.debug("Successfully loaded previous state!")
+        if res is None:
+            logger.debug(
+                f"Node state not found in database: experiment_id={experiment_id} state_id={state_id}"
+            )
+        else:
+            logger.debug(
+                f"Node state found in database: experiment_id={experiment_id} state_id={state_id}"
+            )
         return res
 
     def _save_state(self, state_id: str, state_entry: Dict[str, Any]) -> None:
@@ -201,6 +219,7 @@ class NodeStateManager:
             raise FedbiomedNodeStateManagerError(
                 f"{ErrorNumbers.FB323.value}: failing to save node state into DataBase"
             ) from e
+        logger.debug(f"Node state saved to database: state_id={state_id}")
 
     def initialize(
         self, previous_state_id: Optional[str] = None, testing: Optional[bool] = False
@@ -213,6 +232,10 @@ class NodeStateManager:
         """
 
         self._previous_state_id = previous_state_id
+        logger.debug(
+            f"Initializing node state manager: node_id={self._node_id} "
+            f"previous_state_id={previous_state_id} testing={testing}"
+        )
         if not testing:
             self._generate_new_state_id()
 
@@ -227,6 +250,10 @@ class NodeStateManager:
                     f"{ErrorNumbers.FB323.value}: Failing to create"
                     f" directories {self._node_state_base_dir}"
                 ) from e
+            logger.debug(
+                f"Node state manager ready: state_id={self._state_id} "
+                f"base_dir={self._node_state_base_dir}"
+            )
 
     def get_node_state_base_dir(self) -> Optional[str]:
         """Returns `Node` State base directory path, in which are saved Node state files and other contents
@@ -277,7 +304,12 @@ class NodeStateManager:
             ) from e
         # TODO catch exception here
         file_name = element.value % (round_nb, self._state_id)
-        return os.path.join(base_dir, file_name)
+        path = os.path.join(base_dir, file_name)
+        logger.debug(
+            f"Generated node state file path: experiment_id={experiment_id} "
+            f"round={round_nb} element={element.name} path={path}"
+        )
+        return path
 
     def _generate_new_state_id(self) -> str:
         """Generates randomly a state_id. Should be created at each Round, before saving Node State into Database.
@@ -286,6 +318,7 @@ class NodeStateManager:
             new state_id
         """
         self._state_id = NODE_STATE_PREFIX + str(uuid.uuid4())
+        logger.debug(f"Generated new node state id: state_id={self._state_id}")
         # TODO: would be better to check if state_id doesn't belong to the database
         return self._state_id
 
@@ -295,6 +328,11 @@ class NodeStateManager:
         Args:
             version: version found in the DataBase entries.
         """
+
+        logger.debug(
+            f"Checking node state version compatibility: found={version} "
+            f"current={__node_state_version__}"
+        )
 
         raise_for_version_compatibility(
             version,

--- a/fedbiomed/node/node_state_manager.py
+++ b/fedbiomed/node/node_state_manager.py
@@ -124,10 +124,6 @@ class NodeStateManager:
             )
 
         # from this point, state should be a dictionary
-        logger.debug(
-            f"Loaded node state metadata: experiment_id={experiment_id} "
-            f"state_id={state_id} keys={sorted(state.keys())}"
-        )
         self._check_version(state.get("version_node_id"))
         return state
 
@@ -156,10 +152,6 @@ class NodeStateManager:
         }
 
         state.update(header)
-        logger.debug(
-            f"Saving node state metadata: experiment_id={experiment_id} "
-            f"state_id={self._state_id} keys={sorted(state.keys())}"
-        )
         self._save_state(self._state_id, state)
         return self._state_id
 
@@ -250,10 +242,6 @@ class NodeStateManager:
                     f"{ErrorNumbers.FB323.value}: Failing to create"
                     f" directories {self._node_state_base_dir}"
                 ) from e
-            logger.debug(
-                f"Node state manager ready: state_id={self._state_id} "
-                f"base_dir={self._node_state_base_dir}"
-            )
 
     def get_node_state_base_dir(self) -> Optional[str]:
         """Returns `Node` State base directory path, in which are saved Node state files and other contents

--- a/fedbiomed/node/requests/_n2n_controller.py
+++ b/fedbiomed/node/requests/_n2n_controller.py
@@ -193,6 +193,10 @@ class NodeToNodeController:
         Args:
             inner_msg: received inner message
         """
+        logger.debug(
+            f"Processing channel setup reply: node_id={self._node_id} src_node_id={inner_msg.node_id} "
+            f"request_id={inner_msg.request_id}"
+        )
         if not await self._overlay_channel.set_distant_key(
             inner_msg.node_id,
             inner_msg.public_key,
@@ -217,6 +221,10 @@ class NodeToNodeController:
         Returns:
             A `dict` with overlay reply message
         """
+        logger.debug(
+            f"Handling node-to-node key request: node_id={self._node_id} src_node_id={inner_msg.node_id} "
+            f"request_id={inner_msg.request_id} secagg_id={inner_msg.secagg_id}"
+        )
         # Wait until node has generated its DH keypair
         all_received, data = self._controller_data.wait(
             [inner_msg.secagg_id], TIMEOUT_NODE_TO_NODE_REQUEST
@@ -224,6 +232,10 @@ class NodeToNodeController:
 
         # Don't send reply message if the public key is not available after a timeout
         if not all_received:
+            logger.debug(
+                f"Node-to-node key request timed out waiting for local data: node_id={self._node_id} "
+                f"src_node_id={inner_msg.node_id} request_id={inner_msg.request_id} secagg_id={inner_msg.secagg_id}"
+            )
             return None
 
         # we assume the data is properly formatted
@@ -259,6 +271,10 @@ class NodeToNodeController:
             overlay_resp: overlay reply message to send
         """
         if isinstance(overlay_resp, OverlayMessage):
+            logger.debug(
+                f"Sending node-to-node key reply overlay: node_id={self._node_id} "
+                f"dest_node_id={overlay_resp.dest_node_id} setup={overlay_resp.setup}"
+            )
             self._grpc_controller.send(overlay_resp)
 
     async def _AdditiveSSharingRequest(  # pylint: disable=C0103
@@ -271,12 +287,20 @@ class NodeToNodeController:
         """
 
         from_ = request.node_id
+        logger.debug(
+            f"Handling additive secret sharing request: node_id={self._node_id} src_node_id={from_} "
+            f"request_id={request.request_id} secagg_id={request.secagg_id}"
+        )
         # Wait until node has generated its share for given secagg id
         all_received, data = self._controller_data.wait(
             [request.secagg_id], TIMEOUT_NODE_TO_NODE_REQUEST
         )
 
         if not all_received:
+            logger.debug(
+                f"Additive secret sharing request timed out waiting for local data: node_id={self._node_id} "
+                f"src_node_id={from_} request_id={request.request_id} secagg_id={request.secagg_id}"
+            )
             return None
 
         share = data[0]["shares"].get(from_)
@@ -313,6 +337,10 @@ class NodeToNodeController:
             overlay_resp: overlay reply message to send
         """
         if isinstance(overlay_resp, OverlayMessage):
+            logger.debug(
+                f"Sending additive secret sharing reply overlay: node_id={self._node_id} "
+                f"dest_node_id={overlay_resp.dest_node_id} setup={overlay_resp.setup}"
+            )
             self._grpc_controller.send(overlay_resp)
 
     async def _HandlerKeyReply(  # pylint: disable=C0103

--- a/fedbiomed/node/requests/_overlay.py
+++ b/fedbiomed/node/requests/_overlay.py
@@ -86,6 +86,9 @@ class _ChannelKeys:
             distant_node_id: unique ID of the peer node
         """
         if distant_node_id not in self._channel_keys:
+            logger.debug(
+                f"Creating node-to-node channel state: distant_node_id={distant_node_id}"
+            )
             local_key = DHKey()
             self._channel_manager.add(distant_node_id, local_key.export_private_key())
 
@@ -118,6 +121,10 @@ class _ChannelKeys:
         """
         async with self._channel_keys_lock:
             self._channel_keys[distant_node_id].pending_requests.append(request_id)
+            logger.debug(
+                f"Registered pending node-to-node channel request: distant_node_id={distant_node_id} "
+                f"request_id={request_id} pending_count={len(self._channel_keys[distant_node_id].pending_requests)}"
+            )
 
     async def set_distant_key(
         self,
@@ -147,12 +154,19 @@ class _ChannelKeys:
                 or request_id
                 not in self._channel_keys[distant_node_id].pending_requests
             ):
+                logger.debug(
+                    f"Ignoring distant node key update: distant_node_id={distant_node_id} "
+                    f"request_id={request_id} reason=unregistered_or_unexpected"
+                )
                 return False
 
             self._channel_keys[distant_node_id].distant_key = dh_key
             r = self._channel_keys[distant_node_id].pending_requests
             r.pop(r.index(request_id))
             self._channel_keys[distant_node_id].ready_event.set()
+            logger.debug(
+                f"Stored distant node key: distant_node_id={distant_node_id} request_id={request_id}"
+            )
             return True
 
     async def get_local_public_key(self, distant_node_id: str) -> bytes:
@@ -177,12 +191,21 @@ class _ChannelKeys:
             True if keys for the channel are ready for usage, False if keys are not ready.
         """
         try:
+            logger.debug(
+                f"Waiting for node-to-node channel readiness: distant_node_id={distant_node_id}"
+            )
             await asyncio.wait_for(
                 self._channel_keys[distant_node_id].ready_event.wait(),
                 TIMEOUT_NODE_TO_NODE_REQUEST,
             )
+            logger.debug(
+                f"Node-to-node channel ready: distant_node_id={distant_node_id}"
+            )
             return True
         except TimeoutError:
+            logger.debug(
+                f"Node-to-node channel wait timed out: distant_node_id={distant_node_id}"
+            )
             return False
 
 
@@ -294,6 +317,10 @@ class OverlayChannel:
         Returns:
             True if the distant key was set, False if it was not set
         """
+        logger.debug(
+            f"Setting distant channel key: node_id={self._node_id} distant_node_id={distant_node_id} "
+            f"request_id={request_id}"
+        )
         return await self._channel_keys.set_distant_key(
             distant_node_id, public_key_pem, request_id
         )
@@ -323,6 +350,11 @@ class OverlayChannel:
             FedbiomedNodeToNodeError: distant node does not answer during channel setup
         """
 
+        logger.debug(
+            f"Preparing node-to-node channel keys: node_id={self._node_id} distant_node_id={distant_node_id} "
+            f"researcher_id={researcher_id} setup={setup} salt_len={len(salt)}"
+        )
+
         if setup:
             # If we are doing channel setup exchange, then use the default or "master" keys
             # for the channel
@@ -344,6 +376,10 @@ class OverlayChannel:
 
                 await self._channel_keys.add_pending_request(
                     distant_node_id, distant_node_message.request_id
+                )
+                logger.debug(
+                    f"Sending channel setup request: node_id={self._node_id} distant_node_id={distant_node_id} "
+                    f"request_id={distant_node_message.request_id}"
                 )
                 received = await self.send_node_setup(
                     researcher_id,
@@ -370,6 +406,10 @@ class OverlayChannel:
         ).agree(
             node_v_id=distant_node_id,
             public_key_pem=distant_key.export_public_key(),
+        )
+        logger.debug(
+            f"Derived node-to-node symmetric key: node_id={self._node_id} distant_node_id={distant_node_id} "
+            f"setup={setup}"
         )
         return local_key, distant_key, derived_key
 
@@ -398,6 +438,12 @@ class OverlayChannel:
             raise FedbiomedNodeToNodeError(
                 f"{ErrorNumbers.FB324.value}: not an inner message"
             )
+
+        logger.debug(
+            f"Formatting outgoing overlay message: node_id={self._node_id} "
+            f"dest_node_id={message.get_param('dest_node_id')} type={message.__name__} "
+            f"request_id={getattr(message, 'request_id', None)} setup={setup}"
+        )
 
         # Value for salting the symmetric encryption key generation for this message
         # Adjust length of `salt` depending on algorithm
@@ -432,7 +478,13 @@ class OverlayChannel:
             mode=None,
             backend=default_backend(),
         ).encryptor()
-        return encryptor.update(signed) + encryptor.finalize(), salt, nonce
+        overlay = encryptor.update(signed) + encryptor.finalize()
+        logger.debug(
+            f"Formatted outgoing overlay payload: node_id={self._node_id} "
+            f"dest_node_id={message.get_param('dest_node_id')} type={message.__name__} "
+            f"request_id={getattr(message, 'request_id', None)} payload_bytes={len(overlay)}"
+        )
+        return overlay, salt, nonce
 
     async def format_incoming_overlay(
         self, overlay_msg: OverlayMessage
@@ -459,6 +511,11 @@ class OverlayChannel:
             raise FedbiomedNodeToNodeError(
                 f"{ErrorNumbers.FB324.value}: not an overlay message"
             )
+
+        logger.debug(
+            f"Formatting incoming overlay message: node_id={self._node_id} src_node_id={overlay_msg.node_id} "
+            f"dest_node_id={overlay_msg.dest_node_id} setup={overlay_msg.setup} payload_bytes={len(overlay_msg.overlay)}"
+        )
 
         _, distant_node_public_key, derived_key = await self._setup_use_channel_keys(
             overlay_msg.node_id,
@@ -517,6 +574,11 @@ class OverlayChannel:
                 f"inner_node_id={inner_msg.dest_node_id} overlay_node_id={overlay_msg.dest_node_id}"
             )
 
+        logger.debug(
+            f"Validated incoming overlay message: node_id={self._node_id} src_node_id={overlay_msg.node_id} "
+            f"type={inner_msg.__name__} request_id={getattr(inner_msg, 'request_id', None)} setup={overlay_msg.setup}"
+        )
+
         return inner_msg
 
     async def send_node_setup(
@@ -535,6 +597,10 @@ class OverlayChannel:
         Returns:
             True if channel is ready, False if channel not ready after timeout
         """
+        logger.debug(
+            f"Starting node-to-node channel setup send: node_id={self._node_id} distant_node_id={node} "
+            f"type={message.__name__} request_id={getattr(message, 'request_id', None)}"
+        )
         overlay, salt, nonce = await self.format_outgoing_overlay(
             message, researcher_id, True
         )
@@ -550,4 +616,9 @@ class OverlayChannel:
 
         self._grpc_client.send(message_overlay)
 
-        return await self._channel_keys.wait_ready_channel(node)
+        ready = await self._channel_keys.wait_ready_channel(node)
+        logger.debug(
+            f"Completed node-to-node channel setup send: node_id={self._node_id} distant_node_id={node} "
+            f"request_id={getattr(message, 'request_id', None)} ready={ready}"
+        )
+        return ready

--- a/fedbiomed/node/requests/_send_nodes.py
+++ b/fedbiomed/node/requests/_send_nodes.py
@@ -5,6 +5,7 @@ from typing import Any, List, Tuple
 
 from fedbiomed.common.constants import TIMEOUT_NODE_TO_NODE_REQUEST, ErrorNumbers
 from fedbiomed.common.exceptions import FedbiomedNodeToNodeError
+from fedbiomed.common.logger import logger
 from fedbiomed.common.message import InnerMessage, InnerRequestReply, OverlayMessage
 from fedbiomed.common.synchro import EventWaitExchange
 from fedbiomed.transport.controller import GrpcController
@@ -42,6 +43,10 @@ def send_nodes(
     request_ids = []
 
     for node, message in zip(nodes, messages, strict=False):
+        logger.debug(
+            f"Preparing node-to-node message: src_node_id={n2n_router.node_id} dest_node_id={node} "
+            f"type={message.__name__} request_id={getattr(message, 'request_id', None)}"
+        )
         overlay, salt, nonce = n2n_router.format_outgoing_overlay(
             message, researcher_id
         )
@@ -56,12 +61,24 @@ def send_nodes(
         )
 
         grpc_client.send(message_overlay)
+        logger.debug(
+            f"Sent node-to-node overlay message: src_node_id={n2n_router.node_id} dest_node_id={node} "
+            f"type={message.__name__} request_id={getattr(message, 'request_id', None)} payload_bytes={len(overlay)}"
+        )
 
         if isinstance(message, InnerRequestReply):
             request_ids += [message.get_param("request_id")]
 
+    logger.debug(
+        f"Waiting for node-to-node replies: src_node_id={n2n_router.node_id} request_ids={request_ids} "
+        f"timeout_s={TIMEOUT_NODE_TO_NODE_REQUEST}"
+    )
     all_received, replies = pending_requests.wait(
         request_ids, TIMEOUT_NODE_TO_NODE_REQUEST
+    )
+    logger.debug(
+        f"Completed node-to-node wait: src_node_id={n2n_router.node_id} request_ids={request_ids} "
+        f"received={len(replies)} all_received={all_received}"
     )
     if not all_received and raise_if_not_all_received:
         nodes_no_answer = set(nodes) - set(m.node_id for m in replies)

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -500,6 +500,15 @@ class Round:
             )
 
             if self._secure_aggregation.use_secagg:
+                logger.debug(
+                    'SecAgg active: encrypting model parameters with the secure aggregation scheme "%s" for round %d',
+                    self._secure_aggregation.scheme.name,
+                    self._round,
+                )
+                if results["optim_aux_var"]:
+                    logger.debug(
+                        "Optimizer Auxiliary variables found, they will also be encrypted."
+                    )
                 model_weights, enc_factor, aux_var = self._encrypt_weights_and_auxvar(
                     model_weights=model_weights,
                     optim_aux_var=results["optim_aux_var"],
@@ -508,6 +517,9 @@ class Round:
                 )
                 results["encrypted"] = True
                 results["encryption_factor"] = enc_factor
+                logger.debug(
+                    f"Model parameters encrypted for round {self._round} , with encryption factor {enc_factor} and scheme {self._secure_aggregation.scheme.name}."
+                )
                 if aux_var is not None:
                     results["optim_aux_var"] = aux_var.to_dict()
             results["params"] = model_weights
@@ -605,11 +617,6 @@ class Round:
                 "This process can take some time depending on model size.",
                 researcher_id=self.researcher_id,
             )
-            # encrypted_wgt = self._secure_aggregation.scheme.encrypt(
-            #         params=model_weights,
-            #         current_round=self._round,
-            #         weight=sample_size,
-            # )
             encrypted_aux = None
 
         encrypted_wgt = self._secure_aggregation.scheme.encrypt(
@@ -750,7 +757,7 @@ class Round:
                     f"Loading Optimizer from state {state_id} failed ... Resuming Experiment with default"
                     "Optimizer state."
                 )
-                logger.debug(f" Error detail {err}")
+                logger.debug(f" Error detail {repr(err)}")
 
         # load testing dataset if any
         if state["testing_dataset"] and not self.is_test_data_shuffled:

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -346,12 +346,17 @@ class Round:
         try:
             error_message = self.process_optim_aux_var()
         except Exception as e:
-            if error_message:
-                logger.error(
-                    f"Error while processing optimizer auxiliary variables: {error_message}. Details: {repr(e)}"
-                )
+            logger.error(
+                f"Error while processing optimizer auxiliary variables: Details: {repr(e)}"
+            )
             logger.debug(
                 f"Optimizer auxiliary variables processing error details: {traceback.format_exc()}"
+            )
+            return self._send_round_reply(success=False, message=error_message)
+
+        if error_message is not None:
+            logger.error(
+                f"Error while processing optimizer auxiliary variables: {error_message}"
             )
             return self._send_round_reply(success=False, message=error_message)
 

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -211,16 +211,24 @@ class Round:
         Returns:
             Returns the corresponding node message, training reply instance
         """
+        dataset_id = (
+            self.dataset.get("dataset_id") if isinstance(self.dataset, dict) else None
+        )
+        dp_active = (
+            self.training_arguments.get("dp_args") is not None
+            if self.training_arguments is not None
+            else None
+        )
         logger.debug(
             "Starting round execution: node_id=%s experiment=%s round=%s training=%s dataset=%s secagg_active=%s force_secagg=%s dp_active=%s secagg_args_keys=%s",
             self._node_id,
             self.experiment_id,
             self._round,
             self.training,
-            self.dataset.get("dataset_id"),
+            dataset_id,
             secagg_active,
             force_secagg,
-            self.training_arguments.get("dp_args") is not None,
+            dp_active,
             sorted((secagg_arguments or {}).keys()),
         )
         # Validate secagg status. Raises error if the training request is not compatible with
@@ -447,9 +455,9 @@ class Round:
                 "Executing training phase for round: experiment=%s round=%s dataset=%s has_testing_loader=%s has_training_loader=%s",
                 self.experiment_id,
                 self._round,
-                self.dataset.get("dataset_id"),
-                self.training_plan.testing_data_loader is not None,
-                self.training_plan.training_data_loader is not None,
+                dataset_id,
+                getattr(self.training_plan, "testing_data_loader", None) is not None,
+                getattr(self.training_plan, "training_data_loader", None) is not None,
             )
             results = {}  # type: Dict[str, Any]
 

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -66,6 +66,7 @@ class Round:
         round_number: int = 0,
         dlp_and_loading_block_metadata: Optional[Tuple[dict, List[dict]]] = None,
         aux_vars: Optional[Dict[str, AuxVar]] = None,
+        debug: Optional[bool] = False,
     ) -> None:
         """Constructor of the class
 
@@ -137,6 +138,7 @@ class Round:
         )
         self._temp_dir = tempfile.TemporaryDirectory()
         self._keep_files_dir = self._temp_dir.name
+        self._debug = debug
 
     def __del__(self):
         """Class destructor"""
@@ -255,8 +257,10 @@ class Round:
                 code=self.training_plan_source, class_name=self.training_plan_class
             )
             self.training_plan = CurrentTrainingPlan()
-        except Exception:
+        except Exception as e:
             error_message = "Cannot instantiate training plan object."
+            if self._debug:
+                logger.error(f"{error_message} Details: {repr(e)}")
             return self._send_round_reply(success=False, message=error_message)
 
         # save and load training plan to a file to be sure
@@ -282,8 +286,10 @@ class Round:
             CurrentTPModule, self.training_plan = utils.import_class_object_from_file(
                 training_plan_file, self.training_plan_class
             )
-        except Exception:
+        except Exception as e:
             error_message = "Cannot load training plan object from file."
+            if self._debug:
+                logger.error(f"{error_message} Details: {repr(e)}")
             return self._send_round_reply(success=False, message=error_message)
 
         try:
@@ -293,8 +299,10 @@ class Round:
                 aggregator_args=self.aggregator_args,
                 node_id=self._node_id,
             )
-        except Exception:
+        except Exception as e:
             error_message = "Can't initialize training plan with the arguments."
+            if self._debug:
+                logger.error(f"{error_message} Details: {repr(e)}")
             return self._send_round_reply(success=False, message=error_message)
 
         # load node state
@@ -302,8 +310,10 @@ class Round:
         if previous_state_id is not None:
             try:
                 self._load_round_state(previous_state_id)
-            except Exception:
-                # don't send error details
+            except Exception as e:
+                if self._debug:
+                    logger.error(f"Can't read previous node state. Details: {repr(e)}")
+                # don't send error details to researcher
                 return self._send_round_reply(
                     success=False, message="Can't read previous node state."
                 )
@@ -311,14 +321,20 @@ class Round:
         # Load model parameters received from researcher
         try:
             self.training_plan.set_model_params(self.params)
-        except Exception:
+        except Exception as e:
             error_message = "Cannot initialize model parameters."
+            if self._debug:
+                logger.error(f"{error_message} Details: {repr(e)}")
             return self._send_round_reply(success=False, message=error_message)
         # ---------------------------------------------------------------------
 
         # Process Optimizer auxiliary variables, if any.
         error_message = self.process_optim_aux_var()
         if error_message:
+            if self._debug:
+                logger.error(
+                    f"Error while processing optimizer auxiliary variables: {error_message}"
+                )
             return self._send_round_reply(success=False, message=error_message)
 
         # Split training and validation data -------------------------------------
@@ -327,12 +343,16 @@ class Round:
 
         except FedbiomedError as fe:
             error_message = f"Can not create validation/train data: {repr(fe)}"
+            if self._debug:
+                logger.error(error_message)
             return self._send_round_reply(success=False, message=error_message)
         except Exception as e:
             error_message = (
                 f"Undetermined error while creating data for training/validation. Can not create "
                 f"validation/train data: {repr(e)}"
             )
+            if self._debug:
+                logger.error(error_message)
             return self._send_round_reply(success=False, message=error_message)
         # ------------------------------------------------------------------------
 
@@ -382,6 +402,8 @@ class Round:
                     ptime_after = time.process_time()
                 except Exception as exc:
                     error_message = f"Cannot train model in round: {repr(exc)}"
+                    if self._debug:
+                        logger.error(error_message)
                     return self._send_round_reply(success=False, message=error_message)
 
             # Collect Optimizer auxiliary variables, if any.
@@ -392,6 +414,8 @@ class Round:
                 error_message = (
                     f"Cannot collect Optimizer auxiliary variables: {repr(exc)}"
                 )
+                if self._debug:
+                    logger.error(error_message)
                 return self._send_round_reply(success=False, message=error_message)
 
             # Validation after training
@@ -452,8 +476,10 @@ class Round:
 
             try:
                 self._save_round_state()
-            except Exception:
+            except Exception as e:
                 # don't send details to researcher
+                if self._debug:
+                    logger.error(f"Error while saving round state: {repr(e)}")
                 return self._send_round_reply(
                     success=False, message="Can't save new node state."
                 )
@@ -462,8 +488,12 @@ class Round:
             try:
                 del self.training_plan
                 del CurrentTPModule
-            except Exception:
+            except Exception as e:
                 logger.debug("Exception raised while deleting training plan instance")
+                if self._debug:
+                    logger.error(
+                        f"Exception raised while deleting training plan instance: {repr(e)}"
+                    )
 
             return self._send_round_reply(
                 success=True,

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -220,16 +220,11 @@ class Round:
             else None
         )
         logger.debug(
-            "Starting round execution: node_id=%s experiment=%s round=%s training=%s dataset=%s secagg_active=%s force_secagg=%s dp_active=%s secagg_args_keys=%s",
-            self._node_id,
-            self.experiment_id,
-            self._round,
-            self.training,
-            dataset_id,
-            secagg_active,
-            force_secagg,
-            dp_active,
-            sorted((secagg_arguments or {}).keys()),
+            f"Starting round execution: node_id={self._node_id} "
+            f"experiment={self.experiment_id} round={self._round} "
+            f"training={self.training} dataset={dataset_id} "
+            f"secagg_active={secagg_active} force_secagg={force_secagg} "
+            f"dp_active={dp_active} secagg_args_keys={sorted((secagg_arguments or {}).keys())}"
         )
         # Validate secagg status. Raises error if the training request is not compatible with
         # secure aggregation settings
@@ -273,7 +268,7 @@ class Round:
             else:
                 logger.info(
                     f"Training plan has been approved by the node {training_plan_['name']}",
-                    researcher_id=self.researcher_id,
+                    f"researcher_id={self.researcher_id}",
                 )
 
         # Import training plan, save to file, reload, instantiate a training plan
@@ -328,15 +323,10 @@ class Round:
                 node_id=self._node_id,
             )
             logger.debug(
-                "Training plan initialized for round: experiment=%s round=%s plan=%s training=%s dp_active=%s aggregator=%s",
-                self.experiment_id,
-                self._round,
-                self.training_plan.__class__.__name__,
-                self.training,
-                self.training_arguments.get("dp_args") is not None,
-                self.aggregator_args.get("aggregator_name")
-                if self.aggregator_args
-                else None,
+                f"Training plan initialized for round: experiment={self.experiment_id} "
+                f"round={self._round} plan={self.training_plan.__class__.__name__} "
+                f"training={self.training} dp_active={self.training_arguments.get('dp_args') is not None} "
+                f"aggregator={self.aggregator_args.get('aggregator_name') if self.aggregator_args else None}",
             )
         except Exception as e:
             error_message = "Can't initialize training plan with the arguments."
@@ -533,13 +523,11 @@ class Round:
                 self.training_plan.training_data_loader.dataset
             )
             logger.debug(
-                "Collected round outputs before reply assembly: experiment=%s round=%s sample_size=%s has_aux_var=%s dp_active=%s flatten_for_secagg=%s",
-                self.experiment_id,
-                self._round,
-                results["sample_size"],
-                results["optim_aux_var"] is not None,
-                self.training_arguments.get("dp_args") is not None,
-                self._secure_aggregation.use_secagg,
+                f"Collected round outputs before reply assembly: experiment={self.experiment_id} "
+                f"round={self._round} sample_size={results['sample_size']} "
+                f"has_aux_var={results['optim_aux_var'] is not None} "
+                f"dp_active={self.training_arguments.get('dp_args') is not None} "
+                f"flatten_for_secagg={self._secure_aggregation.use_secagg}"
             )
 
             results["encrypted"] = False
@@ -547,18 +535,14 @@ class Round:
                 flatten=self._secure_aggregation.use_secagg
             )
             logger.debug(
-                "Collected training parameters for round reply: experiment=%s round=%s parameter_count=%s secagg_enabled=%s",
-                self.experiment_id,
-                self._round,
-                len(model_weights),
-                self._secure_aggregation.use_secagg,
+                f"Collected training parameters for round reply: experiment={self.experiment_id} "
+                f"round={self._round} parameter_count={len(model_weights)} "
+                f"secagg_enabled={self._secure_aggregation.use_secagg}"
             )
 
             if self._secure_aggregation.use_secagg:
                 logger.debug(
-                    'SecAgg active: encrypting model parameters with the secure aggregation scheme "%s" for round %d',
-                    self._secure_aggregation.scheme.__class__.__name__,
-                    self._round,
+                    f'SecAgg active: encrypting model parameters with the secure aggregation scheme "{self._secure_aggregation.scheme.__class__.__name__}" for round {self._round}'
                 )
                 if results["optim_aux_var"]:
                     logger.debug(
@@ -616,10 +600,8 @@ class Round:
         else:
             # Only for validation
             logger.debug(
-                "Skipping training execution for round: experiment=%s round=%s dataset=%s reason=training_disabled",
-                self.experiment_id,
-                self._round,
-                self.dataset.get("dataset_id"),
+                f"Skipping training execution for round: experiment={self.experiment_id} "
+                f"round={self._round} dataset={self.dataset.get('dataset_id')} reason=training_disabled"
             )
             return self._send_round_reply(success=True)
 

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -8,6 +8,7 @@ implementation of Round class of the node component
 import os
 import tempfile
 import time
+import traceback
 import uuid
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -66,7 +67,6 @@ class Round:
         round_number: int = 0,
         dlp_and_loading_block_metadata: Optional[Tuple[dict, List[dict]]] = None,
         aux_vars: Optional[Dict[str, AuxVar]] = None,
-        debug: Optional[bool] = False,
     ) -> None:
         """Constructor of the class
 
@@ -138,7 +138,6 @@ class Round:
         )
         self._temp_dir = tempfile.TemporaryDirectory()
         self._keep_files_dir = self._temp_dir.name
-        self._debug = debug
 
     def __del__(self):
         """Class destructor"""
@@ -225,7 +224,10 @@ class Round:
                 experiment_id=self.experiment_id,
             )
         except FedbiomedSecureAggregationError as e:
-            logger.error(str(e))
+            logger.error(repr(e))
+            logger.debug(
+                f"Secure aggregation configuration error details: {traceback.format_exc()}"
+            )
             return self._send_round_reply(
                 success=False, message="Could not configure secure aggregation on node"
             )
@@ -239,6 +241,9 @@ class Round:
             )
 
             if not approved:
+                logger.info(
+                    f"Training plan is not approved by the node. Training plan details: {training_plan_['name']}"
+                )
                 return self._send_round_reply(
                     False,
                     f"Requested training plan is not approved by the node with: \n"
@@ -259,8 +264,10 @@ class Round:
             self.training_plan = CurrentTrainingPlan()
         except Exception as e:
             error_message = "Cannot instantiate training plan object."
-            if self._debug:
-                logger.error(f"{error_message} Details: {repr(e)}")
+            logger.error(f"{error_message} Details: {repr(e)}")
+            logger.debug(
+                f"Training plan instantiation error details: {traceback.format_exc()}"
+            )
             return self._send_round_reply(success=False, message=error_message)
 
         # save and load training plan to a file to be sure
@@ -277,6 +284,7 @@ class Round:
         except Exception as e:
             error_message = "Cannot save the training plan to a local tmp dir"
             logger.error(f"Cannot save the training plan to a local tmp dir : {e}")
+            logger.debug(f"Training plan save error details: {traceback.format_exc()}")
             return self._send_round_reply(success=False, message=error_message)
 
         del CurrentTrainingPlan
@@ -288,8 +296,8 @@ class Round:
             )
         except Exception as e:
             error_message = "Cannot load training plan object from file."
-            if self._debug:
-                logger.error(f"{error_message} Details: {repr(e)}")
+            logger.error(f"{error_message} Details: {repr(e)}")
+            logger.debug(f"Training plan load error details: {traceback.format_exc()}")
             return self._send_round_reply(success=False, message=error_message)
 
         try:
@@ -301,8 +309,10 @@ class Round:
             )
         except Exception as e:
             error_message = "Can't initialize training plan with the arguments."
-            if self._debug:
-                logger.error(f"{error_message} Details: {repr(e)}")
+            logger.error(f"{error_message} Details: {repr(e)}")
+            logger.debug(
+                f"Training plan initialization error details: {traceback.format_exc()}"
+            )
             return self._send_round_reply(success=False, message=error_message)
 
         # load node state
@@ -311,8 +321,10 @@ class Round:
             try:
                 self._load_round_state(previous_state_id)
             except Exception as e:
-                if self._debug:
-                    logger.error(f"Can't read previous node state. Details: {repr(e)}")
+                logger.error(f"Can't read previous node state. Details: {repr(e)}")
+                logger.debug(
+                    f"Previous node state load error details: {traceback.format_exc()}"
+                )
                 # don't send error details to researcher
                 return self._send_round_reply(
                     success=False, message="Can't read previous node state."
@@ -323,36 +335,45 @@ class Round:
             self.training_plan.set_model_params(self.params)
         except Exception as e:
             error_message = "Cannot initialize model parameters."
-            if self._debug:
-                logger.error(f"{error_message} Details: {repr(e)}")
+            logger.error(f"{error_message} Details: {repr(e)}")
+            logger.debug(
+                f"Model parameters initialization error details: {traceback.format_exc()}"
+            )
             return self._send_round_reply(success=False, message=error_message)
         # ---------------------------------------------------------------------
 
         # Process Optimizer auxiliary variables, if any.
-        error_message = self.process_optim_aux_var()
-        if error_message:
-            if self._debug:
+        try:
+            error_message = self.process_optim_aux_var()
+        except Exception as e:
+            if error_message:
                 logger.error(
-                    f"Error while processing optimizer auxiliary variables: {error_message}"
+                    f"Error while processing optimizer auxiliary variables: {error_message}. Details: {repr(e)}"
                 )
+            logger.debug(
+                f"Optimizer auxiliary variables processing error details: {traceback.format_exc()}"
+            )
             return self._send_round_reply(success=False, message=error_message)
 
         # Split training and validation data -------------------------------------
         try:
             self._set_training_testing_data_loaders()
-
         except FedbiomedError as fe:
             error_message = f"Can not create validation/train data: {repr(fe)}"
-            if self._debug:
-                logger.error(error_message)
+            logger.error(error_message)
+            logger.debug(
+                f"Validation/train data creation error details: {traceback.format_exc()}"
+            )
             return self._send_round_reply(success=False, message=error_message)
         except Exception as e:
             error_message = (
                 f"Undetermined error while creating data for training/validation. Can not create "
                 f"validation/train data: {repr(e)}"
             )
-            if self._debug:
-                logger.error(error_message)
+            logger.error(error_message)
+            logger.debug(
+                f"Validation/train data creation error details: {traceback.format_exc()}"
+            )
             return self._send_round_reply(success=False, message=error_message)
         # ------------------------------------------------------------------------
 
@@ -373,11 +394,17 @@ class Round:
                         f"{repr(e)}",
                         researcher_id=self.researcher_id,
                     )
+                    logger.debug(
+                        f"Validation on global parameter updates error details: {traceback.format_exc()}"
+                    )
                 except Exception as e:
                     logger.error(
                         f"Undetermined error during the testing phase on global parameter updates: "
                         f"{repr(e)}",
                         researcher_id=self.researcher_id,
+                    )
+                    logger.debug(
+                        f"Validation on global parameter updates error details: {traceback.format_exc()}"
                     )
             else:
                 logger.error(
@@ -402,8 +429,8 @@ class Round:
                     ptime_after = time.process_time()
                 except Exception as exc:
                     error_message = f"Cannot train model in round: {repr(exc)}"
-                    if self._debug:
-                        logger.error(error_message)
+                    logger.error(error_message)
+                    logger.debug(f"Training error details: {traceback.format_exc()}")
                     return self._send_round_reply(success=False, message=error_message)
 
             # Collect Optimizer auxiliary variables, if any.
@@ -414,8 +441,10 @@ class Round:
                 error_message = (
                     f"Cannot collect Optimizer auxiliary variables: {repr(exc)}"
                 )
-                if self._debug:
-                    logger.error(error_message)
+                logger.error(error_message)
+                logger.debug(
+                    f"Optimizer auxiliary variables collecting error details: {traceback.format_exc()}"
+                )
                 return self._send_round_reply(success=False, message=error_message)
 
             # Validation after training
@@ -436,11 +465,17 @@ class Round:
                             f"{repr(e)}",
                             researcher_id=self.researcher_id,
                         )
+                        logger.debug(
+                            f"Validation on local parameter updates error details: {traceback.format_exc()}"
+                        )
                     except Exception as e:
                         logger.error(
                             f"Undetermined error during the validation phase on local parameter updates"
                             f"{repr(e)}",
                             researcher_id=self.researcher_id,
+                        )
+                        logger.debug(
+                            f"Validation on local parameter updates error details: {traceback.format_exc()}"
                         )
                 else:
                     logger.error(
@@ -478,8 +513,10 @@ class Round:
                 self._save_round_state()
             except Exception as e:
                 # don't send details to researcher
-                if self._debug:
-                    logger.error(f"Error while saving round state: {repr(e)}")
+                logger.error(f"Error while saving round state: {repr(e)}")
+                logger.debug(
+                    f"Round state saving error details: {traceback.format_exc()}"
+                )
                 return self._send_round_reply(
                     success=False, message="Can't save new node state."
                 )
@@ -489,11 +526,12 @@ class Round:
                 del self.training_plan
                 del CurrentTPModule
             except Exception as e:
-                logger.debug("Exception raised while deleting training plan instance")
-                if self._debug:
-                    logger.error(
-                        f"Exception raised while deleting training plan instance: {repr(e)}"
-                    )
+                logger.error(
+                    f"Exception raised while deleting training plan instance: {repr(e)}"
+                )
+                logger.debug(
+                    f"Training plan instance deletion error details: {traceback.format_exc()}"
+                )
 
             return self._send_round_reply(
                 success=True,

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -211,6 +211,18 @@ class Round:
         Returns:
             Returns the corresponding node message, training reply instance
         """
+        logger.debug(
+            "Starting round execution: node_id=%s experiment=%s round=%s training=%s dataset=%s secagg_active=%s force_secagg=%s dp_active=%s secagg_args_keys=%s",
+            self._node_id,
+            self.experiment_id,
+            self._round,
+            self.training,
+            self.dataset.get("dataset_id"),
+            secagg_active,
+            force_secagg,
+            self.training_arguments.get("dp_args") is not None,
+            sorted((secagg_arguments or {}).keys()),
+        )
         # Validate secagg status. Raises error if the training request is not compatible with
         # secure aggregation settings
 
@@ -306,6 +318,17 @@ class Round:
                 training_args=self.training_arguments,
                 aggregator_args=self.aggregator_args,
                 node_id=self._node_id,
+            )
+            logger.debug(
+                "Training plan initialized for round: experiment=%s round=%s plan=%s training=%s dp_active=%s aggregator=%s",
+                self.experiment_id,
+                self._round,
+                self.training_plan.__class__.__name__,
+                self.training,
+                self.training_arguments.get("dp_args") is not None,
+                self.aggregator_args.get("aggregator_name")
+                if self.aggregator_args
+                else None,
             )
         except Exception as e:
             error_message = "Can't initialize training plan with the arguments."
@@ -420,6 +443,14 @@ class Round:
 
         # If training is activated.
         if self.training:
+            logger.debug(
+                "Executing training phase for round: experiment=%s round=%s dataset=%s has_testing_loader=%s has_training_loader=%s",
+                self.experiment_id,
+                self._round,
+                self.dataset.get("dataset_id"),
+                self.training_plan.testing_data_loader is not None,
+                self.training_plan.training_data_loader is not None,
+            )
             results = {}  # type: Dict[str, Any]
 
             # Perform the training round.
@@ -493,10 +524,26 @@ class Round:
             results["sample_size"] = len(
                 self.training_plan.training_data_loader.dataset
             )
+            logger.debug(
+                "Collected round outputs before reply assembly: experiment=%s round=%s sample_size=%s has_aux_var=%s dp_active=%s flatten_for_secagg=%s",
+                self.experiment_id,
+                self._round,
+                results["sample_size"],
+                results["optim_aux_var"] is not None,
+                self.training_arguments.get("dp_args") is not None,
+                self._secure_aggregation.use_secagg,
+            )
 
             results["encrypted"] = False
             model_weights = self.training_plan.after_training_params(
                 flatten=self._secure_aggregation.use_secagg
+            )
+            logger.debug(
+                "Collected training parameters for round reply: experiment=%s round=%s parameter_count=%s secagg_enabled=%s",
+                self.experiment_id,
+                self._round,
+                len(model_weights),
+                self._secure_aggregation.use_secagg,
             )
 
             if self._secure_aggregation.use_secagg:
@@ -560,6 +607,12 @@ class Round:
             )
         else:
             # Only for validation
+            logger.debug(
+                "Skipping training execution for round: experiment=%s round=%s dataset=%s reason=training_disabled",
+                self.experiment_id,
+                self._round,
+                self.dataset.get("dataset_id"),
+            )
             return self._send_round_reply(success=True)
 
     def _encrypt_weights_and_auxvar(
@@ -664,8 +717,21 @@ class Round:
         if timing is None:
             timing = {}
 
+        logger.debug(
+            "Building round reply: experiment=%s round=%s success=%s message=%s extend_keys=%s timing_keys=%s encrypted=%s has_params=%s has_aux_var=%s",
+            self.experiment_id,
+            self._round,
+            success,
+            bool(message),
+            sorted(extend_with.keys()),
+            sorted(timing.keys()),
+            extend_with.get("encrypted"),
+            "params" in extend_with,
+            extend_with.get("optim_aux_var") is not None,
+        )
+
         # If round is not successful log error message
-        return TrainReply(
+        reply = TrainReply(
             **{
                 "node_id": self._node_id,
                 "node_name": self._node_name,
@@ -679,6 +745,16 @@ class Round:
                 **extend_with,
             }
         )
+        logger.debug(
+            "Built round reply: experiment=%s round=%s reply_type=%s success=%s encrypted=%s dataset=%s",
+            self.experiment_id,
+            self._round,
+            reply.__class__.__name__,
+            reply.success,
+            getattr(reply, "encrypted", None),
+            getattr(reply, "dataset_id", None),
+        )
+        return reply
 
     def process_optim_aux_var(self) -> Optional[str]:
         """Process researcher-emitted Optimizer auxiliary variables, if any.

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -502,7 +502,7 @@ class Round:
             if self._secure_aggregation.use_secagg:
                 logger.debug(
                     'SecAgg active: encrypting model parameters with the secure aggregation scheme "%s" for round %d',
-                    self._secure_aggregation.scheme.name,
+                    self._secure_aggregation.scheme.__class__.__name__,
                     self._round,
                 )
                 if results["optim_aux_var"]:
@@ -518,7 +518,7 @@ class Round:
                 results["encrypted"] = True
                 results["encryption_factor"] = enc_factor
                 logger.debug(
-                    f"Model parameters encrypted for round {self._round} , with encryption factor {enc_factor} and scheme {self._secure_aggregation.scheme.name}."
+                    f"Model parameters encrypted for round {self._round} , with encryption factor {enc_factor} and scheme {self._secure_aggregation.scheme.__class__.__name__}."
                 )
                 if aux_var is not None:
                     results["optim_aux_var"] = aux_var.to_dict()

--- a/fedbiomed/node/secagg/_secagg_round.py
+++ b/fedbiomed/node/secagg/_secagg_round.py
@@ -60,6 +60,11 @@ class _SecaggSchemeRound(ABC):
         """
         return self._secagg_random
 
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable scheme name used by callers and logs."""
+
     @abstractmethod
     def encrypt(
         self, params: List[float], current_round: int, weight: Optional[int] = None
@@ -80,6 +85,10 @@ class _JLSRound(_SecaggSchemeRound):
     """Class for Joye Libert secure aggregation handling of a training round on node"""
 
     _min_num_round: int = 3
+
+    @property
+    def name(self) -> str:
+        return SecureAggregationSchemes.JOYE_LIBERT.name
 
     def __init__(
         self, db: str, node_id: str, secagg_arguments: Dict, experiment_id: str
@@ -146,6 +155,10 @@ class _LomRound(_SecaggSchemeRound):
     """Class for LOM secure aggregation handling of a training round on node"""
 
     _min_num_parties: int = 2
+
+    @property
+    def name(self) -> str:
+        return SecureAggregationSchemes.LOM.name
 
     def __init__(self, db, node_id, secagg_arguments: Dict, experiment_id: str):
         """Constructor of the class

--- a/fedbiomed/node/secagg/_secagg_round.py
+++ b/fedbiomed/node/secagg/_secagg_round.py
@@ -60,11 +60,6 @@ class _SecaggSchemeRound(ABC):
         """
         return self._secagg_random
 
-    @property
-    @abstractmethod
-    def name(self) -> str:
-        """Human-readable scheme name used by callers and logs."""
-
     @abstractmethod
     def encrypt(
         self, params: List[float], current_round: int, weight: Optional[int] = None
@@ -85,10 +80,6 @@ class _JLSRound(_SecaggSchemeRound):
     """Class for Joye Libert secure aggregation handling of a training round on node"""
 
     _min_num_round: int = 3
-
-    @property
-    def name(self) -> str:
-        return SecureAggregationSchemes.JOYE_LIBERT.name
 
     def __init__(
         self, db: str, node_id: str, secagg_arguments: Dict, experiment_id: str
@@ -155,10 +146,6 @@ class _LomRound(_SecaggSchemeRound):
     """Class for LOM secure aggregation handling of a training round on node"""
 
     _min_num_parties: int = 2
-
-    @property
-    def name(self) -> str:
-        return SecureAggregationSchemes.LOM.name
 
     def __init__(self, db, node_id, secagg_arguments: Dict, experiment_id: str):
         """Constructor of the class

--- a/fedbiomed/node/secagg/_secagg_setups.py
+++ b/fedbiomed/node/secagg/_secagg_setups.py
@@ -270,7 +270,7 @@ class SecaggServkeySetup(_SecaggNN):
 
         logger.debug(
             f"Completed Serverkey secret sharing setup with success={all_received} "
-            f"node_id='{self._node_id}' secagg_id='{self._secagg_id}"
+            f"node_id='{self._node_id}' secagg_id='{self._secagg_id}'"
         )
 
         biprime = get_default_biprime()
@@ -280,7 +280,7 @@ class SecaggServkeySetup(_SecaggNN):
         )
 
         logger.info(
-            "Server key share successfully created for "
+            f"Server key share successfully created for "
             f"node_id='{self._node_id}' secagg_id='{self._secagg_id}'"
         )
 
@@ -375,7 +375,7 @@ class SecaggSetup:
         else:
             raise FedbiomedSecaggError(
                 f"{ErrorNumbers.FB318.value}: Received bad request message: "
-                "incorrect `element` {self._element}"
+                f"incorrect `element` {self._element}"
             )
 
         try:

--- a/fedbiomed/researcher/cli.py
+++ b/fedbiomed/researcher/cli.py
@@ -65,11 +65,14 @@ class ResearcherControl(CLIArgumentParser):
         else:
             nb_start_dir = os.path.join(component_path, NOTEBOOKS_FOLDER_NAME)
 
-        if bool(args.debug) or os.environ.get("FBM_DEBUG", "").lower() in (
+        debug_enabled = bool(args.debug) or os.environ.get("FBM_DEBUG", "").lower() in (
             "1",
             "true",
             "yes",
-        ):
+        )
+
+        if debug_enabled:
+            print("Debug mode activated for Researcher CLI")
             logger.setLevel("DEBUG")
         else:
             logger.setLevel("INFO")
@@ -77,6 +80,8 @@ class ResearcherControl(CLIArgumentParser):
         options.append(f"--notebook-dir={nb_start_dir}")
 
         current_env = os.environ.copy()
+        if debug_enabled:
+            current_env["FBM_DEBUG"] = "1"
         # comp_root = os.environ.get("FBM_RESEARCHER_COMPONENT_ROOT", None)
         command = ["jupyter", "notebook"]
         command = [*command, *options]

--- a/fedbiomed/researcher/cli.py
+++ b/fedbiomed/researcher/cli.py
@@ -10,6 +10,7 @@ from typing import Dict, List
 
 from fedbiomed.common.cli import CLIArgumentParser, CommonCLI, ComponentDirectoryAction
 from fedbiomed.common.constants import NOTEBOOKS_FOLDER_NAME, ComponentType
+from fedbiomed.common.logger import logger
 
 __intro__ = """
    __         _ _     _                          _
@@ -41,6 +42,15 @@ class ResearcherControl(CLIArgumentParser):
             required=False,
             help="The directory where jupyter notebook will be started.",
         )
+
+        start.add_argument(
+            "--debug",
+            "-D",
+            action="store_true",
+            required=False,
+            help="Activate debug mode for the Node. Default is `False`",
+        )
+
         start.set_defaults(func=self.start)
 
     def start(self, args):
@@ -54,6 +64,15 @@ class ResearcherControl(CLIArgumentParser):
             nb_start_dir = args.directory
         else:
             nb_start_dir = os.path.join(component_path, NOTEBOOKS_FOLDER_NAME)
+
+        if bool(args.debug) or os.environ.get("FBM_DEBUG", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        ):
+            logger.setLevel("DEBUG")
+        else:
+            logger.setLevel("INFO")
 
         options.append(f"--notebook-dir={nb_start_dir}")
 

--- a/fedbiomed/researcher/config.py
+++ b/fedbiomed/researcher/config.py
@@ -101,7 +101,10 @@ class ResearcherConfig(Config):
         os.makedirs(self.vars["EXPERIMENTS_DIR"], exist_ok=True)
 
 
-logger.setLevel("DEBUG")
+if os.environ.get("FBM_DEBUG_RESEARCHER", "").lower() in ("1", "true", "yes"):
+    logger.setLevel("DEBUG")
+else:
+    logger.setLevel("INFO")
 
 component_root = os.environ.get("FBM_RESEARCHER_COMPONENT_ROOT", None)
 

--- a/fedbiomed/researcher/config.py
+++ b/fedbiomed/researcher/config.py
@@ -101,7 +101,7 @@ class ResearcherConfig(Config):
         os.makedirs(self.vars["EXPERIMENTS_DIR"], exist_ok=True)
 
 
-if os.environ.get("FBM_DEBUG_RESEARCHER", "").lower() in ("1", "true", "yes"):
+if os.environ.get("FBM_DEBUG", "").lower() in ("1", "true", "yes"):
     logger.setLevel("DEBUG")
 else:
     logger.setLevel("INFO")

--- a/fedbiomed/researcher/federated_workflows/_federated_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_workflow.py
@@ -126,11 +126,14 @@ def exp_exceptions(function):
             try:
                 return function(*args, **kwargs)
             except FedbiomedSilentTerminationError as exp:
-                logger.debug(f"FedbiomedSilentTerminationError raised: {str(exp)}")
+                traceback.print_exc(file=sys.stdout)
+                logger.debug(f"FedbiomedSilentTerminationError raised: {repr(exp)}")
+                logger.debug(f"Error details: {traceback.format_exc()}")
                 raise
             except FedbiomedExperimentError as exp:
                 traceback.print_exc(file=sys.stdout)
-                logger.debug(f"FedbiomedExperimentError raised: {str(exp)}")
+                logger.debug(f"FedbiomedExperimentError raised: {repr(exp)}")
+                logger.debug(f"Error details: {traceback.format_exc()}")
                 raise
 
     return payload

--- a/fedbiomed/researcher/federated_workflows/_federated_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_workflow.py
@@ -71,7 +71,7 @@ def exp_exceptions(function):
     def payload(*args, **kwargs):
         code = 0
 
-        if os.environ.get("FBM_DEBUG_RESEARCHER", "").lower() not in (
+        if os.environ.get("FBM_DEBUG", "").lower() not in (
             "1",
             "true",
             "yes",
@@ -123,17 +123,7 @@ def exp_exceptions(function):
             return ret
 
         else:
-            try:
-                return function(*args, **kwargs)
-            except FedbiomedSilentTerminationError:
-                traceback.print_exc(file=sys.stdout)
-                logger.debug("FedbiomedSilentTerminationError raised.")
-                raise
-            except FedbiomedExperimentError as exp:
-                traceback.print_exc(file=sys.stdout)
-                logger.error(f"FedbiomedExperimentError raised: {repr(exp)}")
-                logger.debug(f"Error details: {traceback.format_exc()}")
-                raise
+            return function(*args, **kwargs)
 
     return payload
 

--- a/fedbiomed/researcher/federated_workflows/_federated_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_workflow.py
@@ -118,7 +118,16 @@ def exp_exceptions(function):
 
             return ret
 
-        return function(*args, **kwargs)
+        else:
+            try:
+                return function(*args, **kwargs)
+            except FedbiomedSilentTerminationError as exp:
+                logger.debug(f"FedbiomedSilentTerminationError raised: {str(exp)}")
+                raise
+            except FedbiomedExperimentError as exp:
+                traceback.print_exc(file=sys.stdout)
+                logger.debug(f"FedbiomedExperimentError raised: {str(exp)}")
+                raise
 
     return payload
 

--- a/fedbiomed/researcher/federated_workflows/_federated_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_workflow.py
@@ -71,7 +71,11 @@ def exp_exceptions(function):
     def payload(*args, **kwargs):
         code = 0
 
-        if not os.environ.get("FEDBIOMED_DEBUG"):
+        if os.environ.get("FBM_DEBUG_RESEARCHER", "").lower() not in (
+            "1",
+            "true",
+            "yes",
+        ):
             try:
                 ret = function(*args, **kwargs)
             except FedbiomedSilentTerminationError:

--- a/fedbiomed/researcher/federated_workflows/_federated_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_workflow.py
@@ -125,14 +125,13 @@ def exp_exceptions(function):
         else:
             try:
                 return function(*args, **kwargs)
-            except FedbiomedSilentTerminationError as exp:
+            except FedbiomedSilentTerminationError:
                 traceback.print_exc(file=sys.stdout)
-                logger.debug(f"FedbiomedSilentTerminationError raised: {repr(exp)}")
-                logger.debug(f"Error details: {traceback.format_exc()}")
+                logger.debug("FedbiomedSilentTerminationError raised.")
                 raise
             except FedbiomedExperimentError as exp:
                 traceback.print_exc(file=sys.stdout)
-                logger.debug(f"FedbiomedExperimentError raised: {repr(exp)}")
+                logger.error(f"FedbiomedExperimentError raised: {repr(exp)}")
                 logger.debug(f"Error details: {traceback.format_exc()}")
                 raise
 

--- a/fedbiomed/researcher/monitor.py
+++ b/fedbiomed/researcher/monitor.py
@@ -264,6 +264,14 @@ class Monitor:
         """
 
         # For now monitor can only handle add_scalar messages
+        logger.debug(
+            "Received History monitor message from: node=%s train=%s metric=%s round=%d iteration=%s",
+            msg["node_id"],
+            msg["train"],
+            msg["metric"],
+            self._round,
+            msg["iteration"],
+        )
 
         # Save iteration value
         cumulative_iter, *_ = self._metric_store.add_iteration(

--- a/fedbiomed/researcher/requests/_policies.py
+++ b/fedbiomed/researcher/requests/_policies.py
@@ -201,7 +201,7 @@ class PolicyController:
             error_value = getattr(req, "error", None)
             logger.debug(
                 f"PolicyController: Request {request_id} "
-                f"for node {node} "
+                f"for node id:{getattr(node, 'id', None)} "
                 f"has status {status_value} and error {error_value}"
             )
 

--- a/fedbiomed/researcher/requests/_policies.py
+++ b/fedbiomed/researcher/requests/_policies.py
@@ -194,12 +194,6 @@ class PolicyController:
             ]
         )
 
-        ### DEBUG POLICY CONTROLLER STATUS ON CONTINUE ALL
-        # policy name
-        # node id that triggered it
-        # request status that caused it
-        # whether it returned CONTINUE, STOPPED, or COMPLETED
-
         for req in requests:
             logger.debug(
                 f"PolicyController: Request {req._request_id} "
@@ -220,17 +214,12 @@ class PolicyController:
             [policy.status == PolicyStatus.STOPPED for policy in self._policies]
         )
 
-        ### DEBUG POLICY CONTROLLER STATUS ON HAS STOPPED ANY
-        # policy name
-        # node id that triggered it
-        # request status that caused it
-        # whether it returned CONTINUE, STOPPED, or COMPLETED
         for policy in self._policies:
             logger.debug(
                 f"PolicyController: Policy {policy.__class__.__name__} "
                 f"has status {policy.status} "
             )
-            if policy.stop_caused_by:
+            if is_stopped:
                 logger.debug(f"and stop caused by {policy.stop_caused_by}")
 
         return is_stopped

--- a/fedbiomed/researcher/requests/_policies.py
+++ b/fedbiomed/researcher/requests/_policies.py
@@ -192,6 +192,12 @@ class PolicyController:
             ]
         )
 
+        ### DEBUG POLICY CONTROLLER STATUS ON CONTINUE ALL
+        # policy name
+        # node id that triggered it
+        # request status that caused it
+        # whether it returned CONTINUE, STOPPED, or COMPLETED
+
         return PolicyStatus.CONTINUE if status else PolicyStatus.COMPLETED
 
     def has_stopped_any(self) -> bool:
@@ -204,6 +210,12 @@ class PolicyController:
         is_stopped = any(
             [policy.status == PolicyStatus.STOPPED for policy in self._policies]
         )
+
+        ### DEBUG POLICY CONTROLLER STATUS ON HAS STOPPED ANY
+        # policy name
+        # node id that triggered it
+        # request status that caused it
+        # whether it returned CONTINUE, STOPPED, or COMPLETED
 
         return is_stopped
 

--- a/fedbiomed/researcher/requests/_policies.py
+++ b/fedbiomed/researcher/requests/_policies.py
@@ -4,6 +4,8 @@
 import datetime
 from typing import Dict, List, Optional, TypeVar
 
+from fedbiomed.common.logger import logger
+
 from ._status import PolicyStatus, RequestStatus
 
 TRequest = TypeVar("TRequest")
@@ -198,6 +200,13 @@ class PolicyController:
         # request status that caused it
         # whether it returned CONTINUE, STOPPED, or COMPLETED
 
+        for req in requests:
+            logger.debug(
+                f"PolicyController: Request {req._request_id} "
+                f"for node {req._node} "
+                f"has status {req.status} and error {req.error}"
+            )
+
         return PolicyStatus.CONTINUE if status else PolicyStatus.COMPLETED
 
     def has_stopped_any(self) -> bool:
@@ -216,6 +225,13 @@ class PolicyController:
         # node id that triggered it
         # request status that caused it
         # whether it returned CONTINUE, STOPPED, or COMPLETED
+        for policy in self._policies:
+            logger.debug(
+                f"PolicyController: Policy {policy.__class__.__name__} "
+                f"has status {policy.status} "
+            )
+            if policy.stop_caused_by:
+                logger.debug(f"and stop caused by {policy.stop_caused_by}")
 
         return is_stopped
 

--- a/fedbiomed/researcher/requests/_policies.py
+++ b/fedbiomed/researcher/requests/_policies.py
@@ -195,10 +195,14 @@ class PolicyController:
         )
 
         for req in requests:
+            request_id = getattr(req, "_request_id", getattr(req, "request_id", None))
+            node = getattr(req, "_node", getattr(req, "node", None))
+            status_value = getattr(req, "status", None)
+            error_value = getattr(req, "error", None)
             logger.debug(
-                f"PolicyController: Request {req._request_id} "
-                f"for node {req._node} "
-                f"has status {req.status} and error {req.error}"
+                f"PolicyController: Request {request_id} "
+                f"for node {node} "
+                f"has status {status_value} and error {error_value}"
             )
 
         return PolicyStatus.CONTINUE if status else PolicyStatus.COMPLETED

--- a/fedbiomed/researcher/requests/_requests.py
+++ b/fedbiomed/researcher/requests/_requests.py
@@ -97,12 +97,13 @@ class Request:
 
     def send(self) -> None:
         """Sends the request"""
-        ### (OPTIONAL) DEBUG REQUEST SENDING
-        # request id
-        # target node
-        # message class
 
         self._message.request_id = self._request_id
+        logger.debug(
+            f"Sending request {self._request_id} "
+            f"to node {self._node.id} "
+            f"with message {self._message.__class__.__name__}"
+        )
         self._node.send(self._message, self.on_reply)
         self.status = RequestStatus.NO_REPLY_YET
 
@@ -152,12 +153,6 @@ class FederatedRequest:
             nodes: list of nodes that are sent the message
             policy: list of policies for controlling the handling of the request
         """
-        ### DEBUG MESSAGE THAT GIVES INFO ON EACH CREATED FEDERATED REQUEST
-        # federated request id
-        # number of target nodes
-        # message class
-        # policies enabled
-        # one log per node-specific request
 
         self._message = message
         self._nodes = nodes
@@ -170,6 +165,13 @@ class FederatedRequest:
         # Set-up policies
         self._policy = PolicyController(policy)
 
+        logger.debug(
+            f"Creating federated request with message {message.__class__.__name__} "
+            f"to nodes {[node.id for node in nodes]} "
+            f"with policies {[p.__class__.__name__ for p in policy] if policy else 'None'}"
+            f" and request id {self._request_id}"
+        )
+
         # Set up single requests
         if isinstance(self._message, Message):
             for node in self._nodes:
@@ -178,6 +180,9 @@ class FederatedRequest:
                         self._message, node, self._pending_replies, self._request_id
                     )
                 )
+                logger.debug(
+                    f"Created request for node {node.id} with message {self._message.__class__.__name__}"
+                )
 
         # Different message for each node
         elif isinstance(self._message, MessagesByNode):
@@ -185,6 +190,9 @@ class FederatedRequest:
                 if m := self._message.get(node.id):
                     self._requests.append(
                         Request(m, node, self._pending_replies, self._request_id)
+                    )
+                    logger.debug(
+                        f"Created request for node {node.id} with message {m.__class__.__name__}"
                     )
                 else:
                     logger.warning(
@@ -226,6 +234,10 @@ class FederatedRequest:
         """
         ### (OPTIONAL) DEBUG EXITING FEDERATED REQUEST CONTEXT MANAGER
         ### THIS SHOULD ALSO BE COVERED BY POLICY CONTROLLER STATUS DEBUG
+        logger.debug(
+            f"Exiting federated request context manager for request id {self._request_id}"
+            f" for nodes {[node.id for node in self._nodes]}"
+        )
 
         # Clear the replies that are processed
         has_stopped = self._policy.has_stopped_any()

--- a/fedbiomed/researcher/requests/_requests.py
+++ b/fedbiomed/researcher/requests/_requests.py
@@ -328,7 +328,7 @@ class Requests(metaclass=SingletonMeta):
 
     def start_messaging(self) -> None:
         """Start communications endpoint"""
-        ### DEBUG GRPC SERVER START
+        logger.debug("Starting researcher messaging GRPC Server endpoint")
         self._grpc_server.start()
 
     def on_message(

--- a/fedbiomed/researcher/requests/_requests.py
+++ b/fedbiomed/researcher/requests/_requests.py
@@ -100,9 +100,12 @@ class Request:
 
         self._message.request_id = self._request_id
         logger.debug(
-            f"Sending request {self._request_id} "
-            f"to node {self._node.id} "
-            f"with message {self._message.__class__.__name__}"
+            "Sending request req=%s node=%s type=%s experiment=%s researcher_id=%s",
+            self._request_id,
+            self._node.id,
+            self._message.__class__.__name__,
+            getattr(self._message, "experiment_id", None),
+            getattr(self._message, "researcher_id", None),
         )
         self._node.send(self._message, self.on_reply)
         self.status = RequestStatus.NO_REPLY_YET
@@ -166,10 +169,11 @@ class FederatedRequest:
         self._policy = PolicyController(policy)
 
         logger.debug(
-            f"Creating federated request with message {message.__class__.__name__} "
-            f"to nodes {[node.id for node in nodes]} "
-            f"with policies {[p.__class__.__name__ for p in policy] if policy else 'None'}"
-            f" and request id {self._request_id}"
+            "Creating federated request req=%s message=%s nodes=%s policies=%s",
+            self._request_id,
+            message.__class__.__name__,
+            [node.id for node in nodes],
+            [p.__class__.__name__ for p in policy] if policy else [],
         )
 
         # Set up single requests
@@ -180,9 +184,6 @@ class FederatedRequest:
                         self._message, node, self._pending_replies, self._request_id
                     )
                 )
-                logger.debug(
-                    f"Created request for node {node.id} with message {self._message.__class__.__name__}"
-                )
 
         # Different message for each node
         elif isinstance(self._message, MessagesByNode):
@@ -190,9 +191,6 @@ class FederatedRequest:
                 if m := self._message.get(node.id):
                     self._requests.append(
                         Request(m, node, self._pending_replies, self._request_id)
-                    )
-                    logger.debug(
-                        f"Created request for node {node.id} with message {m.__class__.__name__}"
                     )
                 else:
                     logger.warning(
@@ -232,15 +230,16 @@ class FederatedRequest:
             value: ignored
             traceback: ignored
         """
-        ### (OPTIONAL) DEBUG EXITING FEDERATED REQUEST CONTEXT MANAGER
-        ### THIS SHOULD ALSO BE COVERED BY POLICY CONTROLLER STATUS DEBUG
-        logger.debug(
-            f"Exiting federated request context manager for request id {self._request_id}"
-            f" for nodes {[node.id for node in self._nodes]}"
-        )
-
         # Clear the replies that are processed
         has_stopped = self._policy.has_stopped_any()
+        logger.debug(
+            "Exiting federated request context manager for req=%s replies=%d errors=%d disconnects=%d stopped=%s",
+            self._request_id,
+            len(self.replies()),
+            len(self.errors()),
+            len(self.disconnected_requests()),
+            has_stopped,
+        )
         for req in self._requests:
             req.flush(stopped=has_stopped)
 
@@ -277,10 +276,16 @@ class FederatedRequest:
 
     def wait(self) -> None:
         """Waits for the replies of the messages that are sent"""
-        ### DEBUG - SHOULD BE COVERED BY POLICY CONTROLLER STATUS DEBUG
+        logger.debug(
+            "Waiting for federated request req=%s replies from %d nodes",
+            self._request_id,
+            len(self._requests),
+        )
 
         while self._policy.continue_all(self._requests) == PolicyStatus.CONTINUE:
             self._pending_replies.acquire(timeout=REQUEST_STATUS_CHECK_TIMEOUT)
+
+        logger.debug("Federated request wait finished req=%s", self._request_id)
 
 
 class Requests(metaclass=SingletonMeta):

--- a/fedbiomed/researcher/requests/_requests.py
+++ b/fedbiomed/researcher/requests/_requests.py
@@ -84,6 +84,10 @@ class Request:
         Args:
             True if a reply was received from node
         """
+        ### DEBUG REQUEST STATUS
+        # current request status per node
+        # whether node became DISCONNECT
+        # whether request has reply / error / timeout
 
         if self._node.status == NodeActiveStatus.DISCONNECTED:
             self.status = RequestStatus.DISCONNECT
@@ -93,6 +97,11 @@ class Request:
 
     def send(self) -> None:
         """Sends the request"""
+        ### (OPTIONAL) DEBUG REQUEST SENDING
+        # request id
+        # target node
+        # message class
+
         self._message.request_id = self._request_id
         self._node.send(self._message, self.on_reply)
         self.status = RequestStatus.NO_REPLY_YET
@@ -143,6 +152,12 @@ class FederatedRequest:
             nodes: list of nodes that are sent the message
             policy: list of policies for controlling the handling of the request
         """
+        ### DEBUG MESSAGE THAT GIVES INFO ON EACH CREATED FEDERATED REQUEST
+        # federated request id
+        # number of target nodes
+        # message class
+        # policies enabled
+        # one log per node-specific request
 
         self._message = message
         self._nodes = nodes
@@ -209,6 +224,8 @@ class FederatedRequest:
             value: ignored
             traceback: ignored
         """
+        ### (OPTIONAL) DEBUG EXITING FEDERATED REQUEST CONTEXT MANAGER
+        ### THIS SHOULD ALSO BE COVERED BY POLICY CONTROLLER STATUS DEBUG
 
         # Clear the replies that are processed
         has_stopped = self._policy.has_stopped_any()
@@ -248,6 +265,7 @@ class FederatedRequest:
 
     def wait(self) -> None:
         """Waits for the replies of the messages that are sent"""
+        ### DEBUG - SHOULD BE COVERED BY POLICY CONTROLLER STATUS DEBUG
 
         while self._policy.continue_all(self._requests) == PolicyStatus.CONTINUE:
             self._pending_replies.acquire(timeout=REQUEST_STATUS_CHECK_TIMEOUT)
@@ -267,6 +285,8 @@ class Requests(metaclass=SingletonMeta):
         Args:
             config: Object for handling the component configuration
         """
+        ### DEBUG GRPC SERVER INFORMATION
+
         self._monitor_message_callbacks: Dict[str, Callable] = {}
 
         server_host = config.get("server", "host")
@@ -291,6 +311,7 @@ class Requests(metaclass=SingletonMeta):
 
     def start_messaging(self) -> None:
         """Start communications endpoint"""
+        ### DEBUG GRPC SERVER START
         self._grpc_server.start()
 
     def on_message(

--- a/fedbiomed/researcher/requests/_requests.py
+++ b/fedbiomed/researcher/requests/_requests.py
@@ -10,6 +10,7 @@ import os
 import tempfile
 import threading
 import uuid
+from time import time
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import tabulate
@@ -61,6 +62,8 @@ class Request:
             request_id: unique ID of request
             sem_pending: semaphore for signaling new pending reply
         """
+        self._send_time = None
+        self._reply_time = None
         self._request_id = request_id if request_id else str(uuid.uuid4())
         self._node = node
         self._message = message
@@ -99,6 +102,8 @@ class Request:
         """Sends the request"""
 
         self._message.request_id = self._request_id
+        self._send_time = time()  # ← Track send time
+
         logger.debug(
             "Sending request req=%s node=%s type=%s experiment=%s researcher_id=%s",
             self._request_id,
@@ -116,7 +121,19 @@ class Request:
         Args:
             stopped: True if the request was stopped before completion
         """
+        flush_time = time()
+        elapsed_since_send = flush_time - self._send_time if self._send_time else 0
+
+        logger.debug(
+            "Flushing request req=%s node=%s stopped=%s has_reply=%s elapsed_since_send=%.2fs",
+            self._request_id,
+            self._node.id,
+            stopped,
+            self.reply is not None,
+            elapsed_since_send,
+        )
         self._node.flush(self._request_id, stopped)
+        self._sem_pending.release()
 
     def on_reply(self, reply: Message) -> None:
         """Callback for node agent to execute once it replies.
@@ -124,6 +141,16 @@ class Request:
         Args:
             reply: reply message received from node
         """
+        self._reply_time = time()  # ← Track reply time
+        elapsed = self._reply_time - self._send_time if self._send_time else 0
+
+        logger.debug(
+            "Request: Received reply req=%s node=%s type=%s elapsed=%.2fs",
+            self._request_id,
+            self._node.id,
+            reply.__class__.__name__,
+            elapsed,
+        )
 
         if isinstance(reply, ErrorMessage):
             self.error = reply

--- a/fedbiomed/transport/client.py
+++ b/fedbiomed/transport/client.py
@@ -686,6 +686,7 @@ class Sender(Listener):
                 logger.warning(
                     f"Message can not be sent to researcher after {MAX_SEND_RETRIES} retries. Discard message."
                 )
+            # Only cleanup if not already done (defensive against double task_done)
             self._queue.task_done()
             self._retry_count = 0
             self._retry_item = None
@@ -737,6 +738,7 @@ class Sender(Listener):
         # If it is a Unary-Unary RPC call
         if isinstance(stub_function, grpc.aio.UnaryUnaryMultiCallable):
             await stub_function(item["message"].to_proto())
+            # Clear retry state immediately after successful send to prevent duplicate sends
 
         elif isinstance(stub_function, grpc.aio.StreamUnaryMultiCallable):
             stream_call = stub_function()
@@ -745,6 +747,7 @@ class Sender(Listener):
                 await stream_call.write(reply)
 
             await stream_call.done_writing()
+            # Clear retry state immediately after successful send to prevent duplicate sends
 
             if isinstance(callback, Callable):
                 # we could check the callback prototype

--- a/fedbiomed/transport/client.py
+++ b/fedbiomed/transport/client.py
@@ -590,6 +590,15 @@ class TaskListener(Listener):
                 logger.debug("New task received from researcher")
                 task = Serializer.loads(reply)
 
+                logger.debug(
+                    "[WIRE][S->N][RX] req=%s node=%s type=%s  bytes=%d retry=%d",
+                    task.get("request_id", None),
+                    self._node_id,
+                    Message.from_dict(task).__class__.__name__,
+                    len(reply),
+                    self._retry_count,
+                )
+
                 # Guess ID of connected researcher, for un-authenticated connection
                 await self._update_id(task["researcher_id"])
 
@@ -699,6 +708,15 @@ class Sender(Listener):
             raise FedbiomedCommunicationError(
                 f"Unknown type of stub in gRPC Sender listener {item['stub']}"
             )
+
+        logger.debug(
+            "[WIRE][N->S][TX] req=%s stub=%s node=%s type=%s retry=%d",
+            getattr(item["message"], "request_id", None),
+            self._stub_type.name,
+            getattr(item["message"], "node_id", None),
+            item["message"].__class__.__name__,
+            self._retry_count,
+        )
 
         # If it is a Unary-Unary RPC call
         if isinstance(stub_function, grpc.aio.UnaryUnaryMultiCallable):

--- a/fedbiomed/transport/client.py
+++ b/fedbiomed/transport/client.py
@@ -323,7 +323,7 @@ class GrpcClient:
                 break
             else:
                 logger.debug(
-                    "Researcher server is not available, will retry connect in "
+                    "Researcher server is not available, will retry connecting in "
                     f"{GRPC_CLIENT_CONN_RETRY_TIMEOUT} seconds"
                 )
                 await asyncio.sleep(
@@ -560,7 +560,9 @@ class TaskListener(Listener):
     def _message_deadline_exceeded(self):
         """Task listener issues debug message when researcher does not submit task before deadline"""
         logger.debug(
-            "Researcher did not request executing a task before timeout. Send new task request"
+            "Task polling timed out: node=%s timeout_s=%s; sending a new task request",
+            self._node_id,
+            GRPC_CLIENT_TASK_REQUEST_TIMEOUT,
         )
 
     async def _call_researcher(self, callback: Optional[Callable] = None) -> None:
@@ -569,7 +571,12 @@ class TaskListener(Listener):
         Args:
             callback: Callback to execute once a task is arrived
         """
-        logger.debug("Sending new task request to researcher")
+        logger.debug(
+            "Polling researcher for task: node=%s retry=%d timeout_s=%s",
+            self._node_id,
+            self._retry_count,
+            GRPC_CLIENT_TASK_REQUEST_TIMEOUT,
+        )
         # TODO: improve status management. At this point it is not sure we are CONNECTED to server
         # but setting later will leave the client DISCONNECTED when waiting for initial task
         await self._on_status_change(ClientStatus.CONNECTED)
@@ -587,7 +594,6 @@ class TaskListener(Listener):
                 continue
             else:
                 # Execute callback
-                logger.debug("New task received from researcher")
                 task = Serializer.loads(reply)
 
                 logger.debug(
@@ -651,17 +657,19 @@ class Sender(Listener):
         """
         await self._on_status_change(status)
 
-        # Extract useful information for detailed log without assumption on message structures
-        # to cover possible bug cases
-        if isinstance(self._retry_item, dict):
-            msg = self._retry_item["message"]
-            logger.debug(
-                f"Message details: stub={self._retry_item['stub']} "
-                f"researcher_id={msg.researcher_id} "
-                f"type={msg.__name__} "
-            )
-
         if retry and self._retry_count < MAX_SEND_RETRIES:
+            if isinstance(self._retry_item, dict):
+                msg = self._retry_item["message"]
+                logger.debug(
+                    "Retrying sender message req=%s type=%s stub=%s retry=%d/%d",
+                    getattr(msg, "request_id", None),
+                    msg.__class__.__name__,
+                    self._stub_type.name
+                    if self._stub_type != _StubType.NO_STUB
+                    else None,
+                    self._retry_count + 1,
+                    MAX_SEND_RETRIES,
+                )
             await asyncio.sleep(GRPC_CLIENT_CONN_RETRY_TIMEOUT)
             await self._channels.connect(self._stub_type)
             self._retry_count += 1

--- a/fedbiomed/transport/client.py
+++ b/fedbiomed/transport/client.py
@@ -235,7 +235,13 @@ class GrpcClient:
         self._update_id_map = update_id_map
         self._tasks = []
 
-    def start(self, on_task) -> List[Awaitable[Optional[Callable]]]:
+    @property
+    def tasks(self) -> List[asyncio.Task]:
+        """Returns running asyncio task(s) owned by this client."""
+
+        return self._tasks
+
+    def start(self, on_task) -> asyncio.Task:
         """Start researcher gRPC agent.
 
         Starts long-lived tasks, one waiting for server requests, one waiting on the async queue
@@ -245,7 +251,7 @@ class GrpcClient:
             on_task: Callback function to execute once a payload received from researcher.
 
         Returns:
-            A list of task objects of the agent
+            The main task object of the agent
         """
 
         async def run():
@@ -259,8 +265,10 @@ class GrpcClient:
                 self._task_listener.listen(on_task), self._sender.listen()
             )
 
-        # Returns client task
-        return asyncio.create_task(run())
+        # Keep a stable reference so controller health checks can inspect client tasks.
+        task = asyncio.create_task(run())
+        self._tasks = [task]
+        return task
 
     async def send(self, message: Message) -> None:
         """Sends messages from node to researcher server.

--- a/fedbiomed/transport/controller.py
+++ b/fedbiomed/transport/controller.py
@@ -91,8 +91,10 @@ class GrpcAsyncTaskController:
             broadcast: Broadcast the message to all available researcher. This option should be used for general
                 node state messages (e.g. general Error)
         """
-        ### (OPTIONAL) DEBUG THE SENDING OF MESSAGE TO THE RESEARCHER
-        ### THIS IS ALSO NORMALLY COVERED BY THE _CALL_RESEARCHER FUNCTION IN THE CLIENT.PY.
+        logger.debug(
+            f"GrpcAsyncTaskController: Sending message {message.__class__.__name__} "
+            f"to researcher {message.researcher_id} with broadcast={broadcast}"
+        )
 
         if broadcast:
             return await self._broadcast(message)
@@ -120,6 +122,9 @@ class GrpcAsyncTaskController:
         """
         async with self._ip_id_map_lock:
             self._ip_id_map.update({id_: ip})
+            logger.debug(
+                f"GrpcAsyncTaskController: Updated IP-ID map with IP {ip} and ID {id_}"
+            )
 
     async def is_connected(self) -> bool:
         """Checks if there is running tasks"""

--- a/fedbiomed/transport/controller.py
+++ b/fedbiomed/transport/controller.py
@@ -59,16 +59,32 @@ class GrpcAsyncTaskController:
 
         self._debug = debug
         self._on_message = on_message
+        logger.debug(
+            "Initialized gRPC async controller: node_id=%s researchers=%s debug=%s",
+            node_id,
+            [f"{researcher.host}:{researcher.port}" for researcher in researchers],
+            debug,
+        )
 
     async def start(self) -> None:
         """ "Starts the tasks for each GrpcClient"""
-        ### (OPTIONAL) DEBUG THE STARTING OF GRPC CONTROLLER
+        logger.debug(
+            "Starting gRPC async controller: node_id=%s researcher_count=%d",
+            self._node_id,
+            len(self._researchers),
+        )
 
         tasks = []
         for researcher in self._researchers:
             client = GrpcClient(self._node_id, researcher, self._update_id_ip_map)
             tasks.append(client.start(on_task=self._on_message))
             self._clients[f"{researcher.host}:{researcher.port}"] = client
+            logger.debug(
+                "Registered gRPC client: node_id=%s researcher=%s:%s",
+                self._node_id,
+                researcher.host,
+                researcher.port,
+            )
 
         self._loop = asyncio.get_running_loop()
 

--- a/fedbiomed/transport/controller.py
+++ b/fedbiomed/transport/controller.py
@@ -38,6 +38,7 @@ class GrpcAsyncTaskController:
         Raises:
             FedbiomedCommunicationError: bad argument type
         """
+        ### (OPTIONAL) DEBUG THE INITIALIZATION OF GRPC CONTROLLER BY THE NODE
 
         # inform all threads whether communication client is started
         self._is_started = threading.Event()
@@ -61,6 +62,7 @@ class GrpcAsyncTaskController:
 
     async def start(self) -> None:
         """ "Starts the tasks for each GrpcClient"""
+        ### (OPTIONAL) DEBUG THE STARTING OF GRPC CONTROLLER
 
         tasks = []
         for researcher in self._researchers:
@@ -89,6 +91,9 @@ class GrpcAsyncTaskController:
             broadcast: Broadcast the message to all available researcher. This option should be used for general
                 node state messages (e.g. general Error)
         """
+        ### (OPTIONAL) DEBUG THE SENDING OF MESSAGE TO THE RESEARCHER
+        ### THIS IS ALSO NORMALLY COVERED BY THE _CALL_RESEARCHER FUNCTION IN THE CLIENT.PY.
+
         if broadcast:
             return await self._broadcast(message)
 

--- a/fedbiomed/transport/node_agent.py
+++ b/fedbiomed/transport/node_agent.py
@@ -113,6 +113,8 @@ class NodeAgentAsync:
     async def on_reply(self, message: Dict) -> None:
         """Callback to execute each time new reply received from the node"""
 
+        ### DEBUG THE RECEIVED REPLY FROM THE NODE
+
         message = Message.from_dict(message)
 
         # Handle overlay messages to relay to a node
@@ -167,6 +169,10 @@ class NodeAgentAsync:
             retry_count: number of retries already done for this message
             first_send_time: time of first send attempt for this message
         """
+
+        ### (OPTIONAL) DEBUG THE SENT MESSAGE TO THE NODE
+        ### THIS IS ALSO COVERED BY THE TRANSPORT LAYER, BUT IT CAN BE USEFUL THE
+        ### DEBUG THE NODES' STATUS' HERE, BEFORE THE MESSAGE IS ACTUALLY SENT TO THE TRANSPORT LAYER
 
         async with self._status_lock:
             if self._status == NodeActiveStatus.DISCONNECTED:

--- a/fedbiomed/transport/node_agent.py
+++ b/fedbiomed/transport/node_agent.py
@@ -64,6 +64,8 @@ class NodeAgentAsync:
         self._replies_lock = asyncio.Lock()
         self._stopped_request_ids_lock = asyncio.Lock()
         self._node_disconnection_timeout = node_disconnection_timeout
+        self._flushed_request_ids = set()  # ← Track flushed requests
+        self._flushed_request_ids_lock = asyncio.Lock()
 
     async def status_async(self) -> NodeActiveStatus:
         """Getter for node status.
@@ -92,11 +94,21 @@ class NodeAgentAsync:
             stopped: the request was stopped during processing
         """
         async with self._replies_lock:
-            if stopped and self._replies[request_id]["reply"] is None:
-                async with self._stopped_request_ids_lock:
-                    self._stopped_request_ids.append(request_id)
+            if request_id in self._replies:
+                if stopped and self._replies[request_id]["reply"] is None:
+                    async with self._stopped_request_ids_lock:
+                        self._stopped_request_ids.append(request_id)
 
-            self._replies.pop(request_id, None)
+                # Don't remove immediately, mark as flushed
+                async with self._flushed_request_ids_lock:
+                    self._flushed_request_ids.add(request_id)
+
+                # Optional: Clean up old flushed requests after some time
+                # Keep last N flushed requests to handle late replies
+                logger.debug(
+                    f"NodeAgent: Flushed request {request_id} for node {self._id}, "
+                    f"stopped={stopped}"
+                )
 
     def get_task(self) -> Awaitable[Message]:
         """Get tasks assigned by the main thread
@@ -112,56 +124,56 @@ class NodeAgentAsync:
 
     async def on_reply(self, message: Dict) -> None:
         """Callback to execute each time new reply received from the node"""
-
         message = Message.from_dict(message)
 
-        if isinstance(message, OverlayMessage):
-            logger.debug(
-                f"Researcher relay received overlay reply: src_node_id={self._id} "
-                f"dest_node_id={message.dest_node_id} setup={message.setup} payload_bytes={len(message.overlay)}"
-            )
+        # ...existing OverlayMessage handling...
 
         logger.debug(
             f"Node Agent: Received reply message {message.__class__.__name__} "
             f"for request_id={getattr(message, 'request_id', None)} from node_id={self._id}"
         )
 
-        # Handle overlay messages to relay to a node
-        if isinstance(message, OverlayMessage):
-            await self._on_forward(message)
-            return
-
-        # Handle RequestReply messages for the researcher
-        if not message.request_id:
-            logger.error(
-                f"Server received a reply from the client {self._id} that does "
-                "not contains request id."
-            )
-
         async with self._replies_lock:
             if message.request_id in self._replies:
-                if self._replies[message.request_id]["reply"] is None:
-                    self._replies[message.request_id]["reply"] = message
-                    self._replies[message.request_id]["callback"](message)
+                # Check if already flushed
+                async with self._flushed_request_ids_lock:
+                    if message.request_id in self._flushed_request_ids:
+                        logger.info(
+                            f"Received late reply for already flushed request {message.request_id} "
+                            f"from node {self._id}. This reply will be ignored."
+                        )
+                        return
+
+                reply_info = self._replies[message.request_id]
+                if reply_info["reply"] is None:
+                    reply_info["reply"] = message
+                    reply_info["callback"](message)
                 else:
-                    # Handle case of multiple replies
-                    # Avoid conflict with consumption of reply.
                     logger.warning(
                         f"Received multiple replies for request {message.request_id}. "
                         "Keep first reply, ignore subsequent replies"
                     )
             else:
+                # Request not found in _replies at all
                 async with self._stopped_request_ids_lock:
                     if message.request_id in self._stopped_request_ids:
-                        logger.warning(
-                            "Received a reply from a federated request that has been "
-                            f"stopped: {message.request_id}."
+                        logger.info(
+                            f"Received a reply from a stopped request: {message.request_id}"
                         )
                         self._stopped_request_ids.remove(message.request_id)
                     else:
-                        logger.warning(
-                            f"Received a reply from an unexpected request: {message.request_id}"
-                        )
+                        async with self._flushed_request_ids_lock:
+                            if message.request_id in self._flushed_request_ids:
+                                logger.warning(
+                                    f"Received LATE reply for flushed request {message.request_id} "
+                                    f"from node {self._id}. Message type: {message.__class__.__name__}. "
+                                    f"This indicates the reply arrived after the request was completed/timed out."
+                                )
+                            else:
+                                logger.warning(
+                                    f"Received a reply from an unexpected request: {message.request_id}. "
+                                    f"This request was never registered or is from a different session."
+                                )
 
     async def send_async(
         self,

--- a/fedbiomed/transport/node_agent.py
+++ b/fedbiomed/transport/node_agent.py
@@ -126,7 +126,10 @@ class NodeAgentAsync:
         """Callback to execute each time new reply received from the node"""
         message = Message.from_dict(message)
 
-        # ...existing OverlayMessage handling...
+        # Handle overlay messages to relay to a node
+        if isinstance(message, OverlayMessage):
+            await self._on_forward(message)
+            return
 
         logger.debug(
             f"Node Agent: Received reply message {message.__class__.__name__} "

--- a/fedbiomed/transport/node_agent.py
+++ b/fedbiomed/transport/node_agent.py
@@ -115,9 +115,15 @@ class NodeAgentAsync:
 
         message = Message.from_dict(message)
 
+        if isinstance(message, OverlayMessage):
+            logger.debug(
+                f"Researcher relay received overlay reply: src_node_id={self._id} "
+                f"dest_node_id={message.dest_node_id} setup={message.setup} payload_bytes={len(message.overlay)}"
+            )
+
         logger.debug(
             f"Node Agent: Received reply message {message.__class__.__name__} "
-            f"for request {message.request_id} from node {self._id}"
+            f"for request_id={getattr(message, 'request_id', None)} from node_id={self._id}"
         )
 
         # Handle overlay messages to relay to a node
@@ -208,6 +214,12 @@ class NodeAgentAsync:
 
         if first_send_time is None:
             first_send_time = time.time()
+
+        if isinstance(message, OverlayMessage):
+            logger.debug(
+                f"Researcher relay queueing overlay task: dest_node_id={self._id} "
+                f"src_node_id={message.node_id} setup={message.setup} payload_bytes={len(message.overlay)} retry={retry_count}"
+            )
 
         logger.debug(
             f"Node Agent: node {self._id} "

--- a/fedbiomed/transport/node_agent.py
+++ b/fedbiomed/transport/node_agent.py
@@ -113,9 +113,12 @@ class NodeAgentAsync:
     async def on_reply(self, message: Dict) -> None:
         """Callback to execute each time new reply received from the node"""
 
-        ### DEBUG THE RECEIVED REPLY FROM THE NODE
-
         message = Message.from_dict(message)
+
+        logger.debug(
+            f"Node Agent: Received reply message {message.__class__.__name__} "
+            f"for request {message.request_id} from node {self._id}"
+        )
 
         # Handle overlay messages to relay to a node
         if isinstance(message, OverlayMessage):
@@ -170,10 +173,6 @@ class NodeAgentAsync:
             first_send_time: time of first send attempt for this message
         """
 
-        ### (OPTIONAL) DEBUG THE SENT MESSAGE TO THE NODE
-        ### THIS IS ALSO COVERED BY THE TRANSPORT LAYER, BUT IT CAN BE USEFUL THE
-        ### DEBUG THE NODES' STATUS' HERE, BEFORE THE MESSAGE IS ACTUALLY SENT TO THE TRANSPORT LAYER
-
         async with self._status_lock:
             if self._status == NodeActiveStatus.DISCONNECTED:
                 logger.info(f"Node {self._id} is disconnected. Discard message.")
@@ -202,9 +201,19 @@ class NodeAgentAsync:
                 self._replies.update(
                     {message.request_id: {"callback": on_reply, "reply": None}}
                 )
+                logger.debug(
+                    f"Node Agent: Registered callback {on_reply.__name__ if on_reply else 'None'} "
+                    f"for request {message.request_id} in node {self._id}"
+                )
 
         if first_send_time is None:
             first_send_time = time.time()
+
+        logger.debug(
+            f"Node Agent: node {self._id} "
+            f"is sending message {message.__class__.__name__} "
+            f"with retry count {retry_count}"
+        )
         await self._queue.put([message, retry_count, first_send_time])
 
     async def set_active(self) -> None:

--- a/fedbiomed/transport/server.py
+++ b/fedbiomed/transport/server.py
@@ -109,8 +109,26 @@ class ResearcherServicer(researcher_pb2_grpc.ResearcherServiceServicer):
                     logger.warning(
                         f"Message to send is older than {MAX_SEND_DURATION} seconds. Discard message."
                     )
+                    logger.debug(
+                        "[WIRE][S->N][DROP] node=%s type=%s req=%s retry=%d age_s=%.1f reason=expired",
+                        task_request["node"],
+                        task.__class__.__name__ if task else None,
+                        getattr(task, "request_id", None) if task else None,
+                        retry_count,
+                        time.time() - first_send_time,
+                    )
 
             task_bytes = Serializer.dumps(task.to_dict())
+
+            logger.debug(
+                "[WIRE][S->N][TX] node=%s type=%s req=%s retry=%d age_s=%.1f bytes=%d",
+                task_request["node"],
+                task.__class__.__name__,
+                getattr(task, "request_id", None),
+                retry_count,
+                time.time() - first_send_time,
+                len(task_bytes),
+            )
 
             chunk_range = range(0, len(task_bytes), MAX_MESSAGE_BYTES_LENGTH)
             for start, iter_ in zip(
@@ -134,6 +152,14 @@ class ResearcherServicer(researcher_pb2_grpc.ResearcherServiceServicer):
                     # This is not fully coherent with upper layers (Requests) that may trigger an application
                     # level failure in the while, but it is mitigated by the MAX_SEND_DURATION
                     if retry_count < MAX_SEND_RETRIES:
+                        logger.debug(
+                            "[WIRE][S->N][REQUEUE] node=%s type=%s req=%s retry=%d reason=stream_interrupted error=%s",
+                            task_request["node"],
+                            task.__class__.__name__,
+                            getattr(task, "request_id", None),
+                            retry_count,
+                            str(GeneratorExit),
+                        )
                         await node_agent.send_async(
                             message=task,
                             on_reply=None,
@@ -143,6 +169,15 @@ class ResearcherServicer(researcher_pb2_grpc.ResearcherServiceServicer):
                     else:
                         logger.warning(
                             f"Message cannot be sent after {MAX_SEND_RETRIES} retries. Discard message."
+                        )
+                        logger.debug(
+                            "[WIRE][S->N][DROP] node=%s type=%s req=%s retry=%d age_s=%.1f reason=expired error=%s",
+                            task_request["node"],
+                            task.__class__.__name__ if task else None,
+                            getattr(task, "request_id", None) if task else None,
+                            retry_count,
+                            time.time() - first_send_time,
+                            str(GeneratorExit),
                         )
                     await node_agent.change_node_status_after_task()
                     # need return here to avoid RuntimeError
@@ -156,6 +191,14 @@ class ResearcherServicer(researcher_pb2_grpc.ResearcherServiceServicer):
             ):
                 # schedule resend if task was pulled from queue
                 if retry_count < MAX_SEND_RETRIES:
+                    logger.debug(
+                        "[WIRE][S->N][REQUEUE] node=%s type=%s req=%s retry=%d reason=stream_interrupted error=%s",
+                        task_request["node"],
+                        task.__class__.__name__,
+                        getattr(task, "request_id", None),
+                        retry_count,
+                        str(asyncio.CancelledError),
+                    )
                     await node_agent.send_async(
                         message=task,
                         on_reply=None,
@@ -165,6 +208,15 @@ class ResearcherServicer(researcher_pb2_grpc.ResearcherServiceServicer):
                 else:
                     logger.warning(
                         f"Message cannot be sent after {MAX_SEND_RETRIES} retries. Discard message."
+                    )
+                    logger.debug(
+                        "[WIRE][S->N][DROP] node=%s type=%s req=%s retry=%d age_s=%.1f reason=expired error=%s",
+                        task_request["node"],
+                        task.__class__.__name__ if task else None,
+                        getattr(task, "request_id", None) if task else None,
+                        retry_count,
+                        time.time() - first_send_time,
+                        str(asyncio.CancelledError),
                     )
         finally:
             await node_agent.change_node_status_after_task()
@@ -190,6 +242,14 @@ class ResearcherServicer(researcher_pb2_grpc.ResearcherServiceServicer):
             # Deserialize message
             message = Serializer.loads(reply)
 
+            logger.debug(
+                "[WIRE][N->S][RX] node=%s req=%s type=%s bytes=%d",
+                message.get("node_id"),
+                message.get("request_id"),
+                Message.from_dict(message).__class__.__name__,
+                len(reply),
+            )
+
             # Replies are handled by node agent callbacks
             node = await self._agent_store.get(message["node_id"])
             await node.on_reply(message)
@@ -211,6 +271,12 @@ class ResearcherServicer(researcher_pb2_grpc.ResearcherServiceServicer):
         # Get the type of Feedback | log or scalar
         one_of = request.WhichOneof("feedback_type")
         feedback = FeedbackMessage.from_proto(request)
+
+        logger.debug(
+            "[WIRE][N->S][RX] node=%s type=Feedback oneof=%s",
+            feedback.node_id if hasattr(feedback, "node_id") else None,
+            one_of,
+        )
 
         # Execute on_message assigned by the researcher.requests modules
         self._on_message(feedback.get_param(one_of), MessageType.convert(one_of))

--- a/fedbiomed/transport/server.py
+++ b/fedbiomed/transport/server.py
@@ -410,6 +410,10 @@ class _GrpcAsyncServer:
         Args:
             message: Message to forward
         """
+        logger.debug(
+            f"Researcher relay forwarding overlay: src_node_id={message.node_id} "
+            f"dest_node_id={message.dest_node_id} setup={message.setup} payload_bytes={len(message.overlay)}"
+        )
         # caveat: intentionally use `_GrpcAyncServer.send()`
         # if using `self.send()` it uses `GrpcServer.send()`, normally used from another thread
         # if using `super().send()` it's less explicit
@@ -426,8 +430,19 @@ class _GrpcAsyncServer:
         agent = await self._agent_store.get(node_id)
 
         if not agent:
+            if isinstance(message, OverlayMessage):
+                logger.debug(
+                    f"Researcher relay drop: dest_node_id={node_id} src_node_id={message.node_id} "
+                    f"setup={message.setup} reason=node_not_registered"
+                )
             logger.info(f"Node {node_id} is not registered on server. Discard message.")
             return
+
+        if isinstance(message, OverlayMessage):
+            logger.debug(
+                f"Researcher relay dispatching overlay to node agent: dest_node_id={node_id} "
+                f"src_node_id={message.node_id} setup={message.setup} payload_bytes={len(message.overlay)}"
+            )
 
         await agent.send_async(message)
 

--- a/notebooks/101_getting-started.ipynb
+++ b/notebooks/101_getting-started.ipynb
@@ -306,7 +306,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/101_getting-started.ipynb
+++ b/notebooks/101_getting-started.ipynb
@@ -306,7 +306,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+
+# Default researcher workflow tests to debug-mode exception behavior.
+os.environ.setdefault("FBM_DEBUG", "1")

--- a/tests/end2end/conftest.py
+++ b/tests/end2end/conftest.py
@@ -17,7 +17,7 @@ from helpers import (
 
 _PORT = 50151
 
-os.environ["FBM_DEBUG"] = "True"
+os.environ["FBM_DEBUG"] = "1"
 
 
 @pytest.fixture(scope="module")

--- a/tests/end2end/conftest.py
+++ b/tests/end2end/conftest.py
@@ -3,20 +3,21 @@ Module for global PyTest configuration and fixtures
 
 """
 
-import re
 import os
-import tempfile
+import re
 import shutil
+import tempfile
 
-import pytest
 import psutil
-
+import pytest
 from helpers import (
-    kill_process,
     CONFIG_PREFIX,
+    kill_process,
 )
 
 _PORT = 50151
+
+os.environ["FBM_DEBUG"] = "True"
 
 
 @pytest.fixture(scope="module")

--- a/tests/end2end/e2e_secure_aggregation.py
+++ b/tests/end2end/e2e_secure_aggregation.py
@@ -1,29 +1,35 @@
-import time
-import pytest
 import copy
+import time
 
+import pytest
+from experiments.training_plans.mnist_pytorch_training_plan import (
+    MnistModelScaffoldDeclearn,
+    MyTrainingPlan,
+)
 from helpers import (
     add_dataset_to_node,
-    start_nodes,
-    kill_subprocesses,
     clear_component_data,
     clear_experiment_data,
     create_multiple_nodes,
     create_node,
     create_researcher,
     get_data_folder,
+    kill_subprocesses,
+    start_nodes,
 )
 
-from experiments.training_plans.mnist_pytorch_training_plan import (
-    MnistModelScaffoldDeclearn,
-    MyTrainingPlan,
+from fedbiomed.common.exceptions import (
+    FedbiomedSecureAggregationError,
+    FedbiomedStrategyError,
 )
 from fedbiomed.common.optimizers import Optimizer
 from fedbiomed.common.optimizers.declearn import ScaffoldServerModule
-from fedbiomed.researcher.experiment import Experiment
 from fedbiomed.researcher.aggregators.fedavg import FedAverage
+from fedbiomed.researcher.experiment import Experiment
 from fedbiomed.researcher.secagg import (
     SecureAggregation,
+)
+from fedbiomed.researcher.secagg import (
     SecureAggregationSchemes as SecAggSchemes,
 )
 
@@ -302,7 +308,7 @@ def test_03_secagg_pytorch_force_secagg(extra_node_force_secagg):
     )
 
     # This should raise exception with default strategy
-    with pytest.raises(SystemExit):
+    with pytest.raises(FedbiomedStrategyError):
         exp.run()
 
     # Cleaning!
@@ -325,7 +331,7 @@ def test_04_secagg_pytorch_no_validation(extra_node_no_validation):
     )
 
     # This should raise exception with default strategy
-    with pytest.raises(SystemExit):
+    with pytest.raises(FedbiomedSecureAggregationError):
         exp.run()
 
     # Cleaning!

--- a/tests/end2end/e2e_training_plan_approval.py
+++ b/tests/end2end/e2e_training_plan_approval.py
@@ -14,6 +14,7 @@ from helpers import (
     training_plan_operation,
 )
 
+from fedbiomed.common.exceptions import FedbiomedStrategyError
 from fedbiomed.researcher.aggregators.fedavg import FedAverage
 from fedbiomed.researcher.experiment import Experiment
 
@@ -105,7 +106,7 @@ def test_01_training_plan_approval_failure_success_cases(setup_components):
     )
 
     # Training plan is not approved exp.run should fail
-    with pytest.raises(SystemExit):
+    with pytest.raises(FedbiomedStrategyError):
         exp.run()
 
     # Check status
@@ -160,7 +161,7 @@ def test_01_training_plan_approval_failure_success_cases(setup_components):
     assert status[node_2_id].status == "Rejected"
 
     # Should not be able to run experiment with rejected training plan
-    with pytest.raises(SystemExit):
+    with pytest.raises(FedbiomedStrategyError):
         exp.run(rounds=2, increase=True)
 
     # Important always clear experiment  data

--- a/tests/test_db_security_log.py
+++ b/tests/test_db_security_log.py
@@ -15,9 +15,11 @@ def test_security_log_success_strips_forbidden_and_truncates(
 ) -> None:
     security_event = Mock()
     security_context = Mock(side_effect=lambda **_: nullcontext())
+    debug = Mock()
 
     monkeypatch.setattr(db_mod.logger, "security_event", security_event)
     monkeypatch.setattr(db_mod.logger, "security_context", security_context)
+    monkeypatch.setattr(db_mod.logger, "debug", debug)
 
     class _FakeTable:
         name = "my_table"
@@ -45,11 +47,20 @@ def test_security_log_success_strips_forbidden_and_truncates(
 
     security_context.assert_called_once_with(operation="insert", table="my_table")
     security_event.assert_called_once()
+    debug.assert_called_once()
 
     logged = security_event.call_args.kwargs
     assert logged["status"] == "success"
     assert logged["doc_id"] == 7
     assert logged["stacklevel"] == 42
+
+    debug_args = debug.call_args
+    assert "insert in table" in debug_args.args[0]
+    assert "db_args=" in debug_args.args[0]
+    assert "db_kwargs=" in debug_args.args[0]
+    assert debug_args.kwargs["extra"]["db_args"] == logged["db_args"]
+    assert debug_args.kwargs["extra"]["db_kwargs"] == logged["db_kwargs"]
+    assert debug_args.kwargs["stacklevel"] == 42
 
     # Forbidden keys stripped from payload/kwargs logging
     assert "certificate" not in logged["db_args"]
@@ -93,8 +104,10 @@ def test_security_log_failure_logs_and_wraps_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     security_event = Mock()
+    debug = Mock()
     monkeypatch.setattr(db_mod.logger, "security_event", security_event)
     monkeypatch.setattr(db_mod.logger, "security_context", lambda **_: nullcontext())
+    monkeypatch.setattr(db_mod.logger, "debug", debug)
 
     class _FakeTable:
         name = "my_table"
@@ -108,13 +121,22 @@ def test_security_log_failure_logs_and_wraps_exception(
     with pytest.raises(FedbiomedError) as excinfo:
         table.remove({"certificate": "SECRET", "keep": "ok"}, stacklevel=9)
 
-    assert "Failed to remove in table my_table" in str(excinfo.value)
+    assert "Failed to remove" in str(excinfo.value)
     assert isinstance(excinfo.value.__cause__, ValueError)
 
     logged = security_event.call_args.kwargs
     assert logged["status"] == "failure"
     assert logged["details"] == "boom"
     assert logged["stacklevel"] == 9
+
+    debug.assert_called_once()
+    debug_args = debug.call_args
+    assert "Failed to remove" in debug_args.args[0]
+    assert "db_args=" in debug_args.args[0]
+    assert "db_kwargs=" in debug_args.args[0]
+    assert debug_args.kwargs["extra"]["db_args"] == logged["db_args"]
+    assert debug_args.kwargs["extra"]["db_kwargs"] == logged["db_kwargs"]
+    assert debug_args.kwargs["stacklevel"] == 9
 
     # Forbidden keys stripped from args logging even on failure
     assert "certificate" not in logged["db_args"]

--- a/tests/test_exp_exceptions.py
+++ b/tests/test_exp_exceptions.py
@@ -28,8 +28,8 @@ class TestExpExceptions(unittest.TestCase):
         def decFunction():
             raise BaseException
 
-        with patch.dict(os.environ, {"FEDBIOMED_DEBUG": ""}, clear=False):
-            with self.assertRaises(BaseException):
+        with patch.dict(os.environ, {"FBM_DEBUG_RESEARCHER": ""}, clear=False):
+            with self.assertRaises(SystemExit):
                 decFunction()
 
     def test_exp_exceptions_2_system_Exit(self):
@@ -40,7 +40,7 @@ class TestExpExceptions(unittest.TestCase):
         def decFunction():
             raise SystemExit
 
-        with patch.dict(os.environ, {"FEDBIOMED_DEBUG": ""}, clear=False):
+        with patch.dict(os.environ, {"FBM_DEBUG_RESEARCHER": ""}, clear=False):
             with self.assertRaises(SystemExit):
                 decFunction()
 
@@ -51,7 +51,7 @@ class TestExpExceptions(unittest.TestCase):
         def decFunction():
             raise KeyboardInterrupt
 
-        with patch.dict(os.environ, {"FEDBIOMED_DEBUG": ""}, clear=False):
+        with patch.dict(os.environ, {"FBM_DEBUG_RESEARCHER": ""}, clear=False):
             with self.assertRaises(SystemExit):
                 decFunction()
 
@@ -62,7 +62,7 @@ class TestExpExceptions(unittest.TestCase):
         def decFunction():
             raise FedbiomedError
 
-        with patch.dict(os.environ, {"FEDBIOMED_DEBUG": ""}, clear=False):
+        with patch.dict(os.environ, {"FBM_DEBUG_RESEARCHER": ""}, clear=False):
             # on notebook
             with patch.object(
                 fedbiomed.researcher.federated_workflows._federated_workflow,
@@ -83,7 +83,7 @@ class TestExpExceptions(unittest.TestCase):
         def decFunction():
             raise FedbiomedSilentTerminationError
 
-        with patch.dict(os.environ, {"FEDBIOMED_DEBUG": ""}, clear=False):
+        with patch.dict(os.environ, {"FBM_DEBUG_RESEARCHER": ""}, clear=False):
             # SystemExit on notebook
             with self.assertRaises(FedbiomedSilentTerminationError):
                 decFunction()
@@ -95,7 +95,7 @@ class TestExpExceptions(unittest.TestCase):
         def decFunction():
             raise FedbiomedError
 
-        with patch.dict(os.environ, {"FEDBIOMED_DEBUG": ""}, clear=False):
+        with patch.dict(os.environ, {"FBM_DEBUG_RESEARCHER": ""}, clear=False):
             # SystemExit on python shell
             with patch.object(
                 fedbiomed.researcher.federated_workflows._federated_workflow,
@@ -115,7 +115,7 @@ class TestExpExceptions(unittest.TestCase):
 
         stdout = io.StringIO()
         with (
-            patch.dict(os.environ, {"FEDBIOMED_DEBUG": "1"}, clear=False),
+            patch.dict(os.environ, {"FBM_DEBUG_RESEARCHER": "1"}, clear=False),
             patch("sys.stdout", stdout),
         ):
             with self.assertRaises(ValueError):
@@ -134,7 +134,7 @@ class TestExpExceptions(unittest.TestCase):
 
         stdout = io.StringIO()
         with (
-            patch.dict(os.environ, {"FEDBIOMED_DEBUG": "1"}, clear=False),
+            patch.dict(os.environ, {"FBM_DEBUG_RESEARCHER": "1"}, clear=False),
             patch("sys.stdout", stdout),
         ):
             with self.assertRaises(FedbiomedExperimentError):
@@ -143,6 +143,27 @@ class TestExpExceptions(unittest.TestCase):
         out = stdout.getvalue()
         self.assertIn("FedbiomedExperimentError", out)
         self.assertIn("boom-exp", out)
+
+    def test_exp_exceptions_8_debug_mode_fedbiomed_silent_termination_error_prints_traceback_and_reraises(
+        self,
+    ):
+        """In debug mode, FedbiomedSilentTerminationError should print a traceback and re-raise."""
+
+        @exp_exceptions
+        def decFunction():
+            raise FedbiomedSilentTerminationError("boom-silent")
+
+        stdout = io.StringIO()
+        with (
+            patch.dict(os.environ, {"FBM_DEBUG_RESEARCHER": "1"}, clear=False),
+            patch("sys.stdout", stdout),
+        ):
+            with self.assertRaises(FedbiomedSilentTerminationError):
+                decFunction()
+
+        out = stdout.getvalue()
+        self.assertIn("FedbiomedSilentTerminationError", out)
+        self.assertIn("boom-silent", out)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_exp_exceptions.py
+++ b/tests/test_exp_exceptions.py
@@ -28,7 +28,7 @@ class TestExpExceptions(unittest.TestCase):
         def decFunction():
             raise BaseException
 
-        with patch.dict(os.environ, {"FBM_DEBUG_RESEARCHER": ""}, clear=False):
+        with patch.dict(os.environ, {"FBM_DEBUG": ""}, clear=False):
             with self.assertRaises(SystemExit):
                 decFunction()
 
@@ -40,7 +40,7 @@ class TestExpExceptions(unittest.TestCase):
         def decFunction():
             raise SystemExit
 
-        with patch.dict(os.environ, {"FBM_DEBUG_RESEARCHER": ""}, clear=False):
+        with patch.dict(os.environ, {"FBM_DEBUG": ""}, clear=False):
             with self.assertRaises(SystemExit):
                 decFunction()
 
@@ -51,7 +51,7 @@ class TestExpExceptions(unittest.TestCase):
         def decFunction():
             raise KeyboardInterrupt
 
-        with patch.dict(os.environ, {"FBM_DEBUG_RESEARCHER": ""}, clear=False):
+        with patch.dict(os.environ, {"FBM_DEBUG": ""}, clear=False):
             with self.assertRaises(SystemExit):
                 decFunction()
 
@@ -62,7 +62,7 @@ class TestExpExceptions(unittest.TestCase):
         def decFunction():
             raise FedbiomedError
 
-        with patch.dict(os.environ, {"FBM_DEBUG_RESEARCHER": ""}, clear=False):
+        with patch.dict(os.environ, {"FBM_DEBUG": ""}, clear=False):
             # on notebook
             with patch.object(
                 fedbiomed.researcher.federated_workflows._federated_workflow,
@@ -83,7 +83,7 @@ class TestExpExceptions(unittest.TestCase):
         def decFunction():
             raise FedbiomedSilentTerminationError
 
-        with patch.dict(os.environ, {"FBM_DEBUG_RESEARCHER": ""}, clear=False):
+        with patch.dict(os.environ, {"FBM_DEBUG": ""}, clear=False):
             # SystemExit on notebook
             with self.assertRaises(FedbiomedSilentTerminationError):
                 decFunction()
@@ -95,7 +95,7 @@ class TestExpExceptions(unittest.TestCase):
         def decFunction():
             raise FedbiomedError
 
-        with patch.dict(os.environ, {"FBM_DEBUG_RESEARCHER": ""}, clear=False):
+        with patch.dict(os.environ, {"FBM_DEBUG": ""}, clear=False):
             # SystemExit on python shell
             with patch.object(
                 fedbiomed.researcher.federated_workflows._federated_workflow,
@@ -115,7 +115,7 @@ class TestExpExceptions(unittest.TestCase):
 
         stdout = io.StringIO()
         with (
-            patch.dict(os.environ, {"FBM_DEBUG_RESEARCHER": "1"}, clear=False),
+            patch.dict(os.environ, {"FBM_DEBUG": "1"}, clear=False),
             patch("sys.stdout", stdout),
         ):
             with self.assertRaises(ValueError):
@@ -134,7 +134,7 @@ class TestExpExceptions(unittest.TestCase):
 
         stdout = io.StringIO()
         with (
-            patch.dict(os.environ, {"FBM_DEBUG_RESEARCHER": "1"}, clear=False),
+            patch.dict(os.environ, {"FBM_DEBUG": "1"}, clear=False),
             patch("sys.stdout", stdout),
         ):
             with self.assertRaises(FedbiomedExperimentError):
@@ -155,7 +155,7 @@ class TestExpExceptions(unittest.TestCase):
 
         stdout = io.StringIO()
         with (
-            patch.dict(os.environ, {"FBM_DEBUG_RESEARCHER": "1"}, clear=False),
+            patch.dict(os.environ, {"FBM_DEBUG": "1"}, clear=False),
             patch("sys.stdout", stdout),
         ):
             with self.assertRaises(FedbiomedSilentTerminationError):

--- a/tests/test_exp_exceptions.py
+++ b/tests/test_exp_exceptions.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 import fedbiomed.researcher.federated_workflows._federated_workflow
 from fedbiomed.common.exceptions import (
     FedbiomedError,
-    FedbiomedExperimentError,
     FedbiomedSilentTerminationError,
 )
 from fedbiomed.researcher.federated_workflows._federated_workflow import exp_exceptions
@@ -122,48 +121,6 @@ class TestExpExceptions(unittest.TestCase):
                 decFunction()
 
         self.assertEqual("", stdout.getvalue())
-
-    def test_exp_exceptions_7_debug_mode_fedbiomed_experiment_error_prints_traceback_and_reraises(
-        self,
-    ):
-        """In debug mode, FedbiomedExperimentError should print a traceback and re-raise."""
-
-        @exp_exceptions
-        def decFunction():
-            raise FedbiomedExperimentError("boom-exp")
-
-        stdout = io.StringIO()
-        with (
-            patch.dict(os.environ, {"FBM_DEBUG": "1"}, clear=False),
-            patch("sys.stdout", stdout),
-        ):
-            with self.assertRaises(FedbiomedExperimentError):
-                decFunction()
-
-        out = stdout.getvalue()
-        self.assertIn("FedbiomedExperimentError", out)
-        self.assertIn("boom-exp", out)
-
-    def test_exp_exceptions_8_debug_mode_fedbiomed_silent_termination_error_prints_traceback_and_reraises(
-        self,
-    ):
-        """In debug mode, FedbiomedSilentTerminationError should print a traceback and re-raise."""
-
-        @exp_exceptions
-        def decFunction():
-            raise FedbiomedSilentTerminationError("boom-silent")
-
-        stdout = io.StringIO()
-        with (
-            patch.dict(os.environ, {"FBM_DEBUG": "1"}, clear=False),
-            patch("sys.stdout", stdout),
-        ):
-            with self.assertRaises(FedbiomedSilentTerminationError):
-                decFunction()
-
-        out = stdout.getvalue()
-        self.assertIn("FedbiomedSilentTerminationError", out)
-        self.assertIn("boom-silent", out)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_exp_exceptions.py
+++ b/tests/test_exp_exceptions.py
@@ -1,8 +1,14 @@
+import io
+import os
 import unittest
 from unittest.mock import patch
 
 import fedbiomed.researcher.federated_workflows._federated_workflow
-from fedbiomed.common.exceptions import FedbiomedSilentTerminationError, FedbiomedError
+from fedbiomed.common.exceptions import (
+    FedbiomedError,
+    FedbiomedExperimentError,
+    FedbiomedSilentTerminationError,
+)
 from fedbiomed.researcher.federated_workflows._federated_workflow import exp_exceptions
 
 
@@ -22,8 +28,9 @@ class TestExpExceptions(unittest.TestCase):
         def decFunction():
             raise BaseException
 
-        with self.assertRaises(BaseException):
-            decFunction()
+        with patch.dict(os.environ, {"FEDBIOMED_DEBUG": ""}, clear=False):
+            with self.assertRaises(BaseException):
+                decFunction()
 
     def test_exp_exceptions_2_system_Exit(self):
         """Test  raising directly system exit"""
@@ -33,8 +40,9 @@ class TestExpExceptions(unittest.TestCase):
         def decFunction():
             raise SystemExit
 
-        with self.assertRaises(SystemExit):
-            decFunction()
+        with patch.dict(os.environ, {"FEDBIOMED_DEBUG": ""}, clear=False):
+            with self.assertRaises(SystemExit):
+                decFunction()
 
     def test_exp_exceptions_3_key_int(self):
         """Test raisin  KeyboardInterrupt error"""
@@ -43,8 +51,9 @@ class TestExpExceptions(unittest.TestCase):
         def decFunction():
             raise KeyboardInterrupt
 
-        with self.assertRaises(SystemExit):
-            decFunction()
+        with patch.dict(os.environ, {"FEDBIOMED_DEBUG": ""}, clear=False):
+            with self.assertRaises(SystemExit):
+                decFunction()
 
     def test_exp_exception_4_fedbiomed_error(self):
         """Test raising exp FedbiomedError on notebook and python shell"""
@@ -53,18 +62,19 @@ class TestExpExceptions(unittest.TestCase):
         def decFunction():
             raise FedbiomedError
 
-        # on notebook
-        with patch.object(
-            fedbiomed.researcher.federated_workflows._federated_workflow,
-            "is_ipython",
-            create=True,
-        ) as m:
-            m.return_value = True
-            with self.assertRaises(FedbiomedSilentTerminationError):
+        with patch.dict(os.environ, {"FEDBIOMED_DEBUG": ""}, clear=False):
+            # on notebook
+            with patch.object(
+                fedbiomed.researcher.federated_workflows._federated_workflow,
+                "is_ipython",
+                create=True,
+            ) as m:
+                m.return_value = True
+                with self.assertRaises(FedbiomedSilentTerminationError):
+                    decFunction()
+            # on python shell
+            with self.assertRaises(SystemExit):
                 decFunction()
-        # on python shell
-        with self.assertRaises(SystemExit):
-            decFunction()
 
     def test_exp_exception_4_fedbiomed_silent_error(self):
         """Test raising exp FedbiomedSilentTerminationError"""
@@ -73,9 +83,10 @@ class TestExpExceptions(unittest.TestCase):
         def decFunction():
             raise FedbiomedSilentTerminationError
 
-        # SystemExit on notebook
-        with self.assertRaises(FedbiomedSilentTerminationError):
-            decFunction()
+        with patch.dict(os.environ, {"FEDBIOMED_DEBUG": ""}, clear=False):
+            # SystemExit on notebook
+            with self.assertRaises(FedbiomedSilentTerminationError):
+                decFunction()
 
     def test_exp_exception_5_interactive_shell_false(self):
         """Test if get_ipython does not return ZMQInteractiveShell"""
@@ -84,15 +95,54 @@ class TestExpExceptions(unittest.TestCase):
         def decFunction():
             raise FedbiomedError
 
-        # SystemExit on python shell
-        with patch.object(
-            fedbiomed.researcher.federated_workflows._federated_workflow,
-            "is_ipython",
-            create=True,
-        ) as m:
-            m.return_value = False
-            with self.assertRaises(SystemExit):
+        with patch.dict(os.environ, {"FEDBIOMED_DEBUG": ""}, clear=False):
+            # SystemExit on python shell
+            with patch.object(
+                fedbiomed.researcher.federated_workflows._federated_workflow,
+                "is_ipython",
+                create=True,
+            ) as m:
+                m.return_value = False
+                with self.assertRaises(SystemExit):
+                    decFunction()
+
+    def test_exp_exceptions_6_debug_mode_does_not_intercept_generic_exceptions(self):
+        """In debug mode, exp_exceptions should not add special handling to non-experiment errors."""
+
+        @exp_exceptions
+        def decFunction():
+            raise ValueError("boom")
+
+        stdout = io.StringIO()
+        with (
+            patch.dict(os.environ, {"FEDBIOMED_DEBUG": "1"}, clear=False),
+            patch("sys.stdout", stdout),
+        ):
+            with self.assertRaises(ValueError):
                 decFunction()
+
+        self.assertEqual("", stdout.getvalue())
+
+    def test_exp_exceptions_7_debug_mode_fedbiomed_experiment_error_prints_traceback_and_reraises(
+        self,
+    ):
+        """In debug mode, FedbiomedExperimentError should print a traceback and re-raise."""
+
+        @exp_exceptions
+        def decFunction():
+            raise FedbiomedExperimentError("boom-exp")
+
+        stdout = io.StringIO()
+        with (
+            patch.dict(os.environ, {"FEDBIOMED_DEBUG": "1"}, clear=False),
+            patch("sys.stdout", stdout),
+        ):
+            with self.assertRaises(FedbiomedExperimentError):
+                decFunction()
+
+        out = stdout.getvalue()
+        self.assertIn("FedbiomedExperimentError", out)
+        self.assertIn("boom-exp", out)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -12,9 +12,12 @@ from testsupport.fake_training_plan import (
 
 import fedbiomed
 from fedbiomed.common.constants import PreprocType
-from fedbiomed.common.exceptions import FedbiomedExperimentError
+from fedbiomed.common.exceptions import (
+    FedbiomedExperimentError,
+    FedbiomedTypeError,
+    FedbiomedValueError,
+)
 from fedbiomed.common.metrics import MetricTypes
-from fedbiomed.common.optimizers import AuxVar
 from fedbiomed.common.training_args import TrainingArgs
 from fedbiomed.researcher.aggregators.aggregator import Aggregator
 from fedbiomed.researcher.datasets import FederatedDataset
@@ -93,12 +96,15 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
             "retain_full_history": (True, False),
         }  # some of the parameters which have already been tested in FederatedWorkflow have been simplified here
         # Compute cartesian product of parameter values to obtain all possible combinations
-        keys, values = zip(*parameters_and_possible_values.items())
-        all_parameter_combinations = [dict(zip(keys, v)) for v in product(*values)]
+        keys, values = zip(*parameters_and_possible_values.items(), strict=True)
+        all_parameter_combinations = [
+            dict(zip(keys, value_combination, strict=True))
+            for value_combination in product(*values)
+        ]
         for params in all_parameter_combinations:
             try:
                 exp = Experiment(**params)
-            except SystemExit as e:
+            except Exception as e:
                 print(
                     f"Could not instantiate Experiment: exception {e} raised with the following constructor"
                     f"arguments:\n {params}"
@@ -157,7 +163,7 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
 
         _aggregator_class = FakeAggregator
 
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedTypeError):
             exp.set_aggregator(_aggregator_class)
 
         exp.set_aggregator(FakeAggregator())
@@ -203,7 +209,7 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
         _strategy_class = MagicMock()
         _strategy_class.return_value = _strategy
 
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedTypeError):
             exp.set_strategy(FakeStrategy)
 
         exp.set_strategy(FakeStrategy())
@@ -232,13 +238,13 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
         )
 
         # Test error case -------------------------------
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp.run_once(increase="invalid-type")
         # ------------------------------------------------
 
         # Test if no training nodes are returned from strategy.sample_nodes ---
         _strategy.sample_nodes.return_value = []
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp.run_once()
         _strategy.sample_nodes.return_value = ["node-1", "node-2"]
         # ---------------------------------------------------------------------
@@ -249,7 +255,7 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
 
         # Check if it raises if there is missing object block --------
         exp._fds = None
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(AttributeError):
             exp.run_once()
         exp._fds = FederatedDataset(_training_data)
         # -------------------------------------------------------------
@@ -386,13 +392,13 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
 
         # wrong argument types
         with patch.object(exp, "run_once", return_value=1) as mock_run_once:
-            with self.assertRaises(SystemExit):
+            with self.assertRaises(FedbiomedExperimentError):
                 exp.run(rounds=-1)
                 self.assertFalse(mock_run_once.called)
-            with self.assertRaises(SystemExit):
+            with self.assertRaises(FedbiomedExperimentError):
                 exp.run(rounds="one")
                 self.assertFalse(mock_run_once.called)
-            with self.assertRaises(SystemExit):
+            with self.assertRaises(FedbiomedExperimentError):
                 exp.run(increase="True")
                 self.assertFalse(mock_run_once.called)
 
@@ -424,7 +430,7 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
 
         # Tests if run once return 0
         with patch.object(exp, "run_once", return_value=0) as mock_run_once:
-            with self.assertRaises(SystemExit):
+            with self.assertRaises(FedbiomedExperimentError):
                 exp.set_round_limit(exp.round_current() + 1)
                 x = exp.run()
 
@@ -478,7 +484,7 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
         )
         with patch.object(FedbiomedExperimentError, "__init__") as patch_exc:
             patch_exc.return_value = None  # __init__ must return None
-            self.assertRaises(SystemExit, exp.run_once)
+            self.assertRaises(FedbiomedExperimentError, exp.run_once)
         patch_exc.assert_called_once()
         error_msg = patch_exc.call_args[0][0]
         self.assertTrue(
@@ -549,7 +555,7 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
         )
 
         # Test if current round is less than 1 meaning that there is no round ran
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp._set_round_current(0)
             exp.breakpoint()
         # ----------------------------------------------------------------------
@@ -558,11 +564,11 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
         with (
             patch.object(
                 exp, "save_aggregated_params", return_value={"agg_params": "bkpt"}
-            ) as mock_agg_param_save,
+            ),
             patch.object(
                 exp, "save_training_replies", return_value={"replies": "bkpt"}
-            ) as mock_save_replies,
-            patch.object(exp, "training_plan") as mock_tp,
+            ),
+            patch.object(exp, "training_plan"),
         ):
             exp.breakpoint()
 
@@ -628,8 +634,8 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
 
         with patch.object(
             Experiment, "_create_object", new=create_strategy_then_aggregator
-        ) as mock_creat:
-            exp = Experiment.load_breakpoint()
+        ):
+            Experiment.load_breakpoint()
 
     def test_experiment_11_testing_args(self):
         """Tests training arguments setter and getter"""
@@ -678,7 +684,7 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
         self.assertIsNone(exp._agg_optimizer)
 
         invalid_type_optimizer = MagicMock()
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp.set_agg_optimizer(invalid_type_optimizer)
 
         # Check getter
@@ -690,13 +696,13 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
 
         # Normal good case
         exp = Experiment()
-        limit = exp.set_round_limit(2)
+        exp.set_round_limit(2)
         self.assertEqual(exp._round_limit, 2)
 
         # Test if round limit less than current round number
         exp._round_current = 2
-        with self.assertRaises(SystemExit):
-            limit = exp.set_round_limit(1)
+        with self.assertRaises(FedbiomedValueError):
+            exp.set_round_limit(1)
 
         # Test setting it to None
         exp.set_round_limit(None)
@@ -712,7 +718,7 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
 
         # Exception if round limit is less than round current
         exp._round_limit = 4
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp._set_round_current(5)
 
         # Check monitor called correctly
@@ -729,7 +735,7 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
         exp._monitor.set_tensorboard.assert_called_once_with(True)
 
         # Invalid type
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp.set_tensorboard("oops")
 
     def test_experiment_16_set_retain_full_history(self):
@@ -740,7 +746,7 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
         self.assertTrue(exp.retain_full_history())
 
         # Tests setting invalid type
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedTypeError):
             exp.set_retain_full_history("invalid_type")
 
     def test_experiment_17_commit_experiment_history(self):
@@ -799,20 +805,18 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
         exp = Experiment()
 
         # Error case invalid aggregated params
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp.save_aggregated_params("boom", path)
 
         # Error case invalid path
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp.save_aggregated_params(params, True)
 
         # Error case invalid params
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp.save_aggregated_params({"x": 1}, path)
 
-        with patch(
-            "fedbiomed.researcher.federated_workflows._experiment.Serializer"
-        ) as ser:
+        with patch("fedbiomed.researcher.federated_workflows._experiment.Serializer"):
             aggregated_params = exp.save_aggregated_params(params, path)
 
         self.assertTrue(0 in aggregated_params)
@@ -826,7 +830,7 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
         exp = Experiment()
 
         # Invalid type of aggregated params
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp._load_aggregated_params(None)
 
         with patch(
@@ -859,8 +863,6 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
     def test_experiment_22_load_optimizer(self):
         """Tests loading experiment"""
 
-        path = "sate-path"
-
         exp = Experiment()
         r = exp._load_optimizer(None)
         self.assertIsNone(r)
@@ -869,9 +871,7 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
             patch(
                 "fedbiomed.researcher.federated_workflows._experiment.Optimizer"
             ) as opt,
-            patch(
-                "fedbiomed.researcher.federated_workflows._experiment.Serializer"
-            ) as ser,
+            patch("fedbiomed.researcher.federated_workflows._experiment.Serializer"),
         ):
             exp._load_optimizer("state-path")
             opt.load_state.assert_called_once()

--- a/tests/test_federated_workflow.py
+++ b/tests/test_federated_workflow.py
@@ -10,7 +10,12 @@ from fedbiomed.common.constants import (
     SecureAggregationSchemes,
     __breakpoints_version__,
 )
-from fedbiomed.common.exceptions import FedbiomedSecureAggregationError
+from fedbiomed.common.exceptions import (
+    FedbiomedExperimentError,
+    FedbiomedSecureAggregationError,
+    FedbiomedTypeError,
+    FedbiomedValueError,
+)
 from fedbiomed.researcher.datasets import FederatedDataset
 from fedbiomed.researcher.federated_workflows import FederatedWorkflow
 from fedbiomed.researcher.federated_workflows.preproc import FedCombatPreproc
@@ -111,7 +116,7 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
         self.assertDictEqual(exp.training_data().data(), self.fake_search_reply)
 
         # b. when tags, nodes and training data are provided, the latter takes precedence and tags are set to None
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedValueError):
             exp = FederatedWorkflow(
                 tags="some-tags", nodes=["wrong", "nodes"], training_data=_training_data
             )
@@ -126,16 +131,16 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
         self.assertEqual(exp.tags(), ["first", "second"])
 
         # Test invalid type and values
-        with self.assertRaises(SystemExit):  # FedbiomedValueError,
+        with self.assertRaises(FedbiomedValueError):
             exp.set_tags(None)
 
-        with self.assertRaises(SystemExit):  # FedbiomedValueError
+        with self.assertRaises(FedbiomedValueError):
             exp.set_tags([])
 
-        with self.assertRaises(SystemExit):  # FedbiomedTypeError
+        with self.assertRaises(FedbiomedTypeError):
             exp.set_tags(15)
 
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedTypeError):
             exp.set_tags(["x", "y", 15])
 
     def test_federated_workflow_03_set_nodes(self):
@@ -154,27 +159,27 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
         self.assertEqual(exp.nodes(), ["node-1", "node-2"])
 
         # Invalid arguments
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedTypeError):
             exp.set_nodes(["node-1", "node-2", 15])
 
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedTypeError):
             exp.set_nodes("invalid_type")
 
     def test_federated_workflow_04_set_training_data(self):
         exp = FederatedWorkflow()
 
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedValueError):
             exp.set_training_data(None, from_tags=False)
 
         # Invalid from_tags argument
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedTypeError):
             exp.set_training_data(None, from_tags="invalid-type")
 
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedValueError):
             exp.set_training_data("not-none", from_tags=True)
 
         # Invalid training_data argument
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedTypeError):
             exp.set_training_data("not-none", from_tags=False)
 
         self.assertEqual(exp.training_data().data(), {})
@@ -212,7 +217,7 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
 
             mock_exp_folder_creat.side_effect = lambda x: x
             # Invalid argument type
-            with self.assertRaises(SystemExit):
+            with self.assertRaises(FedbiomedExperimentError):
                 exp.set_experimentation_folder(15)
 
     def test_federated_workflow_06_set_preprocessing(self):
@@ -230,11 +235,11 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
             self.assertIsNone(exp.preprocessing)
 
         # Invalid type
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedTypeError):
             exp.set_preprocessing("invalid-type", preproc_args)
 
         # Invalid args
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedTypeError):
             exp.set_preprocessing(PreprocType.FEDCOMBAT, "invalid-args")
 
     def test_federated_workflow_07_set_secagg(self):
@@ -246,12 +251,12 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
         exp.set_secagg(_secagg)
         self.assertEqual(exp.secagg, _secagg)
 
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp.set_secagg("invalid")
 
         bad_schemes = [False, 3, None, "scheme", [SecureAggregationSchemes.LOM]]
         for scheme in bad_schemes:
-            with self.assertRaises(SystemExit):
+            with self.assertRaises(FedbiomedExperimentError):
                 exp.set_secagg(True, scheme)
 
     def test_federated_workflow_08_consistency_fds_tags(self):
@@ -273,7 +278,7 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
         self.assertDictEqual(exp.training_data().data(), self.fake_search_reply)
 
         # setting training data from tags, when tags is None -> raise error
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedValueError):
             exp.set_training_data(None, from_tags=True)
 
         # set tags when training data is not None -> reset training data based on new tags
@@ -444,7 +449,7 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
         # 3. Test error case: if open raises an exception
         mock_open.side_effect = OSError
 
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp.breakpoint(state={}, bkpt_number=1)
 
     @patch("fedbiomed.researcher.federated_workflows._federated_workflow.open")
@@ -464,7 +469,7 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
         mock_open,
     ):
         # Invalid argument should be string or None
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp, _, _ = FederatedWorkflow.load_breakpoint(breakpoint_folder_path=15)
 
         # Normal test case
@@ -548,14 +553,14 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
 
         # If open raises an exception
         mock_open.side_effect = OSError
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp, _, _ = FederatedWorkflow.load_breakpoint()
         mock_open.side_effect = None
 
         # If saved state is not dict
 
         mock_json_load.return_value = ["list"]
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp, _, _ = FederatedWorkflow.load_breakpoint()
 
     def test_federated_workflow_06_all_federation_nodes(self):
@@ -629,7 +634,7 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
         fw.set_save_breakpoints(True)
 
         # Invalid argument
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             fw.set_save_breakpoints("invalid")
 
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -261,6 +261,47 @@ class TestNode(unittest.TestCase):
         self.n1.on_message(self.ping_request.to_dict())
         self.grpc_send_mock.assert_called_once()
 
+    @patch("fedbiomed.common.tasks_queue.TasksQueue.add")
+    def test_node_03b_on_message_train_logs_request_lifecycle(
+        self, task_queue_add_patcher
+    ):
+        """Tests that train requests emit the new structured debug logs."""
+
+        with patch("fedbiomed.node.node.logger.debug") as logger_debug:
+            self.n1.on_message(self.train_request.to_dict())
+
+        task_queue_add_patcher.assert_called_once()
+
+        debug_calls = logger_debug.call_args_list
+        self.assertTrue(
+            any(
+                call.args[0]
+                == "Received researcher message type=%s req=%s researcher=%s experiment=%s dataset=%s round=%s"
+                and call.args[1:]
+                == (
+                    self.train_request.__name__,
+                    getattr(self.train_request, "request_id", None),
+                    self.train_request.researcher_id,
+                    self.train_request.experiment_id,
+                    self.train_request.dataset_id,
+                    self.train_request.round,
+                )
+                for call in debug_calls
+            )
+        )
+        self.assertTrue(
+            any(
+                call.args[0] == "Queueing node task type=%s req=%s experiment=%s"
+                and call.args[1:]
+                == (
+                    self.train_request.__name__,
+                    getattr(self.train_request, "request_id", None),
+                    self.train_request.experiment_id,
+                )
+                for call in debug_calls
+            )
+        )
+
     @patch("fedbiomed.node.node.SecaggManager")
     def test_node_04_on_message_normal_case_scenario_secagg_delete(self, skm):
         """Tests `on_message` method (normal case scenario), with secagg-delete command"""
@@ -583,6 +624,51 @@ class TestNode(unittest.TestCase):
 
         # checks
         self.grpc_send_mock.assert_called_once()
+
+    def test_node_21b_send_error_logs_debug_context(self):
+        """Tests `send_error` emits the new debug traces before and after dispatch."""
+
+        errnum = ErrorNumbers.FB100
+        extra_msg = "this is a test_send_error"
+        researcher_id = "researcher_id_1224"
+
+        with (
+            patch("fedbiomed.node.node.logger.debug") as logger_debug,
+            patch("fedbiomed.node.node.logger.error") as logger_error,
+        ):
+            self.n1.send_error(errnum, extra_msg, researcher_id)
+
+        self.grpc_send_mock.assert_called_once()
+        logger_error.assert_called_once()
+
+        debug_calls = logger_debug.call_args_list
+        self.assertTrue(
+            any(
+                call.args[0]
+                == "Preparing error reply errnum=%s req=%s researcher=%s broadcast=%s connected=%s destination=%s:%s msg_len=%d"
+                and call.args[1:]
+                == (
+                    errnum.name,
+                    None,
+                    researcher_id,
+                    False,
+                    False,
+                    "test",
+                    "5151",
+                    len(extra_msg),
+                )
+                and call.kwargs.get("stack_info") is True
+                for call in debug_calls
+            )
+        )
+        self.assertTrue(
+            any(
+                call.args[0]
+                == "Error reply dispatched errnum=%s req=%s researcher=%s broadcast=%s connected=%s"
+                and call.args[1:] == (errnum.name, None, researcher_id, False, False)
+                for call in debug_calls
+            )
+        )
 
     @patch("fedbiomed.node.node.SecaggSetup")
     def test_node_23_task_secagg(self, secagg_setup):

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -345,7 +345,39 @@ class TestNode(unittest.TestCase):
         mock_dataset_manager = MagicMock()
         mock_dataset_manager.dataset_table.get_by_id = MagicMock(return_value=None)
         self.n1.dataset_manager = mock_dataset_manager
-        self.n1.parser_task_train(self.train_request)
+        with patch("fedbiomed.node.node.logger.error") as logger_error:
+            self.n1.parser_task_train(self.train_request)
+
+            self.assertGreaterEqual(logger_error.call_count, 1)
+            messages = [call.args[0] for call in logger_error.call_args_list]
+            self.assertTrue(any(ErrorNumbers.FB313.value in m for m in messages))
+
+        error = self.grpc_send_mock.call_args.args[1]
+        self.assertIsInstance(error, ErrorMessage)
+
+    @patch("fedbiomed.node.node.Round", autospec=True)
+    @patch("fedbiomed.node.history_monitor.HistoryMonitor.__init__", spec=True)
+    def test_node_13b_parser_task_train_initialize_arguments_failure_returns_none_and_sends_error(
+        self,
+        history_monitor_patch,
+        round_patch,
+    ):
+        """If Round.initialize_arguments raises, parser_task_train must send an error and return None."""
+
+        history_monitor_patch.return_value = None
+        round_patch.return_value.initialize_arguments.side_effect = Exception(
+            "init-args-boom"
+        )
+
+        with (
+            patch("fedbiomed.node.node.logger.error") as logger_error,
+            patch("fedbiomed.node.node.logger.debug") as logger_debug,
+        ):
+            round_ = self.n1.parser_task_train(self.train_request)
+
+        self.assertIsNone(round_)
+        self.assertTrue(logger_error.called)
+        self.assertTrue(logger_debug.called)
 
         error = self.grpc_send_mock.call_args.args[1]
         self.assertIsInstance(error, ErrorMessage)
@@ -408,7 +440,7 @@ class TestNode(unittest.TestCase):
             researcher_id=dict_msg_1_dataset["researcher_id"],
             history_monitor=unittest.mock.ANY,
             aggregator_args=None,
-            node_args=None,
+            node_args={},
             tp_security_manager=ANY,
             round_number=1,
             dlp_and_loading_block_metadata=None,
@@ -470,7 +502,7 @@ class TestNode(unittest.TestCase):
             experiment_id=dict_msg_1_dataset["experiment_id"],
             researcher_id=dict_msg_1_dataset["researcher_id"],
             history_monitor=unittest.mock.ANY,
-            node_args=None,
+            node_args={},
             aggregator_args=None,
             round_number=0,
             dlp_and_loading_block_metadata=None,

--- a/tests/test_node_n2n_controller.py
+++ b/tests/test_node_n2n_controller.py
@@ -1,15 +1,15 @@
 import unittest
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fedbiomed.common.message import (
-    ChannelSetupRequest,
-    ChannelSetupReply,
-    KeyRequest,
-    KeyReply,
-    AdditiveSSharingRequest,
     AdditiveSSharingReply,
-    PingRequest,
+    AdditiveSSharingRequest,
+    ChannelSetupReply,
+    ChannelSetupRequest,
+    KeyReply,
+    KeyRequest,
     OverlayMessage,
+    PingRequest,
 )
 from fedbiomed.node.requests._n2n_controller import NodeToNodeController
 
@@ -85,6 +85,7 @@ class TestNodeToNodeController(unittest.IsolatedAsyncioTestCase, unittest.TestCa
                 [{"shares": {node_id: 12345}}],
                 [{"shares": {node_id: ["shares shares"]}}],
             ],
+            strict=True,
         ):
             # 1. public key is available
 
@@ -111,6 +112,48 @@ class TestNodeToNodeController(unittest.IsolatedAsyncioTestCase, unittest.TestCa
 
             # check
             self.assertIsNone(result)
+
+    async def test_n2n_controller_01b_handle_key_request_logs_debug_context(self):
+        """Handle key request emits structured debug logs for success and timeout."""
+
+        self.controller_data_mock.wait.return_value = [
+            True,
+            [{"public_key": b"my dummy pubkey"}],
+        ]
+
+        with patch(
+            "fedbiomed.node.requests._n2n_controller.logger.debug"
+        ) as logger_debug:
+            result = await self.n2n_controller.handle(self.overlay_msg, self.inner_msg)
+
+        self.assertIsInstance(result, dict)
+        self.assertTrue(
+            any(
+                "Handling node-to-node key request" in call.args[0]
+                and f"request_id={self.inner_msg.request_id}" in call.args[0]
+                and f"secagg_id={self.inner_msg.secagg_id}" in call.args[0]
+                for call in logger_debug.call_args_list
+            )
+        )
+
+        self.controller_data_mock.wait.return_value = [
+            False,
+            [{"public_key": b"my dummy pubkey"}],
+        ]
+
+        with patch(
+            "fedbiomed.node.requests._n2n_controller.logger.debug"
+        ) as logger_debug:
+            result = await self.n2n_controller.handle(self.overlay_msg, self.inner_msg)
+
+        self.assertIsNone(result)
+        self.assertTrue(
+            any(
+                "Node-to-node key request timed out" in call.args[0]
+                and f"request_id={self.inner_msg.request_id}" in call.args[0]
+                for call in logger_debug.call_args_list
+            )
+        )
 
     async def test_n2n_controller_02_handle_key_ASS_reply(self):
         """Handle incoming message KeyReply AdditiveSSharingReply in node to node controller"""
@@ -169,6 +212,35 @@ class TestNodeToNodeController(unittest.IsolatedAsyncioTestCase, unittest.TestCa
 
             self.grpc_controller_mock.reset_mock()
 
+    async def test_n2n_controller_04b_final_key_request_logs_debug_context(self):
+        """Final key request handler logs the outgoing overlay context."""
+
+        overlay_msg = OverlayMessage(
+            researcher_id="dummy researcher",
+            node_id="dummy source overlay node",
+            dest_node_id="dummy dest overlay node",
+            overlay=b"dummy overlay content",
+            setup=False,
+            salt=b"a dummy salt",
+            nonce=b"my own nonce",
+        )
+
+        with patch(
+            "fedbiomed.node.requests._n2n_controller.logger.debug"
+        ) as logger_debug:
+            await self.n2n_controller.final(
+                KeyRequest.__name__, overlay_resp=overlay_msg
+            )
+
+        self.grpc_controller_mock.send.assert_called_once_with(overlay_msg)
+        self.assertTrue(
+            any(
+                "Sending node-to-node key reply" in call.args[0]
+                and f"dest_node_id={overlay_msg.dest_node_id}" in call.args[0]
+                for call in logger_debug.call_args_list
+            )
+        )
+
     async def test_n2n_controller_04_final_key_ASS_reply(self):
         """Final handler for key/ASS reply in node to node controller"""
         for message_name in [
@@ -223,6 +295,31 @@ class TestNodeToNodeController(unittest.IsolatedAsyncioTestCase, unittest.TestCa
 
             # reset
             self.overlay_channel_mock.reset_mock()
+
+    async def test_n2n_controller_06b_final_channel_reply_logs_debug_context(self):
+        """Final channel reply handler logs the channel setup processing context."""
+
+        inner_msg = ChannelSetupReply(
+            node_id="dummy source inner node",
+            dest_node_id="dummy dest inner node",
+            request_id="dummy request id",
+            public_key=b"my public key",
+        )
+
+        with patch(
+            "fedbiomed.node.requests._n2n_controller.logger.debug"
+        ) as logger_debug:
+            await self.n2n_controller.final(
+                ChannelSetupReply.__name__, inner_msg=inner_msg
+            )
+
+        self.assertTrue(
+            any(
+                "Processing channel setup reply" in call.args[0]
+                and f"request_id={inner_msg.request_id}" in call.args[0]
+                for call in logger_debug.call_args_list
+            )
+        )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_node_overlay.py
+++ b/tests/test_node_overlay.py
@@ -1,20 +1,20 @@
-import os
-import unittest
-import tempfile
-from unittest.mock import patch, MagicMock
 import copy
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
 
+from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms
 
 from fedbiomed.common.exceptions import FedbiomedNodeToNodeError
-from fedbiomed.common.message import Message, KeyRequest, InnerMessage, OverlayMessage
+from fedbiomed.common.message import InnerMessage, KeyRequest, Message, OverlayMessage
 from fedbiomed.common.secagg._dh import DHKeyAgreement
 from fedbiomed.common.serializer import Serializer
-from fedbiomed.transport.controller import GrpcController
 from fedbiomed.node.requests._overlay import OverlayChannel, _ChannelKeys
+from fedbiomed.transport.controller import GrpcController
 
 
 class TestNodeRequestsChannelKeys(unittest.IsolatedAsyncioTestCase, unittest.TestCase):
@@ -75,27 +75,28 @@ class TestNodeRequestsChannelKeys(unittest.IsolatedAsyncioTestCase, unittest.Tes
         channel_keys2 = self.overlay_channel._channel_keys
 
         # action
-        local_key1a, distant_key1a = await self.channel_keys.get_keys(node1)
-        await self.channel_keys.add_pending_request(node1, request1)
-        set1 = await self.channel_keys.set_distant_key(
-            node1, self.default_private_key.export_public_key(), request1
-        )
-        local_key1b, distant_key1b = await self.channel_keys.get_keys(node1)
-        local_public1 = await self.channel_keys.get_local_public_key(node1)
+        with patch("fedbiomed.node.requests._overlay.logger.debug") as logger_debug:
+            local_key1a, distant_key1a = await self.channel_keys.get_keys(node1)
+            await self.channel_keys.add_pending_request(node1, request1)
+            set1 = await self.channel_keys.set_distant_key(
+                node1, self.default_private_key.export_public_key(), request1
+            )
+            local_key1b, distant_key1b = await self.channel_keys.get_keys(node1)
+            local_public1 = await self.channel_keys.get_local_public_key(node1)
 
-        local_key2a, distant_key2a = await channel_keys2.get_keys(node2)
-        await channel_keys2.add_pending_request(node2, request2)
-        set2 = await self.overlay_channel.set_distant_key(
-            node2, self.default_private_key.export_public_key(), request2
-        )
-        local_key2b, distant_key2b = await channel_keys2.get_keys(node2)
-        local_public2 = await self.overlay_channel.get_local_public_key(node2)
+            local_key2a, distant_key2a = await channel_keys2.get_keys(node2)
+            await channel_keys2.add_pending_request(node2, request2)
+            set2 = await self.overlay_channel.set_distant_key(
+                node2, self.default_private_key.export_public_key(), request2
+            )
+            local_key2b, distant_key2b = await channel_keys2.get_keys(node2)
+            local_public2 = await self.overlay_channel.get_local_public_key(node2)
 
-        set3 = await self.channel_keys.set_distant_key(
-            "non existing node",
-            self.default_private_key.export_public_key(),
-            "any request",
-        )
+            set3 = await self.channel_keys.set_distant_key(
+                "non existing node",
+                self.default_private_key.export_public_key(),
+                "any request",
+            )
 
         # test
         self.assertEqual(local_key1a, local_key1b)
@@ -117,6 +118,20 @@ class TestNodeRequestsChannelKeys(unittest.IsolatedAsyncioTestCase, unittest.Tes
         self.assertEqual(local_public2, local_key2a.export_public_key())
 
         self.assertFalse(set3)
+        debug_messages = [call.args[0] for call in logger_debug.call_args_list]
+        self.assertTrue(
+            any("Creating node-to-node channel state" in msg for msg in debug_messages)
+        )
+        self.assertTrue(
+            any(
+                "Registered pending node-to-node channel request" in msg
+                for msg in debug_messages
+            )
+        )
+        self.assertTrue(any("Stored distant node key" in msg for msg in debug_messages))
+        self.assertTrue(
+            any("Ignoring distant node key update" in msg for msg in debug_messages)
+        )
 
     async def test_channel_keys_02_wait_ready_channel(self):
         """Test channel keys object wait_ready_channel"""
@@ -223,21 +238,22 @@ class TestNodeRequestsOverlayChannel(
         # 1. correct message
 
         # action
-        payload, salt, nonce = await self.overlay_channel.format_outgoing_overlay(
-            src_message, researcher_id, setup=True
-        )
-        overlay_message = OverlayMessage(
-            researcher_id=researcher_id,
-            node_id=node_id,
-            dest_node_id=dest_node_id,
-            overlay=payload,
-            setup=True,
-            salt=salt,
-            nonce=nonce,
-        )
-        dest_message = await self.overlay_channel.format_incoming_overlay(
-            overlay_message
-        )
+        with patch("fedbiomed.node.requests._overlay.logger.debug") as logger_debug:
+            payload, salt, nonce = await self.overlay_channel.format_outgoing_overlay(
+                src_message, researcher_id, setup=True
+            )
+            overlay_message = OverlayMessage(
+                researcher_id=researcher_id,
+                node_id=node_id,
+                dest_node_id=dest_node_id,
+                overlay=payload,
+                setup=True,
+                salt=salt,
+                nonce=nonce,
+            )
+            dest_message = await self.overlay_channel.format_incoming_overlay(
+                overlay_message
+            )
 
         # check
         self.assertIsInstance(dest_message, InnerMessage)
@@ -246,6 +262,19 @@ class TestNodeRequestsOverlayChannel(
         )
         for k in src_message.get_dict().keys():
             self.assertEqual(src_message.get_param(k), dest_message.get_param(k))
+        debug_messages = [call.args[0] for call in logger_debug.call_args_list]
+        self.assertTrue(
+            any("Formatting outgoing overlay message" in msg for msg in debug_messages)
+        )
+        self.assertTrue(
+            any("Formatted outgoing overlay payload" in msg for msg in debug_messages)
+        )
+        self.assertTrue(
+            any("Formatting incoming overlay message" in msg for msg in debug_messages)
+        )
+        self.assertTrue(
+            any("Validated incoming overlay message" in msg for msg in debug_messages)
+        )
 
         # 2. node_id mismatch
         overlay_message.node_id = "another node id"

--- a/tests/test_round.py
+++ b/tests/test_round.py
@@ -281,6 +281,104 @@ class TestRound(unittest.TestCase):
             # Check that the model weights were saved.
             mock_after_training_params.assert_called_once()
 
+    def test_round_02b_run_model_training_debug_flag_controls_error_details_logging(
+        self,
+    ):
+        """Tests that `Round._debug` controls whether detailed error logs are emitted.
+
+        `run_model_training` has multiple `if self._debug: logger.error(... Details: ...)` branches.
+        Here we force an early failure and assert that the detailed log is only emitted when
+        debug is enabled.
+        """
+
+        # Force training plan import/instantiation failure at the start of `run_model_training`.
+        original_side_effect = self.ic_from_spec_mock.side_effect
+        self.ic_from_spec_mock.side_effect = Exception("boom")
+
+        try:
+            for debug in (False, True):
+                with self.subTest(debug=debug):
+                    self.r1._debug = debug
+                    self.r1.initialize_arguments()
+
+                    with patch("fedbiomed.node.round.logger.error") as logger_error:
+                        msg = self.r1.run_model_training(
+                            tp_approval=False,
+                            secagg_active=False,
+                            force_secagg=False,
+                            secagg_insecure_validation=True,
+                        )
+
+                        # Always fail with the generic message returned to the researcher.
+                        self.assertFalse(msg.get_dict().get("success", True))
+                        self.assertEqual(
+                            msg.get_dict().get("msg"),
+                            "Cannot instantiate training plan object.",
+                        )
+
+                        if debug:
+                            logger_error.assert_called_once()
+                            log_msg = logger_error.call_args.args[0]
+                            self.assertIn(
+                                "Cannot instantiate training plan object.", log_msg
+                            )
+                            self.assertIn("Details:", log_msg)
+                            self.assertIn("boom", log_msg)
+                        else:
+                            logger_error.assert_not_called()
+        finally:
+            self.ic_from_spec_mock.side_effect = original_side_effect
+
+    def test_round_02c_run_model_training_training_routine_exception_logs_only_in_debug(
+        self,
+    ):
+        """Tests the `training_routine` exception path in `run_model_training`.
+
+        When `training_routine` raises, `run_model_training` must return a failure reply with
+        the exception details in the message, and only log an error if debug is enabled.
+        """
+
+        def _fake_set_loaders():
+            # Ensure we go through the training branch.
+            self.r1.training_plan.training_data_loader = object()
+            self.r1.training_plan.testing_data_loader = None
+
+        with (
+            patch.object(
+                self.r1,
+                "_set_training_testing_data_loaders",
+                side_effect=_fake_set_loaders,
+            ),
+            patch.object(
+                FakeModel, "training_routine", side_effect=Exception("boom-train")
+            ),
+        ):
+            for debug in (False, True):
+                with self.subTest(debug=debug):
+                    self.r1._debug = debug
+                    self.r1.initialize_arguments()
+
+                    with patch("fedbiomed.node.round.logger.error") as logger_error:
+                        msg = self.r1.run_model_training(
+                            tp_approval=False,
+                            secagg_active=False,
+                            force_secagg=False,
+                            secagg_insecure_validation=True,
+                        )
+
+                        self.assertFalse(msg.get_dict().get("success", True))
+                        self.assertIn(
+                            "Cannot train model in round:",
+                            msg.get_dict().get("msg", ""),
+                        )
+
+                        if debug:
+                            logger_error.assert_called_once_with(
+                                "Cannot train model in round: Exception('boom-train')"
+                            )
+                        else:
+                            logger_error.assert_not_called()
+
     @patch("fedbiomed.node.round.Round._split_train_and_test_data")
     @patch(
         "fedbiomed.node.training_plan_security_manager.TrainingPlanSecurityManager.check_training_plan_status"

--- a/tests/test_round.py
+++ b/tests/test_round.py
@@ -284,11 +284,9 @@ class TestRound(unittest.TestCase):
     def test_round_02b_run_model_training_debug_flag_controls_error_details_logging(
         self,
     ):
-        """Tests that `Round._debug` controls whether detailed error logs are emitted.
+        """Tests that `run_model_training` logs details on early failures.
 
-        `run_model_training` has multiple `if self._debug: logger.error(... Details: ...)` branches.
-        Here we force an early failure and assert that the detailed log is only emitted when
-        debug is enabled.
+        The code logs an error with exception details and a debug traceback extract.
         """
 
         # Force training plan import/instantiation failure at the start of `run_model_training`.
@@ -296,36 +294,39 @@ class TestRound(unittest.TestCase):
         self.ic_from_spec_mock.side_effect = Exception("boom")
 
         try:
-            for debug in (False, True):
-                with self.subTest(debug=debug):
-                    self.r1._debug = debug
-                    self.r1.initialize_arguments()
+            self.r1.initialize_arguments()
 
-                    with patch("fedbiomed.node.round.logger.error") as logger_error:
-                        msg = self.r1.run_model_training(
-                            tp_approval=False,
-                            secagg_active=False,
-                            force_secagg=False,
-                            secagg_insecure_validation=True,
-                        )
+            with (
+                patch("fedbiomed.node.round.logger.error") as logger_error,
+                patch("fedbiomed.node.round.logger.debug") as logger_debug,
+            ):
+                msg = self.r1.run_model_training(
+                    tp_approval=False,
+                    secagg_active=False,
+                    force_secagg=False,
+                    secagg_insecure_validation=True,
+                )
 
-                        # Always fail with the generic message returned to the researcher.
-                        self.assertFalse(msg.get_dict().get("success", True))
-                        self.assertEqual(
-                            msg.get_dict().get("msg"),
-                            "Cannot instantiate training plan object.",
-                        )
+                self.assertFalse(msg.get_dict().get("success", True))
+                self.assertEqual(
+                    msg.get_dict().get("msg"),
+                    "Cannot instantiate training plan object.",
+                )
 
-                        if debug:
-                            logger_error.assert_called_once()
-                            log_msg = logger_error.call_args.args[0]
-                            self.assertIn(
-                                "Cannot instantiate training plan object.", log_msg
-                            )
-                            self.assertIn("Details:", log_msg)
-                            self.assertIn("boom", log_msg)
-                        else:
-                            logger_error.assert_not_called()
+                logger_error.assert_called_once()
+                log_msg = logger_error.call_args.args[0]
+                self.assertIn("Cannot instantiate training plan object.", log_msg)
+                self.assertIn("Details:", log_msg)
+                self.assertIn("boom", log_msg)
+
+                self.assertTrue(logger_debug.called)
+                debug_messages = [call.args[0] for call in logger_debug.call_args_list]
+                self.assertTrue(
+                    any(
+                        "Training plan instantiation error details" in m
+                        for m in debug_messages
+                    )
+                )
         finally:
             self.ic_from_spec_mock.side_effect = original_side_effect
 
@@ -335,7 +336,7 @@ class TestRound(unittest.TestCase):
         """Tests the `training_routine` exception path in `run_model_training`.
 
         When `training_routine` raises, `run_model_training` must return a failure reply with
-        the exception details in the message, and only log an error if debug is enabled.
+        exception details in the message and log error + debug traceback.
         """
 
         def _fake_set_loaders():
@@ -353,31 +354,34 @@ class TestRound(unittest.TestCase):
                 FakeModel, "training_routine", side_effect=Exception("boom-train")
             ),
         ):
-            for debug in (False, True):
-                with self.subTest(debug=debug):
-                    self.r1._debug = debug
-                    self.r1.initialize_arguments()
+            self.r1.initialize_arguments()
 
-                    with patch("fedbiomed.node.round.logger.error") as logger_error:
-                        msg = self.r1.run_model_training(
-                            tp_approval=False,
-                            secagg_active=False,
-                            force_secagg=False,
-                            secagg_insecure_validation=True,
-                        )
+            with (
+                patch("fedbiomed.node.round.logger.error") as logger_error,
+                patch("fedbiomed.node.round.logger.debug") as logger_debug,
+            ):
+                msg = self.r1.run_model_training(
+                    tp_approval=False,
+                    secagg_active=False,
+                    force_secagg=False,
+                    secagg_insecure_validation=True,
+                )
 
-                        self.assertFalse(msg.get_dict().get("success", True))
-                        self.assertIn(
-                            "Cannot train model in round:",
-                            msg.get_dict().get("msg", ""),
-                        )
+                self.assertFalse(msg.get_dict().get("success", True))
+                self.assertIn(
+                    "Cannot train model in round:",
+                    msg.get_dict().get("msg", ""),
+                )
 
-                        if debug:
-                            logger_error.assert_called_once_with(
-                                "Cannot train model in round: Exception('boom-train')"
-                            )
-                        else:
-                            logger_error.assert_not_called()
+                logger_error.assert_called_once_with(
+                    "Cannot train model in round: Exception('boom-train')"
+                )
+
+                self.assertTrue(logger_debug.called)
+                debug_messages = [call.args[0] for call in logger_debug.call_args_list]
+                self.assertTrue(
+                    any("Training error details" in m for m in debug_messages)
+                )
 
     @patch("fedbiomed.node.round.Round._split_train_and_test_data")
     @patch(

--- a/tests/test_round.py
+++ b/tests/test_round.py
@@ -388,6 +388,108 @@ class TestRound(unittest.TestCase):
         "fedbiomed.node.training_plan_security_manager.TrainingPlanSecurityManager.check_training_plan_status"
     )
     @patch("uuid.uuid4")
+    def test_round_02d_run_model_training_logs_start_context(
+        self, uuid_patch, tp_security_manager_patch, mock_split_test_train_data
+    ):
+        """Tests that successful training emits the structured round start debug log."""
+
+        FakeModel.SLEEPING_TIME = 0
+        uuid_patch.return_value = FakeUuid()
+        tp_security_manager_patch.return_value = (True, {"name": "model_name"})
+        mock_split_test_train_data.return_value = (FakeLoader, FakeLoader)
+
+        self.r1.initialize_arguments()
+
+        with patch("fedbiomed.node.round.logger.debug") as logger_debug:
+            msg = self.r1.run_model_training(
+                tp_approval=False,
+                secagg_active=False,
+                force_secagg=False,
+                secagg_insecure_validation=True,
+            )
+
+        self.assertTrue(msg.get_dict().get("success", False))
+        self.assertTrue(
+            any(
+                call.args[0]
+                == "Starting round execution: node_id=%s experiment=%s round=%s training=%s dataset=%s secagg_active=%s force_secagg=%s dp_active=%s secagg_args_keys=%s"
+                and call.args[1:]
+                == (
+                    self.r1._node_id,
+                    self.r1.experiment_id,
+                    self.r1._round,
+                    self.r1.training,
+                    self.r1.dataset.get("dataset_id"),
+                    False,
+                    False,
+                    False,
+                    [],
+                )
+                for call in logger_debug.call_args_list
+            )
+        )
+
+    def test_round_02e_send_round_reply_logs_build_context(self):
+        """Tests `_send_round_reply` emits the new debug logs when building replies."""
+
+        extend_with = {
+            "encrypted": True,
+            "params": {"weights": [1, 2]},
+            "optim_aux_var": {"scaffold": 1},
+        }
+        timing = {"total_time": 1.23}
+
+        with patch("fedbiomed.node.round.logger.debug") as logger_debug:
+            reply = self.r1._send_round_reply(
+                success=True,
+                message="ok",
+                extend_with=extend_with,
+                timing=timing,
+            )
+
+        self.assertTrue(reply.success)
+        self.assertEqual(reply.dataset_id, self.r1.dataset["dataset_id"])
+        self.assertTrue(
+            any(
+                call.args[0]
+                == "Building round reply: experiment=%s round=%s success=%s message=%s extend_keys=%s timing_keys=%s encrypted=%s has_params=%s has_aux_var=%s"
+                and call.args[1:]
+                == (
+                    self.r1.experiment_id,
+                    self.r1._round,
+                    True,
+                    True,
+                    sorted(extend_with.keys()),
+                    sorted(timing.keys()),
+                    True,
+                    True,
+                    True,
+                )
+                for call in logger_debug.call_args_list
+            )
+        )
+        self.assertTrue(
+            any(
+                call.args[0]
+                == "Built round reply: experiment=%s round=%s reply_type=%s success=%s encrypted=%s dataset=%s"
+                and call.args[1:]
+                == (
+                    self.r1.experiment_id,
+                    self.r1._round,
+                    reply.__class__.__name__,
+                    True,
+                    True,
+                    self.r1.dataset["dataset_id"],
+                )
+                for call in logger_debug.call_args_list
+            )
+        )
+
+    @patch("fedbiomed.node.round.Round._split_train_and_test_data")
+    @patch(
+        "fedbiomed.node.training_plan_security_manager.TrainingPlanSecurityManager.check_training_plan_status"
+    )
+    @patch("uuid.uuid4")
     def test_round_03_test_run_model_training_with_real_model(
         self, uuid_patch, tp_security_manager_patch, mock_split_train_and_test_data
     ):

--- a/tests/test_round.py
+++ b/tests/test_round.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, PropertyMock, create_autospec, patch
 
 import numpy as np
 import pandas as pd
+import pytest
 import torch
 from testsupport import fake_training_plan
 from testsupport.fake_training_plan import DeclearnAuxVarModel, FakeModel
@@ -26,7 +27,11 @@ from fedbiomed.common.dataloadingplan import DataLoadingPlan, DataLoadingPlanMix
 from fedbiomed.common.datamanager import DataManager
 from fedbiomed.common.dataset import Dataset
 from fedbiomed.common.dataset_types import DataReturnFormat
-from fedbiomed.common.exceptions import FedbiomedOptimizerError, FedbiomedRoundError
+from fedbiomed.common.exceptions import (
+    FedbiomedError,
+    FedbiomedOptimizerError,
+    FedbiomedRoundError,
+)
 from fedbiomed.common.logger import logger
 from fedbiomed.common.message import TrainReply
 from fedbiomed.common.models import Model, TorchModel
@@ -51,6 +56,16 @@ from fedbiomed.node.training_plan_security_manager import TrainingPlanSecurityMa
 # Needed to access length of dataset from Round class
 class FakeLoader:
     dataset = [1, 2, 3, 4, 5]
+
+
+@pytest.fixture
+def round():
+    fixture = TestRound()
+    fixture.setUp()
+    try:
+        yield fixture
+    finally:
+        fixture.tearDown()
 
 
 class TestRound(unittest.TestCase):
@@ -1391,6 +1406,90 @@ class TestRound(unittest.TestCase):
         self.state_manager_mock.return_value.initialize.assert_called_once_with(
             previous_state_id=previous_state_id, testing=False
         )
+
+
+########################################
+###### ADDING NEW TESTS IN PYTEST ######
+########################################
+
+
+def test_round_run_model_training_model_params_init_error(monkeypatch, round):
+    class DummyTrainingPlan:
+        def post_init(self, model_args=None, training_args=None, aggregator_args=None):
+            return None
+
+        def set_model_params(self, params):
+            raise Exception("boom")
+
+    monkeypatch.setattr("uuid.uuid4", lambda: FakeUuid())
+    monkeypatch.setattr(
+        "fedbiomed.node.training_plan_security_manager.TrainingPlanSecurityManager.check_training_plan_status",
+        lambda *args, **kwargs: (True, {"name": "model_name"}),
+    )
+
+    round.ic_from_file_mock.return_value = (object(), DummyTrainingPlan())
+
+    round.r1.initialize_arguments()
+    reply = round.r1.run_model_training(
+        tp_approval=False,
+        secagg_active=False,
+        force_secagg=False,
+        secagg_insecure_validation=True,
+    )
+
+    assert reply.success is False
+
+
+def test_round_run_model_training_data_loader_fedbiomed_error(monkeypatch, round):
+    monkeypatch.setattr("uuid.uuid4", lambda: FakeUuid())
+    monkeypatch.setattr(
+        "fedbiomed.node.training_plan_security_manager.TrainingPlanSecurityManager.check_training_plan_status",
+        lambda *args, **kwargs: (True, {"name": "model_name"}),
+    )
+    monkeypatch.setattr(
+        round.r1,
+        "_split_train_and_test_data",
+        lambda *args, **kwargs: (_ for _ in ()).throw(FedbiomedError("bad loader")),
+    )
+
+    round.r1.initialize_arguments()
+    reply = round.r1.run_model_training(
+        tp_approval=False,
+        secagg_active=False,
+        force_secagg=False,
+        secagg_insecure_validation=True,
+    )
+
+    assert reply.success is False
+    assert "Can not create validation/train data" in reply.msg
+    assert "bad loader" in reply.msg
+
+
+def test_round_run_model_training_data_loader_unexpected_error(monkeypatch, round):
+    monkeypatch.setattr("uuid.uuid4", lambda: FakeUuid())
+    monkeypatch.setattr(
+        "fedbiomed.node.training_plan_security_manager.TrainingPlanSecurityManager.check_training_plan_status",
+        lambda *args, **kwargs: (True, {"name": "model_name"}),
+    )
+    monkeypatch.setattr(
+        round.r1,
+        "_split_train_and_test_data",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            Exception("unexpected loader failure")
+        ),
+    )
+
+    round.r1.initialize_arguments()
+    reply = round.r1.run_model_training(
+        tp_approval=False,
+        secagg_active=False,
+        force_secagg=False,
+        secagg_insecure_validation=True,
+    )
+
+    assert reply.success is False
+    assert "Undetermined error while creating data for training/validation" in reply.msg
+    assert "unexpected loader failure" in reply.msg
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_round.py
+++ b/tests/test_round.py
@@ -427,18 +427,12 @@ class TestRound(unittest.TestCase):
         self.assertTrue(
             any(
                 call.args[0]
-                == "Starting round execution: node_id=%s experiment=%s round=%s training=%s dataset=%s secagg_active=%s force_secagg=%s dp_active=%s secagg_args_keys=%s"
-                and call.args[1:]
                 == (
-                    self.r1._node_id,
-                    self.r1.experiment_id,
-                    self.r1._round,
-                    self.r1.training,
-                    self.r1.dataset.get("dataset_id"),
-                    False,
-                    False,
-                    False,
-                    [],
+                    f"Starting round execution: node_id={self.r1._node_id} "
+                    f"experiment={self.r1.experiment_id} round={self.r1._round} "
+                    f"training={self.r1.training} dataset={self.r1.dataset.get('dataset_id')} "
+                    "secagg_active=False force_secagg=False "
+                    "dp_active=False secagg_args_keys=[]"
                 )
                 for call in logger_debug.call_args_list
             )

--- a/tests/test_training_plan_workflow.py
+++ b/tests/test_training_plan_workflow.py
@@ -10,7 +10,10 @@ from testsupport.fake_training_plan import (
 )
 
 import fedbiomed
-from fedbiomed.common.exceptions import FedbiomedExperimentError
+from fedbiomed.common.exceptions import (
+    FedbiomedExperimentError,
+    FedbiomedTypeError,
+)
 from fedbiomed.common.training_args import TrainingArgs
 from fedbiomed.common.training_plans import (
     BaseTrainingPlan,
@@ -62,13 +65,13 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
         def DummyMethod():
             pass
 
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedTypeError):
             TrainingPlanWorkflow(training_plan_class=DummyMethod)
 
         class MyTrainingPlan(dict):
             pass
 
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedTypeError):
             TrainingPlanWorkflow(training_plan_class=MyTrainingPlan)
 
         exp = TrainingPlanWorkflow()
@@ -165,11 +168,11 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
         class DummyInvalidTPClass:
             pass
 
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp.set_training_plan_class(DummyInvalidTPClass)
 
         # Type invalid type of training plan class
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp.set_training_plan_class("Invalid")
 
     def test_training_plan_workflow_03_set_model_args(self):
@@ -193,7 +196,7 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
         self.mock_tp.set_model_params.assert_called_once_with({"model": "new-params"})
 
         # Invalid model args type
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp.set_model_args("invalid-type")
 
     def test_training_plan_workflow_04_approval(self):
@@ -210,7 +213,7 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
             training_plan_class=FakeTorchTrainingPlan, training_data=_training_data
         )
 
-        response = exp.training_plan_approve(description="some description")
+        exp.training_plan_approve(description="some description")
         mock_approval_job.execute.assert_called_once_with()
 
     def test_training_plan_workflow_05_status(self):
@@ -227,12 +230,12 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
             training_plan_class=FakeTorchTrainingPlan, training_data=_training_data
         )
 
-        status = exp.check_training_plan_status()
+        exp.check_training_plan_status()
         mock_approval_job.execute.assert_called_once_with()
 
         # Error cases where training data is no
         exp._fds = None
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp.check_training_plan_status()
 
     @patch("fedbiomed.common.serializer.Serializer.dump")
@@ -341,7 +344,7 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
 
         # Invalid type of training args argument
 
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             exp.set_training_args(True)
 
     @patch("builtins.open")
@@ -354,14 +357,14 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
         file = exp.training_plan_file()
         self.assertEqual(file, "path/to/training-plan.py")
 
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             file = exp.training_plan_file(display="invalid-type")
 
         file = exp.training_plan_file(display=True)
         mock_open.assert_called()
 
         mock_open.side_effect = OSError
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(FedbiomedExperimentError):
             file = exp.training_plan_file(display=True)
 
     def test_training_plan_workflow_10_info(self):

--- a/tests/test_transport_client.py
+++ b/tests/test_transport_client.py
@@ -3,11 +3,16 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import grpc
-from testsupport.mock import AsyncMock
 
 from fedbiomed.common.constants import MAX_RETRIEVE_ERROR_RETRIES, MAX_SEND_RETRIES
 from fedbiomed.common.exceptions import FedbiomedCommunicationError
-from fedbiomed.common.message import FeedbackMessage, Log, Scalar, SearchReply
+from fedbiomed.common.message import (
+    FeedbackMessage,
+    Log,
+    Scalar,
+    SearchReply,
+    SearchRequest,
+)
 from fedbiomed.transport.client import (
     Channels,
     ClientStatus,
@@ -120,6 +125,10 @@ class TestTaskListener(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.serializer_patch = patch("fedbiomed.transport.client.Serializer")
         self.serializer_mock = self.serializer_patch.start()
+        self.serializer_mock.loads.return_value = SearchRequest(
+            researcher_id="test-researcher-id",
+            tags=["test"],
+        ).to_dict()
         self.node_id = "test-node-id"
         self.on_status_change = AsyncMock()
         self.update_id = AsyncMock()
@@ -141,8 +150,6 @@ class TestTaskListener(unittest.IsolatedAsyncioTestCase):
         pass
 
     async def test_task_listener_01_listen(self):
-        self.serializer_mock.load.return_value = {"researcher_id": "test-researcher-id"}
-
         async def async_iterator(items):
             for item in items:
                 yield item
@@ -165,7 +172,7 @@ class TestTaskListener(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(asyncio.CancelledError):
             await task
 
-        # self.callback.assert_called_once()
+        self.callback.assert_called_once()
         self.serializer_mock.loads.assert_called_once()
         self.assertEqual(request_stub.GetTaskUnary.call_count, 2)
         self.update_id.assert_called_once()

--- a/tests/test_transport_client.py
+++ b/tests/test_transport_client.py
@@ -167,15 +167,21 @@ class TestTaskListener(unittest.IsolatedAsyncioTestCase):
             ),
             asyncio.CancelledError,
         ]
-        task = self.task_listener.listen(self.callback)
+        with patch("fedbiomed.transport.client.logger.debug") as logger_debug:
+            task = self.task_listener.listen(self.callback)
 
-        with self.assertRaises(asyncio.CancelledError):
-            await task
+            with self.assertRaises(asyncio.CancelledError):
+                await task
 
         self.callback.assert_called_once()
         self.serializer_mock.loads.assert_called_once()
         self.assertEqual(request_stub.GetTaskUnary.call_count, 2)
         self.update_id.assert_called_once()
+        debug_messages = [call.args[0] for call in logger_debug.call_args_list]
+        self.assertTrue(
+            any("Polling researcher for task" in msg for msg in debug_messages)
+        )
+        self.assertTrue(any("[WIRE][S->N][RX]" in msg for msg in debug_messages))
 
         # Cancel the task for next test
         task.cancel()
@@ -450,10 +456,17 @@ class TestSender(unittest.IsolatedAsyncioTestCase):
         await self.sender.send(message=self.message_log)
         await self.sender.send(message=self.message_log)
 
-        task = self.sender.listen()
-        with self.assertRaises(asyncio.CancelledError):
-            await task
+        with patch("fedbiomed.transport.client.logger.debug") as logger_debug:
+            task = self.sender.listen()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
         self.assertEqual(self.channels.feedback_stub.Feedback.call_count, 2)
+        self.assertTrue(
+            any(
+                "[WIRE][N->S][TX]" in call.args[0]
+                for call in logger_debug.call_args_list
+            )
+        )
 
         task.cancel()
 
@@ -466,14 +479,21 @@ class TestSender(unittest.IsolatedAsyncioTestCase):
         await self.sender.send(message=self.message_search)
         await self.sender.send(message=self.message_search)
 
-        task = self.sender.listen()
-        with self.assertRaises(asyncio.CancelledError):
-            await task
+        with patch("fedbiomed.transport.client.logger.debug") as logger_debug:
+            task = self.sender.listen()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
 
         task.cancel()
         self.assertEqual(self.channels.task_stub.ReplyTask.call_count, 2)
         stream_call.write.assert_called_once()
         stream_call.done_writing.assert_called_once()
+        self.assertTrue(
+            any(
+                "[WIRE][N->S][TX]" in call.args[0]
+                for call in logger_debug.call_args_list
+            )
+        )
 
     @patch("fedbiomed.transport.client.asyncio.sleep")
     async def test_sender_02_listen_exceptions(self, sleep):

--- a/tests/test_transport_node_agent.py
+++ b/tests/test_transport_node_agent.py
@@ -2,14 +2,33 @@ import asyncio
 import unittest
 from unittest.mock import MagicMock, patch
 
-from fedbiomed.common.message import SearchRequest
+import pytest
+
+from fedbiomed.common.message import OverlayMessage, SearchRequest
 from fedbiomed.transport.node_agent import (
     AgentStore,
     NodeActiveStatus,
     NodeAgent,
+    NodeAgentAsync,
 )
 
 message = MagicMock(spec=SearchRequest)
+
+
+@pytest.fixture
+def node_agent():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    fixture = TestNodeAgent()
+    fixture.setUp()
+
+    try:
+        yield fixture
+    finally:
+        fixture.tearDown()
+        loop.close()
+        asyncio.set_event_loop(None)
 
 
 class TestNodeAgent(unittest.IsolatedAsyncioTestCase):
@@ -113,6 +132,156 @@ class TestAgentStore(unittest.IsolatedAsyncioTestCase):
 
         result = await self.agent_store.get("node-id-1")
         self.assertEqual(result.id, "node-id-1")
+
+
+def test_node_agent_flush_marks_stopped_request(node_agent):
+    node_agent.node_agent._replies["req-1"] = {
+        "reply": None,
+        "callback": lambda msg: None,
+    }
+
+    node_agent.loop.run_until_complete(
+        NodeAgentAsync.flush(node_agent.node_agent, "req-1", stopped=True)
+    )
+
+    assert "req-1" in node_agent.node_agent._replies
+    assert "req-1" in node_agent.node_agent._stopped_request_ids
+
+
+def test_node_agent_on_reply_pending_request(monkeypatch, node_agent):
+    class DummyReply:
+        request_id = "req-2"
+
+    seen = {"reply": None}
+
+    def callback(reply):
+        seen["reply"] = reply
+
+    node_agent.node_agent._replies["req-2"] = {"reply": None, "callback": callback}
+
+    monkeypatch.setattr(
+        "fedbiomed.transport.node_agent.Message.from_dict",
+        lambda _: DummyReply(),
+    )
+
+    node_agent.loop.run_until_complete(node_agent.node_agent.on_reply({}))
+
+    assert node_agent.node_agent._replies["req-2"]["reply"].request_id == "req-2"
+    assert seen["reply"].request_id == "req-2"
+
+
+def test_node_agent_on_reply_overlay_message(monkeypatch, node_agent):
+    seen = {"reply": None}
+
+    def callback(reply):
+        seen["reply"] = reply
+
+    overlay = object.__new__(OverlayMessage)
+    overlay.request_id = "req-overlay"
+
+    node_agent.node_agent._replies["req-overlay"] = {
+        "reply": None,
+        "callback": callback,
+    }
+
+    monkeypatch.setattr(
+        "fedbiomed.transport.node_agent.Message.from_dict",
+        lambda _: overlay,
+    )
+
+    node_agent.loop.run_until_complete(node_agent.node_agent.on_reply({}))
+
+    assert node_agent.node_agent._replies["req-overlay"]["reply"] is overlay
+    assert seen["reply"] is overlay
+
+
+def test_node_agent_on_reply_multiple_reply_warning(monkeypatch, node_agent):
+    """Covers the branch where a second reply arrives for the same request."""
+
+    class DummyReply:
+        request_id = "req-dup"
+
+    warnings = {"count": 0}
+
+    def fake_warning(*args, **kwargs):
+        warnings["count"] += 1
+
+    node_agent.node_agent._replies["req-dup"] = {
+        "reply": object(),
+        "callback": lambda msg: None,
+    }
+
+    monkeypatch.setattr(
+        "fedbiomed.transport.node_agent.Message.from_dict",
+        lambda _: DummyReply(),
+    )
+    monkeypatch.setattr("fedbiomed.transport.node_agent.logger.warning", fake_warning)
+
+    node_agent.loop.run_until_complete(node_agent.node_agent.on_reply({}))
+
+    assert warnings["count"] == 1
+
+
+def test_node_agent_on_reply_none_request_id_unexpected_warning(
+    monkeypatch, node_agent
+):
+    """In this implementation, request_id=None does not log error.
+    It falls through to the unexpected-request warning branch.
+    """
+
+    class DummyReply:
+        request_id = None
+
+    warnings = {"count": 0}
+
+    def fake_warning(*args, **kwargs):
+        warnings["count"] += 1
+
+    monkeypatch.setattr(
+        "fedbiomed.transport.node_agent.Message.from_dict",
+        lambda _: DummyReply(),
+    )
+    monkeypatch.setattr("fedbiomed.transport.node_agent.logger.warning", fake_warning)
+
+    node_agent.loop.run_until_complete(node_agent.node_agent.on_reply({}))
+
+    assert warnings["count"] == 1
+
+
+def test_node_agent_on_reply_stopped_request(monkeypatch, node_agent):
+    class DummyReply:
+        request_id = "req-3"
+
+    node_agent.node_agent._stopped_request_ids.append("req-3")
+
+    monkeypatch.setattr(
+        "fedbiomed.transport.node_agent.Message.from_dict",
+        lambda _: DummyReply(),
+    )
+
+    node_agent.loop.run_until_complete(node_agent.node_agent.on_reply({}))
+
+    assert "req-3" not in node_agent.node_agent._stopped_request_ids
+
+
+def test_node_agent_on_reply_unexpected_request(monkeypatch, node_agent):
+    class DummyReply:
+        request_id = "req-404"
+
+    warnings = {"count": 0}
+
+    def fake_warning(*args, **kwargs):
+        warnings["count"] += 1
+
+    monkeypatch.setattr(
+        "fedbiomed.transport.node_agent.Message.from_dict",
+        lambda _: DummyReply(),
+    )
+    monkeypatch.setattr("fedbiomed.transport.node_agent.logger.warning", fake_warning)
+
+    node_agent.loop.run_until_complete(node_agent.node_agent.on_reply({}))
+
+    assert warnings["count"] >= 1
 
 
 if __name__ == "__main__":

--- a/tests/test_transport_node_agent.py
+++ b/tests/test_transport_node_agent.py
@@ -171,18 +171,14 @@ def test_node_agent_on_reply_pending_request(monkeypatch, node_agent):
 
 
 def test_node_agent_on_reply_overlay_message(monkeypatch, node_agent):
-    seen = {"reply": None}
+    seen = {"forwarded": None}
 
-    def callback(reply):
-        seen["reply"] = reply
+    async def on_forward(message):
+        seen["forwarded"] = message
 
     overlay = object.__new__(OverlayMessage)
     overlay.request_id = "req-overlay"
-
-    node_agent.node_agent._replies["req-overlay"] = {
-        "reply": None,
-        "callback": callback,
-    }
+    node_agent.node_agent._on_forward = on_forward
 
     monkeypatch.setattr(
         "fedbiomed.transport.node_agent.Message.from_dict",
@@ -191,8 +187,8 @@ def test_node_agent_on_reply_overlay_message(monkeypatch, node_agent):
 
     node_agent.loop.run_until_complete(node_agent.node_agent.on_reply({}))
 
-    assert node_agent.node_agent._replies["req-overlay"]["reply"] is overlay
-    assert seen["reply"] is overlay
+    assert seen["forwarded"] is overlay
+    assert "req-overlay" not in node_agent.node_agent._replies
 
 
 def test_node_agent_on_reply_multiple_reply_warning(monkeypatch, node_agent):

--- a/tests/test_transport_server.py
+++ b/tests/test_transport_server.py
@@ -81,10 +81,13 @@ class TestResearcherServicer(unittest.IsolatedAsyncioTestCase):
             for i in [1, 2]:
                 yield TaskResult(size=2, iteration=i, bytes_=b"test")
 
-        load.return_value = {"node_id": "test-node"}
+        node_agent = AsyncMock()
+        self.agent_store.get.return_value = node_agent
+        load.return_value = reply.to_dict()
         result = await self.servicer.ReplyTask(
             request_iterator=request_iterator(), unused_context=self.context
         )
+        node_agent.on_reply.assert_called_once_with(load.return_value)
         self.assertEqual(result, Empty())
 
     async def test_researcher_servicer_03_Feedback(self):

--- a/tests/test_transport_server.py
+++ b/tests/test_transport_server.py
@@ -68,11 +68,19 @@ class TestResearcherServicer(unittest.IsolatedAsyncioTestCase):
         node_agent.get_task.return_value = [example_task, 0, time.time()]
 
         self.agent_store.retrieve.return_value = node_agent
-        async for r in self.servicer.GetTaskUnary(
-            request=self.request, context=self.context
-        ):
-            self.assertEqual(r.iteration, 1)
-            self.assertEqual(r.size, 1)
+        with patch("fedbiomed.transport.server.logger.debug") as logger_debug:
+            async for r in self.servicer.GetTaskUnary(
+                request=self.request, context=self.context
+            ):
+                self.assertEqual(r.iteration, 1)
+                self.assertEqual(r.size, 1)
+
+        self.assertTrue(
+            any(
+                "[WIRE][S->N][TX]" in call.args[0]
+                for call in logger_debug.call_args_list
+            )
+        )
 
     @patch("fedbiomed.transport.server.Serializer.loads")
     async def test_researcher_servicer_02_ReplyTask(self, load):
@@ -96,11 +104,18 @@ class TestResearcherServicer(unittest.IsolatedAsyncioTestCase):
             log=FeedbackMessage.Log(node_id="test", level="DEBUG", msg="Error message"),
         )
 
-        result = await self.servicer.Feedback(
-            request=request, unused_context=self.context
-        )
+        with patch("fedbiomed.transport.server.logger.debug") as logger_debug:
+            result = await self.servicer.Feedback(
+                request=request, unused_context=self.context
+            )
         self.on_message.assert_called_once()
         self.assertEqual(result, Empty())
+        self.assertTrue(
+            any(
+                "[WIRE][N->S][RX]" in call.args[0]
+                for call in logger_debug.call_args_list
+            )
+        )
 
     @patch("fedbiomed.transport.server.TaskResponse")
     async def test_researcher_servicer_04_GetTaskUnary_exceptions(self, task_response):
@@ -213,8 +228,16 @@ class TestGrpcAsyncServer(unittest.IsolatedAsyncioTestCase):
         agent = AsyncMock(spec=NodeAgent)
         self.agent_store_mock.return_value.get.return_value = agent
         await self.grpc_server.start()
-        await self.grpc_server._on_forward(overlay_message)
+        with patch("fedbiomed.transport.server.logger.debug") as logger_debug:
+            await self.grpc_server._on_forward(overlay_message)
         agent.send_async.assert_called_once()
+        debug_messages = [call.args[0] for call in logger_debug.call_args_list]
+        self.assertTrue(
+            any("Researcher relay forwarding overlay" in msg for msg in debug_messages)
+        )
+        self.assertTrue(
+            any("Researcher relay dispatching overlay" in msg for msg in debug_messages)
+        )
 
     async def test_grpc_async_server_06_get_node(self):
         agent = AsyncMock(spec=NodeAgent)


### PR DESCRIPTION
Fixes #1266 and #1605.

Implement detailed logging on a train request. 

When debug mode is enabled on the node side, logging is more verbose on each step of a training; such as Round creation, training plan initialization, processing optimizer aux variables and training routine initialization.

When debug mode is enabled on the researcher side, the exception handler is modified and prints tracebacks on FedbiomedExperimentErrors.

**Important Note:** I created two different variables to enable debug mode on node side and researcher side separately. They can be merged into one variable (or implemented completely differently), according to request/feedback.