### PR TITLE
node_id as TrainingPlan member

### DIFF
--- a/docs/user-guide/researcher/training-plan.md
+++ b/docs/user-guide/researcher/training-plan.md
@@ -138,6 +138,11 @@ def training_data(self) -> DataManager:
 You can read the documentation for [training data](../../researcher/training-data) to
 learn more about the `DataManager` class and various use cases.
 
+!!! warning "Be aware of the data types in your dataset"
+    It is ultimately your responsibility to write the code for `training_step` that correctly handles the data types
+    returned by the `__getitem__` function of the dataset you are targeting. Be aware of the specifics of your dataset
+    when writing this function.
+
 ## Initializing the model
 
 In Pytorch training plans, you must also define a `init_model` function with the following signature:
@@ -269,21 +274,6 @@ The `training_step` method of the training class defines how the cost is compute
         loss   = torch.nn.functional.nll_loss(output, target)
         return loss
 ```
-
-### Type of `data` and `target`
-
-The `training_step` function takes as input two arguments, `data` and `target`, which are obtained by cycling through the dataset defined in the `training_data` function. There is some flexibility concerning what type of variables they might be.
-
-In a Pytorch training plan, the following data types are supported:
-
-- a `torch.Tensor`
-- a collection (a `dict`, `tuple` or `list`) of `torch.Tensor`
-- a recursive collection of collections, arbitrarily nested, that ultimately contain `torch.Tensor` objects
-
-!!! warning "Be aware of the data types in your dataset"
-    It is ultimately your responsibility to write the code for `training_step` that correctly handles the data types
-    returned by the `__getitem__` function of the dataset you are targeting. Be aware of the specifics of your dataset
-    when writing this function.
 
 ## Adding Dependencies
 

--- a/docs/user-guide/researcher/training-plan.md
+++ b/docs/user-guide/researcher/training-plan.md
@@ -377,9 +377,10 @@ Of course, loaded model needs to be identical to the training plan's model.
 ## Advanced: node-specific behaviour
 
 Fed-BioMed exposes the ID of the local node through the `TrainingPlan.node_id()` getter function. 
-This function returns an alphanumeric string corresponding to the unique identifier, such as e.g. `NODE_e5fb7b0e-404d-44fe-904b-259036551e99`. 
-It does not return the human-readable node name that may be additionally specified at node creation. 
-With this ID, it is possible to implement node-specific behaviour with `if` statements, or through the following model args pattern:
+This function returns an alphanumeric string corresponding to the unique identifier, such as e.g. `NODE_e5fb7b0e-404d-44fe-904b-259036551e99`, or `None` when the training plan was not fully initialized (i.e. `post_init` has not yet been called) or when the training plan was constructed on the researcher side.
+Note that the `node_id` function does not return the human-readable node name that may have been additionally specified at node creation. 
+
+With the `node_id`, it is possible to implement node-specific behaviour using `if` statements, or through the following model args pattern:
 ```python
 class MyTrainingPlan(TorchTrainingPlan):
     def init_model(self, model_args):

--- a/docs/user-guide/researcher/training-plan.md
+++ b/docs/user-guide/researcher/training-plan.md
@@ -109,6 +109,7 @@ Fed-BioMed provides the following getter functions to access Training Plan attri
 | model arguments     | `model_args()`     | :heavy_check_mark: | :heavy_check_mark:  | |
 | training arguments  | `training_args()`  | :heavy_check_mark: | :heavy_check_mark:  | |
 | optimizer arguments | `optimizer_args()` | :heavy_check_mark: | :heavy_check_mark:  | |
+| node is | `node_id()` | :heavy_check_mark: | :heavy_check_mark:  | |
 
 ####
 
@@ -382,3 +383,23 @@ Of course, loaded model needs to be identical to the training plan's model.
 !!! warning "Usage through `Experiment`"
     Both **exports** and **imports** must be used through [Experiment](../../researcher/experiment) interface. Indeed, `Experiment` class has methods to load Training Plans and for initializing Model. Once the Model is initialized, you can
     use both `export_model` and `import_model` for saving model into a file and respectively load it from a file.
+
+## Advanced: node-specific behaviour
+
+Fed-BioMed exposes the ID of the local node through the `TrainingPlan.node_id()` getter function. 
+This function returns an alphanumeric string corresponding to the unique identifier, such as e.g. `NODE_e5fb7b0e-404d-44fe-904b-259036551e99`. 
+It does not return the human-readable node name that may be additionally specified at node creation. 
+With this ID, it is possible to implement node-specific behaviour with `if` statements, or through the following model args pattern:
+```python
+class MyTrainingPlan(TorchTrainingPlan):
+    def init_model(self, model_args):
+        return MyModel(my_param=model_args['my_param'][self.node_id()])
+    # Remaining training plan definition...
+
+model_args = {
+    'my_param': {
+        'NODE_e5fb7b0e-404d-44fe-904b-259036551e99': 1.0,
+        'NODE_dsl39m23-5551-4242-6767-ao832jkavj2m': 2.0
+    }
+}
+```

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -773,6 +773,14 @@ class BaseTrainingPlan(metaclass=ABCMeta):
     def node_id(self) -> Optional[str]:
         """Retrieve node id
 
+        Node id is the unique identifier of the node that executes the training plan. It is set by the node when calling `post_init` method.
+        It looks something like "NODE_1234abcd-5678-efgh-9012-ijklmnopqrst".
+        It is not the human-readable name of the node, which is set by the node creator.
+
+        The returned node id can be `None` in the following cases:
+        1. The 'post_init' method has not been called yet, which means the training plan has not yet been fully initialized by the node.
+        2. The training plan is being initialized by the researcher.
+
         Returns:
             Node id
         """

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -79,6 +79,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         self._optimizer_args: Dict[str, Any] = None
         self._loader_args: Dict[str, Any] = None
         self._training_args: Dict[str, Any] = None
+        self._node_id: Optional[str] = None
 
         self._error_msg_import_model: str = (
             f"{ErrorNumbers.FB605.value}: Training Plan's Model is not initialized.\n"
@@ -132,6 +133,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         training_args: Dict[str, Any],
         aggregator_args: Optional[Dict[str, Any]] = None,
         initialize_optimizer: bool = True,
+        node_id: Optional[str] = None,
     ) -> None:
         """Process model, training and optimizer arguments.
 
@@ -152,6 +154,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         self._optimizer_args = training_args.optimizer_arguments() or {}
         self._loader_args = training_args.loader_arguments() or {}
         self._training_args = training_args.pure_training_arguments()
+        self._node_id = node_id
 
         # Set random seed: the seed can be either None or an int provided by the researcher.
         # when it is None, both random.seed and np.random.seed rely on the OS to generate a random seed.
@@ -766,3 +769,11 @@ class BaseTrainingPlan(metaclass=ABCMeta):
             Optimizer arguments
         """
         return self._optimizer_args
+
+    def node_id(self) -> Optional[str]:
+        """Retrieve node id
+
+        Returns:
+            Node id
+        """
+        return self._node_id

--- a/fedbiomed/common/training_plans/_sklearn_models.py
+++ b/fedbiomed/common/training_plans/_sklearn_models.py
@@ -269,6 +269,7 @@ class FedPerceptron(FedSGDClassifier):
         model_args: Dict[str, Any],
         training_args: Dict[str, Any],
         aggregator_args: Optional[Dict[str, Any]] = None,
+        node_id: Optional[str] = None,
         **kwargs,
     ) -> None:
         # get default values of Perceptron model (different from SGDClassifier model default values)
@@ -276,7 +277,7 @@ class FedPerceptron(FedSGDClassifier):
         sgd_classifier_default_values = SGDClassifier().get_params()
         # make sure loss used is perceptron loss - can not be changed by user
         model_args["loss"] = "perceptron"
-        super().post_init(model_args, training_args)
+        super().post_init(model_args, training_args, node_id=node_id)
         self._model.set_params(loss="perceptron")
 
         # collect default values of Perceptron and set it to the model FedPerceptron

--- a/fedbiomed/common/training_plans/_sklearn_training_plan.py
+++ b/fedbiomed/common/training_plans/_sklearn_training_plan.py
@@ -90,6 +90,7 @@ class SKLearnTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         training_args: TrainingArgs,
         aggregator_args: Optional[Dict[str, Any]] = None,
         initialize_optimizer: bool = True,
+        node_id: Optional[str] = None,
     ) -> None:
         """Process model, training and optimizer arguments.
 
@@ -103,7 +104,7 @@ class SKLearnTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
             initialize_optimizer: Unused.
         """
         model_args.setdefault("verbose", 1)
-        super().post_init(model_args, training_args, aggregator_args)
+        super().post_init(model_args, training_args, aggregator_args, node_id=node_id)
         self._model = SkLearnModel(self._model_cls)
         self._batch_maxnum = self._training_args.get("batch_maxnum", self._batch_maxnum)
         self._warn_about_training_args()

--- a/fedbiomed/common/training_plans/_torchnn.py
+++ b/fedbiomed/common/training_plans/_torchnn.py
@@ -133,6 +133,7 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         training_args: TrainingArgs,
         aggregator_args: Optional[Dict[str, Any]] = None,
         initialize_optimizer: bool = True,
+        node_id: Optional[str] = None,
     ) -> None:
         """Process model, training and optimizer arguments.
 
@@ -150,7 +151,7 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
                 match expectations, or if the optimizer, model and dependencies
                 configuration goes wrong.
         """
-        super().post_init(model_args, training_args, aggregator_args)
+        super().post_init(model_args, training_args, aggregator_args, node_id=node_id)
         # Assign scalar attributes.
         self._use_gpu = self._training_args.get("use_gpu")
         self._batch_maxnum = self._training_args.get("batch_maxnum")

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -291,6 +291,7 @@ class Round:
                 model_args=self.model_arguments,
                 training_args=self.training_arguments,
                 aggregator_args=self.aggregator_args,
+                node_id=self._node_id,
             )
         except Exception:
             error_message = "Can't initialize training plan with the arguments."

--- a/tests/testsupport/fake_training_plan.py
+++ b/tests/testsupport/fake_training_plan.py
@@ -1,19 +1,21 @@
 """Fake `BaseTrainingPlan` subclass nullifying most methods, for tests use."""
 
+import time
 from typing import Any, Dict, Optional
 from unittest import mock
-import time
-from fedbiomed.common.constants import TrainingPlans
+
 import torch
 from torch.utils.data import Dataset
+
+from fedbiomed.common.constants import TrainingPlans
+from fedbiomed.common.datamanager import DataManager
 from fedbiomed.common.models import Model
 from fedbiomed.common.optimizers import BaseOptimizer
 from fedbiomed.common.training_plans import (
     BaseTrainingPlan,
-    TorchTrainingPlan,
     FedSGDRegressor,
+    TorchTrainingPlan,
 )
-from fedbiomed.common.datamanager import DataManager
 
 
 # Fakes TrainingPlan (either `fedbiomed.common.torchnn`` or `fedbiomed.common.fedbiosklearn`)
@@ -47,9 +49,10 @@ class FakeModel(BaseTrainingPlan):
         model_args: Dict[str, Any],
         training_args: Dict[str, Any],
         aggregator_args: Optional[Dict[str, Any]] = None,
+        node_id: Optional[str] = None,
     ) -> None:
         """Fake 'post_init', that does not make use of input arguments."""
-        super().post_init(model_args, training_args, aggregator_args)
+        super().post_init(model_args, training_args, aggregator_args, node_id=node_id)
 
     def model(self):
         return self._model


### PR DESCRIPTION
**PR description**
Fix #1617.

Introduce `node_id` as a member of TrainingPlan, with the following semantics:
1. It is initialized as `None`, like many other members
2. It is set during `post_init`by the Round class
3. the researcher can access the value with `self.node_id()` inside the TrainingPlan.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`