### PR TITLE
Implement dynamic dataset storage and deletion logic in database

### DIFF
--- a/fedbiomed/node/dataset_manager/_dataset_manager.py
+++ b/fedbiomed/node/dataset_manager/_dataset_manager.py
@@ -193,6 +193,16 @@ class DatasetManager:
         # Validate parent
         parent_entry = self.get_dataset_entry_by_id(parent_dataset_id)
 
+        # Get controller
+        data_type = parent_entry["data_type"]
+        controller = get_controller(
+            data_type,
+            controller_parameters={
+                "root": path,
+                **(dataset_parameters if dataset_parameters is not None else {}),
+            },
+        )
+
         # Insert partial DB entry
         entry = {
             "path": path,
@@ -205,28 +215,11 @@ class DatasetManager:
             "description": description,
             "dataset_id": dataset_id,
             "dataset_parameters": dataset_parameters,
+            "shape": controller.shape(),
+            "dtypes": controller.get_types(),
+            "data_type": data_type,
         }
         dataset_id = self.dynamic_dataset_table.insert(entry)
-
-        # Get controller
-        data_type = parent_entry["data_type"]
-        controller = get_controller(
-            data_type,
-            controller_parameters={
-                "root": path,
-                **(dataset_parameters if dataset_parameters is not None else {}),
-            },
-        )
-
-        # Update DB entry with path, shape and dtypes
-        self.dynamic_dataset_table.update_by_id(
-            dataset_id,
-            {
-                "shape": controller.shape(),
-                "dtypes": controller.get_types(),
-                "data_type": data_type,
-            },
-        )
 
         return dataset_id
 

--- a/fedbiomed/node/dataset_manager/_dataset_manager.py
+++ b/fedbiomed/node/dataset_manager/_dataset_manager.py
@@ -6,6 +6,9 @@ Interfaces with the node component database.
 """
 
 import csv
+import os
+import shutil
+from pathlib import Path
 from typing import Iterable, List, Optional, Tuple, Union
 
 import pandas as pd
@@ -15,7 +18,12 @@ from fedbiomed.common.constants import ErrorNumbers
 from fedbiomed.common.dataloadingplan import DataLoadingPlan
 from fedbiomed.common.dataset import get_controller
 from fedbiomed.common.exceptions import FedbiomedError
-from fedbiomed.node.dataset_manager._db_tables import DatasetTable, DlbTable, DlpTable
+from fedbiomed.node.dataset_manager._db_tables import (
+    DatasetTable,
+    DlbTable,
+    DlpTable,
+    DynamicDatasetTable,
+)
 
 
 class DatasetManager:
@@ -25,15 +33,22 @@ class DatasetManager:
     for the node. Currently uses TinyDB.
     """
 
-    def __init__(self, path: str):
+    def __init__(self, path: str, dynamic_datasets_path: str = None):
         """Initialize with database path."""
         self._dataset_table = DatasetTable(path)
+        self._dynamic_dataset_table = DynamicDatasetTable(path)
         self._dlp_table = DlpTable(path)
         self._dlb_table = DlbTable(path)
+        self._dynamic_datasets_path = dynamic_datasets_path
+        self.create_dynamic_datasets_folder()
 
     @property
     def dataset_table(self) -> DatasetTable:
         return self._dataset_table
+
+    @property
+    def dynamic_dataset_table(self) -> DynamicDatasetTable:
+        return self._dynamic_dataset_table
 
     @property
     def dlp_table(self) -> DlpTable:
@@ -42,6 +57,22 @@ class DatasetManager:
     @property
     def dlb_table(self) -> DlbTable:
         return self._dlb_table
+
+    def create_dynamic_datasets_folder(self):
+        """Creates the folder for storing dynamic datasets if it does not exist.
+
+        Raises:
+            FedbiomedError:
+            - If the folder creation fails.
+        """
+        if self._dynamic_datasets_path:
+            try:
+                os.makedirs(self._dynamic_datasets_path, exist_ok=True)
+            except Exception as e:
+                raise FedbiomedError(
+                    f"{ErrorNumbers.FB632.value}: Failed to create dynamic datasets folder at "
+                    f"{self._dynamic_datasets_path}: {str(e)}"
+                ) from e
 
     def get_dlp_by_id(self, dlp_id: str) -> Tuple[Optional[dict], List[dict]]:
         """Get data loading plan by ID and its associated data loading blocks."""
@@ -145,6 +176,209 @@ class DatasetManager:
             self.save_data_loading_plan(data_loading_plan)
 
         return dataset_entry
+
+    def add_dynamic_dataset(
+        self,
+        data,
+        researcher_id: str,
+        experiment_id: str,
+        processing_id: str,
+        parent_dataset_id: str,
+        name: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        description: Optional[str] = None,
+        dataset_id: Optional[str] = None,
+        dataset_parameters: Optional[dict] = None,
+    ):
+        """Adds a dynamic dataset to the database and saves its content to the filesystem.
+
+        Args:
+            data: the dataset content to be saved, as a pandas DataFrame (for tabular data) or other appropriate format depending on the data type
+            researcher_id: the id of the researcher who created the dynamic dataset
+            experiment_id: the id of the experiment for which the dynamic dataset was created
+            processing_id: the id of the processing that generated the dynamic dataset
+            parent_dataset_id: the id of the parent dataset from which the dynamic dataset was derived
+            name: optional name for the dynamic dataset
+            tags: optional list of tags for the dynamic dataset
+            description: optional description for the dynamic dataset
+            dataset_id: optional id for the dynamic dataset. If None, a new id will be generated.
+            dataset_parameters: optional parameters for the dataset controller, such as e.g. data type specific parameters (e.g. for medical-folder, the tabular file name within the folder)
+
+        Returns:
+            The dataset_id of the registered dynamic dataset
+
+        Raises:
+            FedbiomedError:
+            - If the parent dataset is not found in the database
+        """
+
+        # Insert partial DB entry
+        entry = {
+            "researcher_id": researcher_id,
+            "experiment_id": experiment_id,
+            "processing_id": processing_id,
+            "parent_dataset_id": parent_dataset_id,
+            "name": name,
+            "tags": tags,
+            "description": description,
+            "dataset_id": dataset_id,
+            "dataset_parameters": dataset_parameters,
+        }
+        dataset_id = self.dynamic_dataset_table.insert(entry)
+
+        # Get path, create folder and save data
+        dataset_dir = os.path.join(self._dynamic_datasets_path, dataset_id)
+        os.makedirs(dataset_dir, exist_ok=True)
+        ## TODO: check where to set and choose permissions
+        os.chmod(dataset_dir, 0o750)
+        # TODO: check if saving dataset files should be done in this function,
+        # and how to deal with other types of datasets (e.g. images)
+        data_path = os.path.join(dataset_dir, "data.csv")
+        data.to_csv(data_path, index=False)
+
+        # Get data type from parent dataset
+        parent_dataset_entry = self.dataset_table.get_by_id(parent_dataset_id)
+        parent_dynamic_dataset_entry = self.dynamic_dataset_table.get_by_id(
+            parent_dataset_id
+        )
+        if parent_dataset_entry is None and parent_dynamic_dataset_entry is None:
+            raise FedbiomedError(
+                f"{ErrorNumbers.FB632.value}: Parent dataset with id {parent_dataset_id} not found."
+            )
+        parent_entry = (
+            parent_dataset_entry
+            if parent_dataset_entry is not None
+            else parent_dynamic_dataset_entry
+        )
+        data_type = parent_entry["data_type"]
+
+        # Get controller for data type
+        controller = get_controller(
+            data_type,
+            controller_parameters={
+                "root": data_path,
+                **(dataset_parameters if dataset_parameters is not None else {}),
+            },
+        )
+
+        # Update DB entry with path, shape and dtypes
+        self.dynamic_dataset_table.update_by_id(
+            dataset_id,
+            {
+                "path": data_path,
+                "shape": controller.shape(),
+                "dtypes": controller.get_types(),
+                "data_type": data_type,
+            },
+        )
+
+        return dataset_id
+
+    def delete_dataset_by_id(
+        self,
+        dataset_id: str,
+        recursive: bool = False,
+        force: bool = False,
+    ) -> None:
+        """Deletes a dataset, and the related files, from the database by its ID.
+
+        Args:
+            dataset_id: the ID of the dataset to delete
+            recursive: whether to recursively delete all descendant dynamic datasets (if any). Defaults to False.
+            force: whether to force delete the dataset if it has children, by reassigning its children to its parent dataset. Defaults to False.
+
+        Raises:
+            FedbiomedError:
+            - If the dataset has children and neither recursive nor force is True
+            - If no dataset is found with the given ID
+        """
+        raw_entry = self.dataset_table.get_by_id(dataset_id)
+        dynamic_entry = self.dynamic_dataset_table.get_by_id(dataset_id)
+        if raw_entry is None and dynamic_entry is None:
+            raise FedbiomedError(
+                f"{ErrorNumbers.FB632.value}: No dataset found with id={dataset_id}"
+            )
+
+        children = self.dynamic_dataset_table.get_all_by_value(
+            "parent_dataset_id", dataset_id
+        )
+
+        # Case 1: raw dataset
+        if raw_entry is not None:
+            if children:
+                if force:
+                    raise FedbiomedError(
+                        f"{ErrorNumbers.FB632.value}: Cannot force delete a raw dataset with children. Use recursive=True to delete subtree."
+                    )
+
+                if not recursive:
+                    raise FedbiomedError(
+                        f"{ErrorNumbers.FB632.value}: Dataset has derived dynamic datasets. Use recursive=True to delete subtree."
+                    )
+
+                subtree = self.dynamic_dataset_table.collect_subtree(dataset_id)
+                for dyn_id in reversed(subtree):
+                    self._delete_dynamic_dataset_files(dyn_id)
+                    self.dynamic_dataset_table.delete_by_id(dyn_id)
+
+            # Delete raw dataset entry (no filesystem removal)
+            self.dataset_table.delete_by_id(dataset_id)
+            return
+
+        # Case 2: dynamic dataset
+        if not children:
+            # Simple delete
+            self._delete_dynamic_dataset_files(dataset_id)
+            self.dynamic_dataset_table.delete_by_id(dataset_id)
+            return
+
+        # Has children
+        if recursive:
+            subtree = self.dynamic_dataset_table.collect_subtree(dataset_id)
+
+            for dyn_id in reversed(subtree):
+                self._delete_dynamic_dataset_files(dyn_id)
+                self.dynamic_dataset_table.delete_by_id(dyn_id)
+
+            return
+
+        if force:
+            parent_id = dynamic_entry.get("parent_dataset_id")
+
+            for child in children:
+                self.dynamic_dataset_table.update_by_id(
+                    child["dataset_id"],
+                    {"parent_dataset_id": parent_id},
+                )
+
+            self._delete_dynamic_dataset_files(dataset_id)
+            self.dynamic_dataset_table.delete_by_id(dataset_id)
+            return
+
+        raise FedbiomedError(
+            f"{ErrorNumbers.FB632.value}: Dataset has children. Use recursive=True to delete subtree "
+            "or force=True to reassign children."
+        )
+
+    def _delete_dynamic_dataset_files(self, dataset_id: str) -> None:
+        """Deletes filesystem folder of a dynamic dataset.
+
+        Args:
+            dataset_id: the dynamic dataset id whose files should be deleted
+        """
+        entry = self.dynamic_dataset_table.get_by_id(dataset_id)
+        if entry is not None:
+            dataset_path = entry.get("path")
+            if dataset_path:
+                path = Path(dataset_path)
+                parts = path.parts
+                if dataset_id not in parts:
+                    raise FedbiomedError(
+                        f"{ErrorNumbers.FB632.value}: Dataset path {dataset_path} does not contain dataset id {dataset_id}. Aborting deletion to prevent accidental data loss."
+                    )
+                idx = parts.index(dataset_id)
+                path_folder = Path(*parts[: idx + 1])
+                shutil.rmtree(path_folder)
 
     def remove_dlp_by_id(self, dlp_id: str):
         """Removes a data loading plan (DLP) from the database,

--- a/fedbiomed/node/dataset_manager/_dataset_manager.py
+++ b/fedbiomed/node/dataset_manager/_dataset_manager.py
@@ -6,9 +6,6 @@ Interfaces with the node component database.
 """
 
 import csv
-import os
-import shutil
-from pathlib import Path
 from typing import Iterable, List, Optional, Tuple, Union
 
 import pandas as pd
@@ -33,14 +30,12 @@ class DatasetManager:
     for the node. Currently uses TinyDB.
     """
 
-    def __init__(self, path: str, dynamic_datasets_path: str = None):
+    def __init__(self, path: str):
         """Initialize with database path."""
         self._dataset_table = DatasetTable(path)
         self._dynamic_dataset_table = DynamicDatasetTable(path)
         self._dlp_table = DlpTable(path)
         self._dlb_table = DlbTable(path)
-        self._dynamic_datasets_path = dynamic_datasets_path
-        self.create_dynamic_datasets_folder()
 
     @property
     def dataset_table(self) -> DatasetTable:
@@ -57,22 +52,6 @@ class DatasetManager:
     @property
     def dlb_table(self) -> DlbTable:
         return self._dlb_table
-
-    def create_dynamic_datasets_folder(self):
-        """Creates the folder for storing dynamic datasets if it does not exist.
-
-        Raises:
-            FedbiomedError:
-            - If the folder creation fails.
-        """
-        if self._dynamic_datasets_path:
-            try:
-                os.makedirs(self._dynamic_datasets_path, exist_ok=True)
-            except Exception as e:
-                raise FedbiomedError(
-                    f"{ErrorNumbers.FB632.value}: Failed to create dynamic datasets folder at "
-                    f"{self._dynamic_datasets_path}: {str(e)}"
-                ) from e
 
     def get_dlp_by_id(self, dlp_id: str) -> Tuple[Optional[dict], List[dict]]:
         """Get data loading plan by ID and its associated data loading blocks."""
@@ -179,7 +158,7 @@ class DatasetManager:
 
     def add_dynamic_dataset(
         self,
-        data,
+        path: str,
         researcher_id: str,
         experiment_id: str,
         processing_id: str,
@@ -190,10 +169,10 @@ class DatasetManager:
         dataset_id: Optional[str] = None,
         dataset_parameters: Optional[dict] = None,
     ):
-        """Adds a dynamic dataset to the database and saves its content to the filesystem.
+        """Adds a dynamic dataset to the database.
 
         Args:
-            data: the dataset content to be saved, as a pandas DataFrame (for tabular data) or other appropriate format depending on the data type
+            path: the path where the dynamic dataset files are stored.
             researcher_id: the id of the researcher who created the dynamic dataset
             experiment_id: the id of the experiment for which the dynamic dataset was created
             processing_id: the id of the processing that generated the dynamic dataset
@@ -211,16 +190,12 @@ class DatasetManager:
             FedbiomedError:
             - If the parent dataset is not found in the database
         """
-        if self._dynamic_datasets_path is None:
-            raise FedbiomedError(
-                f"{ErrorNumbers.FB632.value}: Dynamic datasets path is not configured."
-            )
-
         # Validate parent
-        parent_entry = self._get_dataset_entry(parent_dataset_id)
+        parent_entry = self.get_dataset_entry_by_id(parent_dataset_id)
 
         # Insert partial DB entry
         entry = {
+            "path": path,
             "researcher_id": researcher_id,
             "experiment_id": experiment_id,
             "processing_id": processing_id,
@@ -233,22 +208,12 @@ class DatasetManager:
         }
         dataset_id = self.dynamic_dataset_table.insert(entry)
 
-        # Get path, create folder and save data
-        dataset_dir = os.path.join(self._dynamic_datasets_path, dataset_id)
-        os.makedirs(dataset_dir, exist_ok=True)
-        ## TODO: check where to set and choose permissions
-        os.chmod(dataset_dir, 0o750)
-        # TODO: check if saving dataset files should be done in this function,
-        # and how to deal with other types of datasets (e.g. images)
-        data_path = os.path.join(dataset_dir, "data.csv")
-        data.to_csv(data_path, index=False)
-
         # Get controller
         data_type = parent_entry["data_type"]
         controller = get_controller(
             data_type,
             controller_parameters={
-                "root": data_path,
+                "root": path,
                 **(dataset_parameters if dataset_parameters is not None else {}),
             },
         )
@@ -257,7 +222,6 @@ class DatasetManager:
         self.dynamic_dataset_table.update_by_id(
             dataset_id,
             {
-                "path": data_path,
                 "shape": controller.shape(),
                 "dtypes": controller.get_types(),
                 "data_type": data_type,
@@ -266,7 +230,7 @@ class DatasetManager:
 
         return dataset_id
 
-    def _get_dataset_entry(self, dataset_id: str) -> dict:
+    def get_dataset_entry_by_id(self, dataset_id: str) -> dict:
         """
         Validates that the dataset exists and returns its DB entry.
 
@@ -300,7 +264,7 @@ class DatasetManager:
         recursive: bool = False,
         force: bool = False,
     ) -> None:
-        """Deletes a dataset, and the related files, from the database by its ID.
+        """Deletes a dataset from the database by its ID.
 
         Args:
             dataset_id: the ID of the dataset to delete
@@ -312,7 +276,7 @@ class DatasetManager:
             - If the dataset has children and neither recursive nor force is True
             - If no dataset is found with the given ID
         """
-        dataset_entry = self._get_dataset_entry(dataset_id)
+        dataset_entry = self.get_dataset_entry_by_id(dataset_id)
         is_dynamic = "parent_dataset_id" in dataset_entry
 
         children = self.dynamic_dataset_table.get_all_by_value(
@@ -358,7 +322,7 @@ class DatasetManager:
                     {"parent_dataset_id": parent_id},
                 )
 
-        self._delete_dynamic_single(dataset_id)
+        self.dynamic_dataset_table.delete_by_id(dataset_id)
 
     def _delete_dynamic_subtree(self, dataset_id: str, is_dynamic: bool) -> None:
         subtree = self.dynamic_dataset_table.collect_subtree(dataset_id)
@@ -367,31 +331,7 @@ class DatasetManager:
             subtree = subtree[1:]
         # Delete children first
         for dyn_id in reversed(subtree):
-            self._delete_dynamic_single(dyn_id)
-
-    def _delete_dynamic_single(self, dataset_id: str) -> None:
-        self._delete_dynamic_dataset_files(dataset_id)
-        self.dynamic_dataset_table.delete_by_id(dataset_id)
-
-    def _delete_dynamic_dataset_files(self, dataset_id: str) -> None:
-        """Deletes filesystem folder of a dynamic dataset.
-
-        Args:
-            dataset_id: the dynamic dataset id whose files should be deleted
-        """
-        entry = self.dynamic_dataset_table.get_by_id(dataset_id)
-        if entry is not None:
-            dataset_path = entry.get("path")
-            if dataset_path:
-                path = Path(dataset_path)
-                parts = path.parts
-                if dataset_id not in parts:
-                    raise FedbiomedError(
-                        f"{ErrorNumbers.FB632.value}: Dataset path {dataset_path} does not contain dataset id {dataset_id}. Aborting deletion to prevent accidental data loss."
-                    )
-                idx = parts.index(dataset_id)
-                path_folder = Path(*parts[: idx + 1])
-                shutil.rmtree(path_folder)
+            self.dynamic_dataset_table.delete_by_id(dyn_id)
 
     def remove_dlp_by_id(self, dlp_id: str):
         """Removes a data loading plan (DLP) from the database,

--- a/fedbiomed/node/dataset_manager/_dataset_manager.py
+++ b/fedbiomed/node/dataset_manager/_dataset_manager.py
@@ -123,33 +123,17 @@ class DatasetManager:
             - If the data loading plan name is invalid or not unique
             - If the data_type is not supported
         """
-        controller = get_controller(
-            data_type,
-            controller_parameters={
-                "root": path,
-                "dlp": data_loading_plan,
-                **(dataset_parameters if dataset_parameters is not None else {}),
-            },
+        entry = self._build_dataset_entry(
+            data_type=data_type,
+            path=path,
+            dataset_id=dataset_id,
+            dataset_parameters=dataset_parameters,
+            name=name,
+            tags=tags,
+            description=description,
+            data_loading_plan=data_loading_plan,
         )
-
-        dataset_entry = self.dataset_table.insert(
-            entry=dict(
-                dataset_id=dataset_id,
-                name=name,
-                data_type=data_type,
-                tags=tags,
-                description=description,
-                path=controller._controller_kwargs["root"],
-                shape=controller.shape(),
-                dtypes=controller.get_types(),
-                dataset_parameters={
-                    _k: _v
-                    for _k, _v in controller._controller_kwargs.items()
-                    if _k not in ["root", "dlp"]
-                },
-                dlp_id=None if data_loading_plan is None else data_loading_plan.dlp_id,
-            )
-        )
+        dataset_entry = self.dataset_table.insert(entry)
 
         if save_dlp:
             self.save_data_loading_plan(data_loading_plan)
@@ -191,41 +175,86 @@ class DatasetManager:
             - If the parent dataset is not found in the database
         """
         # Validate parent
-        parent_entry = self.get_dataset_entry_by_id(parent_dataset_id)
+        parent_entry, _ = self.get_dataset_entry_by_id(parent_dataset_id)
 
-        # Get controller
+        # Get data type from parent dataset
         data_type = parent_entry["data_type"]
-        controller = get_controller(
-            data_type,
-            controller_parameters={
-                "root": path,
-                **(dataset_parameters if dataset_parameters is not None else {}),
+
+        # Build entry
+        entry = self._build_dataset_entry(
+            data_type=data_type,
+            path=path,
+            dataset_id=dataset_id,
+            dataset_parameters=dataset_parameters,
+            name=name,
+            tags=tags,
+            description=description,
+            data_loading_plan=None,  # DLP is not supported for dynamic datasets for now
+            extra_fields={
+                "researcher_id": researcher_id,
+                "experiment_id": experiment_id,
+                "processing_id": processing_id,
+                "parent_dataset_id": parent_dataset_id,
             },
         )
-
-        # Insert partial DB entry
-        entry = {
-            "path": path,
-            "researcher_id": researcher_id,
-            "experiment_id": experiment_id,
-            "processing_id": processing_id,
-            "parent_dataset_id": parent_dataset_id,
-            "name": name,
-            "tags": tags,
-            "description": description,
-            "dataset_id": dataset_id,
-            "dataset_parameters": dataset_parameters,
-            "shape": controller.shape(),
-            "dtypes": controller.get_types(),
-            "data_type": data_type,
-        }
         dataset_id = self.dynamic_dataset_table.insert(entry)
 
         return dataset_id
 
-    def get_dataset_entry_by_id(self, dataset_id: str) -> dict:
+    def _build_dataset_entry(
+        self,
+        *,
+        data_type: str,
+        path: str,
+        dataset_id: Optional[str],
+        dataset_parameters: Optional[dict],
+        name: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        description: Optional[str] = None,
+        data_loading_plan: Optional[DataLoadingPlan] = None,
+        extra_fields: Optional[dict] = None,
+    ):
+        controller_params = {
+            "root": path,
+            **(dataset_parameters or {}),
+        }
+
+        if data_loading_plan is not None:
+            controller_params["dlp"] = data_loading_plan
+
+        controller = get_controller(
+            data_type,
+            controller_parameters=controller_params,
+        )
+
+        # Creating common entry fields
+        entry = {
+            "dataset_id": dataset_id,
+            "data_type": data_type,
+            "name": name,
+            "tags": tags,
+            "description": description,
+            "path": controller._controller_kwargs["root"],
+            "shape": controller.shape(),
+            "dtypes": controller.get_types(),
+            "dataset_parameters": {
+                k: v
+                for k, v in controller._controller_kwargs.items()
+                if k not in ["root", "dlp"]
+            },
+        }
+
+        if data_loading_plan is not None:
+            entry["dlp_id"] = data_loading_plan.dlp_id
+        # Adding extra fields
+        if extra_fields:
+            entry.update(extra_fields)
+
+        return entry
+
+    def get_dataset_entry_by_id(self, dataset_id: str) -> Tuple[dict, str]:
         """
-        Validates that the dataset exists and returns its DB entry.
+        Validates that the dataset exists and returns its DB entry and dataset type.
 
         The dataset can be either:
             - a dataset (DatasetTable)
@@ -241,11 +270,11 @@ class DatasetManager:
 
         dataset_entry = self.dataset_table.get_by_id(dataset_id)
         if dataset_entry is not None:
-            return dataset_entry
+            return dataset_entry, self.dataset_table._table_name
 
         dynamic_dataset_entry = self.dynamic_dataset_table.get_by_id(dataset_id)
         if dynamic_dataset_entry is not None:
-            return dynamic_dataset_entry
+            return dynamic_dataset_entry, self.dynamic_dataset_table._table_name
 
         raise FedbiomedError(
             f"{ErrorNumbers.FB632.value}: Dataset with id {dataset_id} not found."
@@ -255,22 +284,24 @@ class DatasetManager:
         self,
         dataset_id: str,
         recursive: bool = False,
-        force: bool = False,
+        reassign_children: bool = False,
     ) -> None:
         """Deletes a dataset from the database by its ID.
 
         Args:
             dataset_id: the ID of the dataset to delete
             recursive: whether to recursively delete all descendant dynamic datasets (if any). Defaults to False.
-            force: whether to force delete the dataset if it has children, by reassigning its children to its parent dataset. Defaults to False.
+            reassign_children: whether to delete the dataset, and reassign children to the parent dataset if the dataset has children. Defaults to False.
 
         Raises:
             FedbiomedError:
-            - If the dataset has children and neither recursive nor force is True
             - If no dataset is found with the given ID
+            - If the dataset is a raw dataset and has children, and reassign_children is True (to avoid reassigning children of a raw dataset)
+            - If the dataset is a raw dataset and has children, and recursive is not True
+            - If the dynamic dataset has children and neither recursive nor reassign_children is True
         """
-        dataset_entry = self.get_dataset_entry_by_id(dataset_id)
-        is_dynamic = "parent_dataset_id" in dataset_entry
+        dataset_entry, dataset_type = self.get_dataset_entry_by_id(dataset_id)
+        is_dynamic = dataset_type == self.dynamic_dataset_table._table_name
 
         children = self.dynamic_dataset_table.get_all_by_value(
             "parent_dataset_id", dataset_id
@@ -279,9 +310,9 @@ class DatasetManager:
         # Case 1: dataset
         if not is_dynamic:
             if children:
-                if force:
+                if reassign_children:
                     raise FedbiomedError(
-                        f"{ErrorNumbers.FB632.value}: Cannot force delete a dataset with children. Use recursive=True to delete subtree."
+                        f"{ErrorNumbers.FB632.value}: Cannot reassign children of a dataset with children. Use recursive=True to delete subtree."
                     )
 
                 if not recursive:
@@ -289,24 +320,23 @@ class DatasetManager:
                         f"{ErrorNumbers.FB632.value}: Dataset has derived dynamic datasets. Use recursive=True to delete subtree."
                     )
 
-                self._delete_dynamic_subtree(dataset_id, is_dynamic)
+                self._delete_dynamic_subtree(dataset_id)
 
-            # Delete raw dataset entry (no filesystem removal)
+            # Delete raw dataset entry
             self.dataset_table.delete_by_id(dataset_id)
             return
 
         # Case 2: dynamic dataset
-        if children and not recursive and not force:
+        if children and not recursive and not reassign_children:
             raise FedbiomedError(
                 f"{ErrorNumbers.FB632.value}: Dataset has children. Use recursive=True to delete subtree "
-                "or force=True to reassign children."
+                "or reassign_children=True to reassign children."
             )
 
         if recursive:
-            self._delete_dynamic_subtree(dataset_id, is_dynamic)
-            return
+            self._delete_dynamic_subtree(dataset_id)
 
-        if force:
+        if reassign_children:
             parent_id = dataset_entry.get("parent_dataset_id")
 
             for child in children:
@@ -317,12 +347,18 @@ class DatasetManager:
 
         self.dynamic_dataset_table.delete_by_id(dataset_id)
 
-    def _delete_dynamic_subtree(self, dataset_id: str, is_dynamic: bool) -> None:
+    def _delete_dynamic_subtree(self, dataset_id: str) -> None:
+        """Helper method to delete a subtree of dynamic datasets rooted at dataset_id.
+
+        The root dataset can be either:
+            - a dataset (DatasetTable)
+            - a dynamic dataset (DynamicDatasetTable)
+
+        Args:
+            dataset_id: the ID of the root of the subtree to delete
+        """
         subtree = self.dynamic_dataset_table.collect_subtree(dataset_id)
-        if not is_dynamic:
-            # Remove the parent dataset
-            subtree = subtree[1:]
-        # Delete children first
+        # Delete children in reversed order
         for dyn_id in reversed(subtree):
             self.dynamic_dataset_table.delete_by_id(dyn_id)
 

--- a/fedbiomed/node/dataset_manager/_dataset_manager.py
+++ b/fedbiomed/node/dataset_manager/_dataset_manager.py
@@ -211,6 +211,13 @@ class DatasetManager:
             FedbiomedError:
             - If the parent dataset is not found in the database
         """
+        if self._dynamic_datasets_path is None:
+            raise FedbiomedError(
+                f"{ErrorNumbers.FB632.value}: Dynamic datasets path is not configured."
+            )
+
+        # Validate parent
+        parent_entry = self._get_dataset_entry(parent_dataset_id)
 
         # Insert partial DB entry
         entry = {
@@ -236,23 +243,8 @@ class DatasetManager:
         data_path = os.path.join(dataset_dir, "data.csv")
         data.to_csv(data_path, index=False)
 
-        # Get data type from parent dataset
-        parent_dataset_entry = self.dataset_table.get_by_id(parent_dataset_id)
-        parent_dynamic_dataset_entry = self.dynamic_dataset_table.get_by_id(
-            parent_dataset_id
-        )
-        if parent_dataset_entry is None and parent_dynamic_dataset_entry is None:
-            raise FedbiomedError(
-                f"{ErrorNumbers.FB632.value}: Parent dataset with id {parent_dataset_id} not found."
-            )
-        parent_entry = (
-            parent_dataset_entry
-            if parent_dataset_entry is not None
-            else parent_dynamic_dataset_entry
-        )
+        # Get controller
         data_type = parent_entry["data_type"]
-
-        # Get controller for data type
         controller = get_controller(
             data_type,
             controller_parameters={
@@ -274,6 +266,34 @@ class DatasetManager:
 
         return dataset_id
 
+    def _get_dataset_entry(self, dataset_id: str) -> dict:
+        """
+        Validates that the dataset exists and returns its DB entry.
+
+        The dataset can be either:
+            - a dataset (DatasetTable)
+            - a dynamic dataset (DynamicDatasetTable)
+
+        Args:
+            dataset_id: the id of the dataset to validate
+
+        Raises:
+            FedbiomedError:
+            - If dataset or dynamic dataset does not exist.
+        """
+
+        dataset_entry = self.dataset_table.get_by_id(dataset_id)
+        if dataset_entry is not None:
+            return dataset_entry
+
+        dynamic_dataset_entry = self.dynamic_dataset_table.get_by_id(dataset_id)
+        if dynamic_dataset_entry is not None:
+            return dynamic_dataset_entry
+
+        raise FedbiomedError(
+            f"{ErrorNumbers.FB632.value}: Dataset with id {dataset_id} not found."
+        )
+
     def delete_dataset_by_id(
         self,
         dataset_id: str,
@@ -292,23 +312,19 @@ class DatasetManager:
             - If the dataset has children and neither recursive nor force is True
             - If no dataset is found with the given ID
         """
-        raw_entry = self.dataset_table.get_by_id(dataset_id)
-        dynamic_entry = self.dynamic_dataset_table.get_by_id(dataset_id)
-        if raw_entry is None and dynamic_entry is None:
-            raise FedbiomedError(
-                f"{ErrorNumbers.FB632.value}: No dataset found with id={dataset_id}"
-            )
+        dataset_entry = self._get_dataset_entry(dataset_id)
+        is_dynamic = "parent_dataset_id" in dataset_entry
 
         children = self.dynamic_dataset_table.get_all_by_value(
             "parent_dataset_id", dataset_id
         )
 
-        # Case 1: raw dataset
-        if raw_entry is not None:
+        # Case 1: dataset
+        if not is_dynamic:
             if children:
                 if force:
                     raise FedbiomedError(
-                        f"{ErrorNumbers.FB632.value}: Cannot force delete a raw dataset with children. Use recursive=True to delete subtree."
+                        f"{ErrorNumbers.FB632.value}: Cannot force delete a dataset with children. Use recursive=True to delete subtree."
                     )
 
                 if not recursive:
@@ -316,34 +332,25 @@ class DatasetManager:
                         f"{ErrorNumbers.FB632.value}: Dataset has derived dynamic datasets. Use recursive=True to delete subtree."
                     )
 
-                subtree = self.dynamic_dataset_table.collect_subtree(dataset_id)
-                for dyn_id in reversed(subtree):
-                    self._delete_dynamic_dataset_files(dyn_id)
-                    self.dynamic_dataset_table.delete_by_id(dyn_id)
+                self._delete_dynamic_subtree(dataset_id, is_dynamic)
 
             # Delete raw dataset entry (no filesystem removal)
             self.dataset_table.delete_by_id(dataset_id)
             return
 
         # Case 2: dynamic dataset
-        if not children:
-            # Simple delete
-            self._delete_dynamic_dataset_files(dataset_id)
-            self.dynamic_dataset_table.delete_by_id(dataset_id)
-            return
+        if children and not recursive and not force:
+            raise FedbiomedError(
+                f"{ErrorNumbers.FB632.value}: Dataset has children. Use recursive=True to delete subtree "
+                "or force=True to reassign children."
+            )
 
-        # Has children
         if recursive:
-            subtree = self.dynamic_dataset_table.collect_subtree(dataset_id)
-
-            for dyn_id in reversed(subtree):
-                self._delete_dynamic_dataset_files(dyn_id)
-                self.dynamic_dataset_table.delete_by_id(dyn_id)
-
+            self._delete_dynamic_subtree(dataset_id, is_dynamic)
             return
 
         if force:
-            parent_id = dynamic_entry.get("parent_dataset_id")
+            parent_id = dataset_entry.get("parent_dataset_id")
 
             for child in children:
                 self.dynamic_dataset_table.update_by_id(
@@ -351,14 +358,20 @@ class DatasetManager:
                     {"parent_dataset_id": parent_id},
                 )
 
-            self._delete_dynamic_dataset_files(dataset_id)
-            self.dynamic_dataset_table.delete_by_id(dataset_id)
-            return
+        self._delete_dynamic_single(dataset_id)
 
-        raise FedbiomedError(
-            f"{ErrorNumbers.FB632.value}: Dataset has children. Use recursive=True to delete subtree "
-            "or force=True to reassign children."
-        )
+    def _delete_dynamic_subtree(self, dataset_id: str, is_dynamic: bool) -> None:
+        subtree = self.dynamic_dataset_table.collect_subtree(dataset_id)
+        if not is_dynamic:
+            # Remove the parent dataset
+            subtree = subtree[1:]
+        # Delete children first
+        for dyn_id in reversed(subtree):
+            self._delete_dynamic_single(dyn_id)
+
+    def _delete_dynamic_single(self, dataset_id: str) -> None:
+        self._delete_dynamic_dataset_files(dataset_id)
+        self.dynamic_dataset_table.delete_by_id(dataset_id)
 
     def _delete_dynamic_dataset_files(self, dataset_id: str) -> None:
         """Deletes filesystem folder of a dynamic dataset.

--- a/fedbiomed/node/dataset_manager/_db_dataclasses.py
+++ b/fedbiomed/node/dataset_manager/_db_dataclasses.py
@@ -56,13 +56,13 @@ class DatasetEntry(TableEntry):
 class DynamicDatasetEntry(TableEntry):
     """Dynamic dataset entry"""
 
+    path: str
     researcher_id: str
     experiment_id: str
     processing_id: str
     parent_dataset_id: str
     shape: Optional[List[int] | Dict[str, List[int]]] = None
     dtypes: Optional[Dict[str, str]] = None
-    path: Optional[str] = None
     name: Optional[str] = None
     tags: Optional[List[str]] = None
     data_type: Optional[str] = None

--- a/fedbiomed/node/dataset_manager/_db_dataclasses.py
+++ b/fedbiomed/node/dataset_manager/_db_dataclasses.py
@@ -53,6 +53,29 @@ class DatasetEntry(TableEntry):
 
 
 @dataclass
+class DynamicDatasetEntry(TableEntry):
+    """Dynamic dataset entry"""
+
+    researcher_id: str
+    experiment_id: str
+    processing_id: str
+    parent_dataset_id: str
+    shape: Optional[List[int] | Dict[str, List[int]]] = None
+    dtypes: Optional[Dict[str, str]] = None
+    path: Optional[str] = None
+    name: Optional[str] = None
+    tags: Optional[List[str]] = None
+    data_type: Optional[str] = None
+    description: Optional[str] = None
+    dataset_id: Optional[str] = None
+    dataset_parameters: Optional[Dict[str, Any]] = None
+
+    def __post_init__(self):
+        if self.dataset_id is None:
+            self.dataset_id = f"dynamic_dataset_{uuid.uuid4()}"
+
+
+@dataclass
 class DlpEntry(TableEntry):
     """Data Loading Plan entry"""
 

--- a/fedbiomed/node/dataset_manager/_db_tables.py
+++ b/fedbiomed/node/dataset_manager/_db_tables.py
@@ -149,16 +149,17 @@ class DynamicDatasetTable(BaseTable):
     def collect_subtree(self, parent_id: str) -> List[str]:
         """Return a list of dataset_ids in the subtree rooted at parent_id.
 
-        The returned list starts with parent_id, then its children recursively.
+        The returned list contains only descendants of parent_id (children, grandchildren, ...).
+        The parent_id itself is NOT included. Returns an empty list if there are no descendants.
         """
         collected: List[str] = []
 
         def _dfs(current_id: str):
-            collected.append(current_id)
             children = self.get_all_by_value("parent_dataset_id", current_id)
             for c in children:
                 child_id = c.get(self._id_name)
                 if child_id:
+                    collected.append(child_id)
                     _dfs(child_id)
 
         _dfs(parent_id)

--- a/fedbiomed/node/dataset_manager/_db_tables.py
+++ b/fedbiomed/node/dataset_manager/_db_tables.py
@@ -8,7 +8,7 @@ from fedbiomed.common.db import TinyTableConnector
 from fedbiomed.common.exceptions import FedbiomedError
 from fedbiomed.common.logger import logger
 
-from ._db_dataclasses import DatasetEntry, DlbEntry, DlpEntry
+from ._db_dataclasses import DatasetEntry, DlbEntry, DlpEntry, DynamicDatasetEntry
 
 
 class BaseTable(TinyTableConnector):
@@ -139,6 +139,30 @@ class DatasetTable(BaseTable):
                 raise FedbiomedError(msg)
 
         return super().update_by_id(dataset_id, modified_dataset)
+
+
+class DynamicDatasetTable(BaseTable):
+    _table_name = "DynamicDatasets"
+    _id_name = "dataset_id"
+    _dataclass = DynamicDatasetEntry
+
+    def collect_subtree(self, parent_id: str) -> List[str]:
+        """Return a list of dataset_ids in the subtree rooted at parent_id.
+
+        The returned list starts with parent_id, then its children recursively.
+        """
+        collected: List[str] = []
+
+        def _dfs(current_id: str):
+            collected.append(current_id)
+            children = self.get_all_by_value("parent_dataset_id", current_id)
+            for c in children:
+                child_id = c.get(self._id_name)
+                if child_id:
+                    _dfs(child_id)
+
+        _dfs(parent_id)
+        return collected
 
 
 class DlpTable(BaseTable):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3,8 +3,15 @@ import unittest
 
 from fedbiomed.common.constants import DatasetTypes
 from fedbiomed.common.exceptions import FedbiomedError
-from fedbiomed.node.dataset_manager._db_dataclasses import DatasetEntry
-from fedbiomed.node.dataset_manager._db_tables import DatasetTable, DlpTable
+from fedbiomed.node.dataset_manager._db_dataclasses import (
+    DatasetEntry,
+    DynamicDatasetEntry,
+)
+from fedbiomed.node.dataset_manager._db_tables import (
+    DatasetTable,
+    DlpTable,
+    DynamicDatasetTable,
+)
 
 
 class TestDatasetEntry(unittest.TestCase):
@@ -35,6 +42,57 @@ class TestDatasetEntry(unittest.TestCase):
         self.assertIn("name", dict_rep)
         self.assertIn("data_type", dict_rep)
         self.assertEqual(dict_rep["name"], "Test Dataset")
+
+
+class TestDynamicDatasetEntry(unittest.TestCase):
+    def test_dataclass_initialization(self):
+        entry = DynamicDatasetEntry(
+            researcher_id="res_123",
+            experiment_id="exp_456",
+            processing_id="proc_789",
+            parent_dataset_id="dataset_000",
+            name="Dynamic Dataset",
+        )
+        self.assertEqual(entry.researcher_id, "res_123")
+        self.assertEqual(entry.experiment_id, "exp_456")
+        self.assertEqual(entry.name, "Dynamic Dataset")
+        self.assertTrue(entry.dataset_id.startswith("dynamic_dataset_"))
+
+    def test_preserve_given_dataset_id(self):
+        entry = DynamicDatasetEntry(
+            researcher_id="res_123",
+            experiment_id="exp_456",
+            processing_id="proc_789",
+            parent_dataset_id="dataset_000",
+            dataset_id="custom_dynamic_id",
+        )
+        self.assertEqual(entry.dataset_id, "custom_dynamic_id")
+
+    def test_dataclass_todict(self):
+        entry = DynamicDatasetEntry(
+            researcher_id="res_123",
+            experiment_id="exp_456",
+            processing_id="proc_789",
+            parent_dataset_id="dataset_000",
+        )
+        dict_rep = entry.to_dict()
+        self.assertIn("researcher_id", dict_rep)
+        self.assertIn("experiment_id", dict_rep)
+        self.assertEqual(dict_rep["researcher_id"], "res_123")
+        self.assertNotIn("name", dict_rep)
+
+    def test_from_dict(self):
+        dict_data = {
+            "researcher_id": "res_123",
+            "experiment_id": "exp_456",
+            "processing_id": "proc_789",
+            "parent_dataset_id": "dataset_000",
+            "name": "Dynamic Dataset",
+        }
+        entry = DynamicDatasetEntry.from_dict(dict_data)
+        self.assertEqual(entry.researcher_id, "res_123")
+        self.assertEqual(entry.experiment_id, "exp_456")
+        self.assertEqual(entry.name, "Dynamic Dataset")
 
 
 class TestDatasetTable(unittest.TestCase):
@@ -124,6 +182,56 @@ class TestDatasetTable(unittest.TestCase):
         self.assertIsNone(not_found)
         validated = self.table.get_validated_entry(dataset_id)
         self.assertEqual(validated.name, "dataset_get")
+
+
+class TestDynamicDatasetTable(unittest.TestCase):
+    def setUp(self):
+        self.dbfile = tempfile.NamedTemporaryFile(delete=True)
+        self.table = DynamicDatasetTable(self.dbfile.name)
+
+    def tearDown(self):
+        self.dbfile.close()
+
+    def test_insert_and_get_by_id(self):
+        entry = {
+            "researcher_id": "res_001",
+            "experiment_id": "exp_001",
+            "processing_id": "proc_001",
+            "parent_dataset_id": "dataset_001",
+            "name": "Dynamic Dataset 1",
+        }
+        dataset_id = self.table.insert(entry)
+        found = self.table.get_by_id(dataset_id)
+        self.assertEqual(found["researcher_id"], "res_001")
+        self.assertEqual(found["experiment_id"], "exp_001")
+        self.assertEqual(found["name"], "Dynamic Dataset 1")
+        not_found = self.table.get_by_id("NON_EXISTENT")
+        self.assertIsNone(not_found)
+
+    def test_collect_subtree(self):
+        dataset_root_id = "dataset_root_id"
+        dyn_dataset_child1 = {
+            "researcher_id": "res_child1",
+            "experiment_id": "exp_child1",
+            "processing_id": "proc_child1",
+            "parent_dataset_id": dataset_root_id,
+        }
+        dyn_dataset_child1_id = self.table.insert(dyn_dataset_child1)
+        dyn_dataset_grandchild1_id = {
+            "researcher_id": "res_grandchild1",
+            "experiment_id": "exp_grandchild1",
+            "processing_id": "proc_grandchild1",
+            "parent_dataset_id": dyn_dataset_child1_id,
+        }
+        dyn_dataset_grandchild1_id = self.table.insert(dyn_dataset_grandchild1_id)
+        subtree = self.table.collect_subtree(dataset_root_id)
+        self.assertEqual(
+            subtree,
+            [dataset_root_id, dyn_dataset_child1_id, dyn_dataset_grandchild1_id],
+        )
+        subtree_inexistent = self.table.collect_subtree("unknown_id")
+        # current implementation still returns the id itself
+        self.assertEqual(subtree_inexistent, ["unknown_id"])
 
 
 class TestDlpTable(unittest.TestCase):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -47,12 +47,14 @@ class TestDatasetEntry(unittest.TestCase):
 class TestDynamicDatasetEntry(unittest.TestCase):
     def test_dataclass_initialization(self):
         entry = DynamicDatasetEntry(
+            path="/path/to/dynamic",
             researcher_id="res_123",
             experiment_id="exp_456",
             processing_id="proc_789",
             parent_dataset_id="dataset_000",
             name="Dynamic Dataset",
         )
+        self.assertEqual(entry.path, "/path/to/dynamic")
         self.assertEqual(entry.researcher_id, "res_123")
         self.assertEqual(entry.experiment_id, "exp_456")
         self.assertEqual(entry.name, "Dynamic Dataset")
@@ -60,6 +62,7 @@ class TestDynamicDatasetEntry(unittest.TestCase):
 
     def test_preserve_given_dataset_id(self):
         entry = DynamicDatasetEntry(
+            path="/path/to/dynamic",
             researcher_id="res_123",
             experiment_id="exp_456",
             processing_id="proc_789",
@@ -70,6 +73,7 @@ class TestDynamicDatasetEntry(unittest.TestCase):
 
     def test_dataclass_todict(self):
         entry = DynamicDatasetEntry(
+            path="/path/to/dynamic",
             researcher_id="res_123",
             experiment_id="exp_456",
             processing_id="proc_789",
@@ -83,6 +87,7 @@ class TestDynamicDatasetEntry(unittest.TestCase):
 
     def test_from_dict(self):
         dict_data = {
+            "path": "/path/to/dynamic",
             "researcher_id": "res_123",
             "experiment_id": "exp_456",
             "processing_id": "proc_789",
@@ -90,6 +95,7 @@ class TestDynamicDatasetEntry(unittest.TestCase):
             "name": "Dynamic Dataset",
         }
         entry = DynamicDatasetEntry.from_dict(dict_data)
+        self.assertEqual(entry.path, "/path/to/dynamic")
         self.assertEqual(entry.researcher_id, "res_123")
         self.assertEqual(entry.experiment_id, "exp_456")
         self.assertEqual(entry.name, "Dynamic Dataset")
@@ -194,6 +200,7 @@ class TestDynamicDatasetTable(unittest.TestCase):
 
     def test_insert_and_get_by_id(self):
         entry = {
+            "path": "/path/to/dynamic",
             "researcher_id": "res_001",
             "experiment_id": "exp_001",
             "processing_id": "proc_001",
@@ -202,6 +209,7 @@ class TestDynamicDatasetTable(unittest.TestCase):
         }
         dataset_id = self.table.insert(entry)
         found = self.table.get_by_id(dataset_id)
+        self.assertEqual(found["path"], "/path/to/dynamic")
         self.assertEqual(found["researcher_id"], "res_001")
         self.assertEqual(found["experiment_id"], "exp_001")
         self.assertEqual(found["name"], "Dynamic Dataset 1")
@@ -211,6 +219,7 @@ class TestDynamicDatasetTable(unittest.TestCase):
     def test_collect_subtree(self):
         dataset_root_id = "dataset_root_id"
         dyn_dataset_child1 = {
+            "path": "/path/to/dynamic/child1",
             "researcher_id": "res_child1",
             "experiment_id": "exp_child1",
             "processing_id": "proc_child1",
@@ -218,6 +227,7 @@ class TestDynamicDatasetTable(unittest.TestCase):
         }
         dyn_dataset_child1_id = self.table.insert(dyn_dataset_child1)
         dyn_dataset_grandchild1_id = {
+            "path": "/path/to/dynamic/grandchild1",
             "researcher_id": "res_grandchild1",
             "experiment_id": "exp_grandchild1",
             "processing_id": "proc_grandchild1",

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -237,11 +237,10 @@ class TestDynamicDatasetTable(unittest.TestCase):
         subtree = self.table.collect_subtree(dataset_root_id)
         self.assertEqual(
             subtree,
-            [dataset_root_id, dyn_dataset_child1_id, dyn_dataset_grandchild1_id],
+            [dyn_dataset_child1_id, dyn_dataset_grandchild1_id],
         )
         subtree_inexistent = self.table.collect_subtree("unknown_id")
-        # current implementation still returns the id itself
-        self.assertEqual(subtree_inexistent, ["unknown_id"])
+        self.assertEqual(subtree_inexistent, [])
 
 
 class TestDlpTable(unittest.TestCase):

--- a/tests/test_dataset_manager.py
+++ b/tests/test_dataset_manager.py
@@ -1,5 +1,4 @@
 # tests/test_dataset_manager.py
-import pandas as pd
 import pytest
 
 # ---- Import the module under test (adjust the import line if your path differs) ----
@@ -237,31 +236,8 @@ def test_obfuscate_private_information_raises_on_bad_item():
         list(dm_mod.DatasetManager.obfuscate_private_information([{"path": "x"}, 123]))
 
 
-def test_create_dynamic_datasets_folder(tmp_path):
-    dynamic_path = tmp_path / "dyn"
-    assert not dynamic_path.exists()
-
-    _ = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=str(dynamic_path))
-
-    assert dynamic_path.exists()
-    assert dynamic_path.is_dir()
-
-
-def test_add_dynamic_dataset_without_path_raises():
-    dm = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=None)
-
-    with pytest.raises(FedbiomedError):
-        dm.add_dynamic_dataset(
-            data=None,
-            researcher_id="r",
-            experiment_id="e",
-            processing_id="p",
-            parent_dataset_id="parent",
-        )
-
-
-def test_get_dataset_entry_from_both_tables(tmp_path):
-    dm = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=str(tmp_path))
+def test_get_dataset_entry_from_both_tables():
+    dm = dm_mod.DatasetManager(path="/db")
 
     # Insert raw dataset
     raw_id = dm.dataset_table.insert({"dataset_id": "raw1", "data_type": "tabular"})
@@ -271,23 +247,21 @@ def test_get_dataset_entry_from_both_tables(tmp_path):
         {"dataset_id": "dyn1", "parent_dataset_id": "raw1"}
     )
 
-    assert dm._get_dataset_entry("raw1")["dataset_id"] == raw_id
-    assert dm._get_dataset_entry("dyn1")["dataset_id"] == dyn_id
+    assert dm.get_dataset_entry_by_id("raw1")["dataset_id"] == raw_id
+    assert dm.get_dataset_entry_by_id("dyn1")["dataset_id"] == dyn_id
 
     with pytest.raises(FedbiomedError):
-        dm._get_dataset_entry("does-not-exist")
+        dm.get_dataset_entry_by_id("does-not-exist")
 
 
-def test_add_dynamic_dataset_creates_files_and_db(tmp_path):
-    dm = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=str(tmp_path))
+def test_add_dynamic_dataset():
+    dm = dm_mod.DatasetManager(path="/db")
 
     # Insert parent raw dataset
     parent_id = dm.dataset_table.insert({"dataset_id": "raw1", "data_type": "tabular"})
 
-    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
-
     dyn_id = dm.add_dynamic_dataset(
-        data=df,
+        path="/path/to/dynamic",
         researcher_id="r",
         experiment_id="e",
         processing_id="p",
@@ -297,26 +271,19 @@ def test_add_dynamic_dataset_creates_files_and_db(tmp_path):
     # DB entry exists
     entry = dm.dynamic_dataset_table.get_by_id(dyn_id)
     assert entry is not None
+    assert entry["path"] == "/path/to/dynamic"
     assert entry["data_type"] == "tabular"
     assert entry["shape"] == (3, 4)
     assert entry["dtypes"] == {"col1": "float", "col2": "int"}
 
-    # File exists
-    dataset_folder = tmp_path / dyn_id
-    assert dataset_folder.exists()
-    assert (dataset_folder / "data.csv").exists()
-    assert entry["path"] == str(dataset_folder / "data.csv")
 
-
-def test_delete_dynamic_single_removes_files_and_db(tmp_path):
-    dm = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=str(tmp_path))
+def test_delete_dynamic_single():
+    dm = dm_mod.DatasetManager(path="/db")
 
     parent_id = dm.dataset_table.insert({"dataset_id": "raw1", "data_type": "tabular"})
 
-    df = pd.DataFrame({"a": [1]})
-
     dyn_id = dm.add_dynamic_dataset(
-        data=df,
+        path="/path/to/dynamic",
         researcher_id="r",
         experiment_id="e",
         processing_id="p",
@@ -326,18 +293,27 @@ def test_delete_dynamic_single_removes_files_and_db(tmp_path):
     dm.delete_dataset_by_id(dyn_id)
 
     assert dm.dynamic_dataset_table.get_by_id(dyn_id) is None
-    assert not (tmp_path / dyn_id).exists()
 
 
-def test_delete_dynamic_dataset_recursive(tmp_path):
-    dm = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=str(tmp_path))
+def test_delete_dynamic_dataset_recursive():
+    dm = dm_mod.DatasetManager(path="/db")
 
     parent = dm.dataset_table.insert({"dataset_id": "raw1", "data_type": "tabular"})
 
-    df = pd.DataFrame({"a": [1]})
-
-    child1 = dm.add_dynamic_dataset(df, "r", "e", "p1", parent)
-    child2 = dm.add_dynamic_dataset(df, "r", "e", "p2", child1)
+    child1 = dm.add_dynamic_dataset(
+        path="/path/to/dynamic/child1",
+        researcher_id="r",
+        experiment_id="e",
+        processing_id="p1",
+        parent_dataset_id=parent,
+    )
+    child2 = dm.add_dynamic_dataset(
+        path="/path/to/dynamic/child2",
+        researcher_id="r",
+        experiment_id="e",
+        processing_id="p2",
+        parent_dataset_id=child1,
+    )
 
     # Inject fake subtree behavior
     dm.dynamic_dataset_table._fake_subtrees = {child1: [child1, child2]}
@@ -347,19 +323,27 @@ def test_delete_dynamic_dataset_recursive(tmp_path):
     assert dm.dataset_table.get_by_id(parent) is not None
     assert dm.dynamic_dataset_table.get_by_id(child1) is None
     assert dm.dynamic_dataset_table.get_by_id(child2) is None
-    assert not (tmp_path / child1).exists()
-    assert not (tmp_path / child2).exists()
 
 
-def test_delete_dynamic_dataset_with_force_reassigns_children(tmp_path):
-    dm = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=str(tmp_path))
+def test_delete_dynamic_dataset_with_force_reassigns_children():
+    dm = dm_mod.DatasetManager(path="/db")
 
     parent = dm.dataset_table.insert({"dataset_id": "raw1", "data_type": "tabular"})
 
-    df = pd.DataFrame({"a": [1]})
-
-    child1 = dm.add_dynamic_dataset(df, "r", "e", "p1", parent)
-    child2 = dm.add_dynamic_dataset(df, "r", "e", "p2", child1)
+    child1 = dm.add_dynamic_dataset(
+        path="/path/to/dynamic/child1",
+        researcher_id="r",
+        experiment_id="e",
+        processing_id="p1",
+        parent_dataset_id=parent,
+    )
+    child2 = dm.add_dynamic_dataset(
+        path="/path/to/dynamic/child2",
+        researcher_id="r",
+        experiment_id="e",
+        processing_id="p2",
+        parent_dataset_id=child1,
+    )
 
     dm.delete_dataset_by_id(child1, force=True)
 
@@ -370,15 +354,25 @@ def test_delete_dynamic_dataset_with_force_reassigns_children(tmp_path):
     assert dm.dynamic_dataset_table.get_by_id(child1) is None
 
 
-def test_delete_dataset_by_id_raises(tmp_path):
-    dm = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=str(tmp_path))
+def test_delete_dataset_by_id_raises():
+    dm = dm_mod.DatasetManager(path="/db")
 
     parent = dm.dataset_table.insert({"dataset_id": "raw1", "data_type": "tabular"})
 
-    df = pd.DataFrame({"a": [1]})
-
-    child1 = dm.add_dynamic_dataset(df, "r", "e", "p1", parent)
-    _ = dm.add_dynamic_dataset(df, "r", "e", "p2", child1)
+    child1 = dm.add_dynamic_dataset(
+        path="/path/to/dynamic/child1",
+        researcher_id="r",
+        experiment_id="e",
+        processing_id="p1",
+        parent_dataset_id=parent,
+    )
+    _ = dm.add_dynamic_dataset(
+        path="/path/to/dynamic/child2",
+        researcher_id="r",
+        experiment_id="e",
+        processing_id="p2",
+        parent_dataset_id=child1,
+    )
 
     with pytest.raises(FedbiomedError):
         dm.delete_dataset_by_id(child1)
@@ -388,29 +382,38 @@ def test_delete_dataset_by_id_raises(tmp_path):
         dm.delete_dataset_by_id(parent, force=True)
 
 
-def test_delete_dataset_without_children(tmp_path):
-    dm = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=str(tmp_path))
+def test_delete_dataset_without_children():
+    dm = dm_mod.DatasetManager(path="/db")
 
     parent1 = dm.dataset_table.insert({"dataset_id": "raw1", "data_type": "tabular"})
     parent2 = dm.dataset_table.insert({"dataset_id": "raw2", "data_type": "tabular"})
 
-    df = pd.DataFrame({"a": [1]})
-
-    _ = dm.add_dynamic_dataset(df, "r", "e", "p1", parent1)
+    _ = dm.add_dynamic_dataset(
+        path="/path/to/dynamic/child1",
+        researcher_id="r",
+        experiment_id="e",
+        processing_id="p1",
+        parent_dataset_id=parent1,
+    )
 
     dm.delete_dataset_by_id(parent2)
 
     assert dm.dataset_table.get_by_id(parent2) is None
+    assert dm.dataset_table.get_by_id(parent1) is not None
 
 
-def test_delete_dataset_with_children_recursive(tmp_path):
-    dm = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=str(tmp_path))
+def test_delete_dataset_with_children_recursive():
+    dm = dm_mod.DatasetManager(path="/db")
 
     parent = dm.dataset_table.insert({"dataset_id": "raw1", "data_type": "tabular"})
 
-    df = pd.DataFrame({"a": [1]})
-
-    child = dm.add_dynamic_dataset(df, "r", "e", "p1", parent)
+    child = dm.add_dynamic_dataset(
+        path="/path/to/dynamic/child1",
+        researcher_id="r",
+        experiment_id="e",
+        processing_id="p1",
+        parent_dataset_id=parent,
+    )
 
     # Inject fake subtree behavior
     dm.dynamic_dataset_table._fake_subtrees = {parent: [parent, child]}
@@ -419,4 +422,3 @@ def test_delete_dataset_with_children_recursive(tmp_path):
 
     assert dm.dataset_table.get_by_id(parent) is None
     assert dm.dynamic_dataset_table.get_by_id(child) is None
-    assert not (tmp_path / child).exists()

--- a/tests/test_dataset_manager.py
+++ b/tests/test_dataset_manager.py
@@ -1,4 +1,5 @@
 # tests/test_dataset_manager.py
+import pandas as pd
 import pytest
 
 # ---- Import the module under test (adjust the import line if your path differs) ----
@@ -10,11 +11,12 @@ from fedbiomed.node.dataset_manager import _dataset_manager as dm_mod
 
 
 class FakeTable:
-    """In-memory table replacement compatible with DatasetTable/DlpTable/DlbTable."""
+    """In-memory table replacement compatible with DatasetTable/DlpTable/DlbTable/DynamicDatasetTable."""
 
     def __init__(self, *_, **__):
         self._items = []
         self._by = {}
+        self._fake_subtrees = {}
 
     def insert(self, entry: dict):
         # identify a reasonable key or generate one
@@ -35,6 +37,8 @@ class FakeTable:
         return self._by.get(key)
 
     def get_all_by_value(self, field, values):
+        if not isinstance(values, (list, tuple)):
+            values = [values]
         s = set(values)
         return [row for row in self._items if row.get(field) in s]
 
@@ -45,6 +49,14 @@ class FakeTable:
 
     def all(self):
         return [dict(x) for x in self._items]
+
+    def update_by_id(self, key, updates):
+        item = self._by.get(key)
+        if item is not None:
+            item.update(updates)
+
+    def collect_subtree(self, parent_id):
+        return self._fake_subtrees.get(parent_id, [parent_id])
 
 
 class FakeController:
@@ -78,6 +90,7 @@ def patch_dependencies(monkeypatch):
     so we don't need to mess with sys.modules. Each test starts with a clean in-memory DB.
     """
     monkeypatch.setattr(dm_mod, "DatasetTable", FakeTable, raising=True)
+    monkeypatch.setattr(dm_mod, "DynamicDatasetTable", FakeTable, raising=True)
     monkeypatch.setattr(dm_mod, "DlpTable", FakeTable, raising=True)
     monkeypatch.setattr(dm_mod, "DlbTable", FakeTable, raising=True)
 
@@ -222,3 +235,188 @@ def test_obfuscate_private_information_hides_sensitive_fields():
 def test_obfuscate_private_information_raises_on_bad_item():
     with pytest.raises(FedbiomedError):
         list(dm_mod.DatasetManager.obfuscate_private_information([{"path": "x"}, 123]))
+
+
+def test_create_dynamic_datasets_folder(tmp_path):
+    dynamic_path = tmp_path / "dyn"
+    assert not dynamic_path.exists()
+
+    _ = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=str(dynamic_path))
+
+    assert dynamic_path.exists()
+    assert dynamic_path.is_dir()
+
+
+def test_add_dynamic_dataset_without_path_raises():
+    dm = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=None)
+
+    with pytest.raises(FedbiomedError):
+        dm.add_dynamic_dataset(
+            data=None,
+            researcher_id="r",
+            experiment_id="e",
+            processing_id="p",
+            parent_dataset_id="parent",
+        )
+
+
+def test_get_dataset_entry_from_both_tables(tmp_path):
+    dm = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=str(tmp_path))
+
+    # Insert raw dataset
+    raw_id = dm.dataset_table.insert({"dataset_id": "raw1", "data_type": "tabular"})
+
+    # Insert dynamic dataset
+    dyn_id = dm.dynamic_dataset_table.insert(
+        {"dataset_id": "dyn1", "parent_dataset_id": "raw1"}
+    )
+
+    assert dm._get_dataset_entry("raw1")["dataset_id"] == raw_id
+    assert dm._get_dataset_entry("dyn1")["dataset_id"] == dyn_id
+
+    with pytest.raises(FedbiomedError):
+        dm._get_dataset_entry("does-not-exist")
+
+
+def test_add_dynamic_dataset_creates_files_and_db(tmp_path):
+    dm = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=str(tmp_path))
+
+    # Insert parent raw dataset
+    parent_id = dm.dataset_table.insert({"dataset_id": "raw1", "data_type": "tabular"})
+
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+
+    dyn_id = dm.add_dynamic_dataset(
+        data=df,
+        researcher_id="r",
+        experiment_id="e",
+        processing_id="p",
+        parent_dataset_id=parent_id,
+    )
+
+    # DB entry exists
+    entry = dm.dynamic_dataset_table.get_by_id(dyn_id)
+    assert entry is not None
+    assert entry["data_type"] == "tabular"
+    assert entry["shape"] == (3, 4)
+    assert entry["dtypes"] == {"col1": "float", "col2": "int"}
+
+    # File exists
+    dataset_folder = tmp_path / dyn_id
+    assert dataset_folder.exists()
+    assert (dataset_folder / "data.csv").exists()
+    assert entry["path"] == str(dataset_folder / "data.csv")
+
+
+def test_delete_dynamic_single_removes_files_and_db(tmp_path):
+    dm = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=str(tmp_path))
+
+    parent_id = dm.dataset_table.insert({"dataset_id": "raw1", "data_type": "tabular"})
+
+    df = pd.DataFrame({"a": [1]})
+
+    dyn_id = dm.add_dynamic_dataset(
+        data=df,
+        researcher_id="r",
+        experiment_id="e",
+        processing_id="p",
+        parent_dataset_id=parent_id,
+    )
+
+    dm.delete_dataset_by_id(dyn_id)
+
+    assert dm.dynamic_dataset_table.get_by_id(dyn_id) is None
+    assert not (tmp_path / dyn_id).exists()
+
+
+def test_delete_dynamic_dataset_recursive(tmp_path):
+    dm = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=str(tmp_path))
+
+    parent = dm.dataset_table.insert({"dataset_id": "raw1", "data_type": "tabular"})
+
+    df = pd.DataFrame({"a": [1]})
+
+    child1 = dm.add_dynamic_dataset(df, "r", "e", "p1", parent)
+    child2 = dm.add_dynamic_dataset(df, "r", "e", "p2", child1)
+
+    # Inject fake subtree behavior
+    dm.dynamic_dataset_table._fake_subtrees = {child1: [child1, child2]}
+
+    dm.delete_dataset_by_id(child1, recursive=True)
+
+    assert dm.dataset_table.get_by_id(parent) is not None
+    assert dm.dynamic_dataset_table.get_by_id(child1) is None
+    assert dm.dynamic_dataset_table.get_by_id(child2) is None
+    assert not (tmp_path / child1).exists()
+    assert not (tmp_path / child2).exists()
+
+
+def test_delete_dynamic_dataset_with_force_reassigns_children(tmp_path):
+    dm = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=str(tmp_path))
+
+    parent = dm.dataset_table.insert({"dataset_id": "raw1", "data_type": "tabular"})
+
+    df = pd.DataFrame({"a": [1]})
+
+    child1 = dm.add_dynamic_dataset(df, "r", "e", "p1", parent)
+    child2 = dm.add_dynamic_dataset(df, "r", "e", "p2", child1)
+
+    dm.delete_dataset_by_id(child1, force=True)
+
+    # child2 should now point to raw parent
+    updated = dm.dynamic_dataset_table.get_by_id(child2)
+    assert updated["parent_dataset_id"] == parent
+
+    assert dm.dynamic_dataset_table.get_by_id(child1) is None
+
+
+def test_delete_dataset_by_id_raises(tmp_path):
+    dm = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=str(tmp_path))
+
+    parent = dm.dataset_table.insert({"dataset_id": "raw1", "data_type": "tabular"})
+
+    df = pd.DataFrame({"a": [1]})
+
+    child1 = dm.add_dynamic_dataset(df, "r", "e", "p1", parent)
+    _ = dm.add_dynamic_dataset(df, "r", "e", "p2", child1)
+
+    with pytest.raises(FedbiomedError):
+        dm.delete_dataset_by_id(child1)
+    with pytest.raises(FedbiomedError):
+        dm.delete_dataset_by_id(parent)
+    with pytest.raises(FedbiomedError):
+        dm.delete_dataset_by_id(parent, force=True)
+
+
+def test_delete_dataset_without_children(tmp_path):
+    dm = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=str(tmp_path))
+
+    parent1 = dm.dataset_table.insert({"dataset_id": "raw1", "data_type": "tabular"})
+    parent2 = dm.dataset_table.insert({"dataset_id": "raw2", "data_type": "tabular"})
+
+    df = pd.DataFrame({"a": [1]})
+
+    _ = dm.add_dynamic_dataset(df, "r", "e", "p1", parent1)
+
+    dm.delete_dataset_by_id(parent2)
+
+    assert dm.dataset_table.get_by_id(parent2) is None
+
+
+def test_delete_dataset_with_children_recursive(tmp_path):
+    dm = dm_mod.DatasetManager(path="/db", dynamic_datasets_path=str(tmp_path))
+
+    parent = dm.dataset_table.insert({"dataset_id": "raw1", "data_type": "tabular"})
+
+    df = pd.DataFrame({"a": [1]})
+
+    child = dm.add_dynamic_dataset(df, "r", "e", "p1", parent)
+
+    # Inject fake subtree behavior
+    dm.dynamic_dataset_table._fake_subtrees = {parent: [parent, child]}
+
+    dm.delete_dataset_by_id(parent, recursive=True)
+
+    assert dm.dataset_table.get_by_id(parent) is None
+    assert dm.dynamic_dataset_table.get_by_id(child) is None
+    assert not (tmp_path / child).exists()

--- a/tests/test_dataset_manager.py
+++ b/tests/test_dataset_manager.py
@@ -15,7 +15,6 @@ class FakeTable:
     def __init__(self, *_, **__):
         self._items = []
         self._by = {}
-        self._fake_subtrees = {}
 
     def insert(self, entry: dict):
         # identify a reasonable key or generate one
@@ -54,8 +53,20 @@ class FakeTable:
         if item is not None:
             item.update(updates)
 
+
+class FakeDatasetTable(FakeTable):
+    _table_name = "Datasets"
+
+
+class FakeDynamicDatasetTable(FakeTable):
+    _table_name = "DynamicDatasets"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._fake_subtrees = {}
+
     def collect_subtree(self, parent_id):
-        return self._fake_subtrees.get(parent_id, [parent_id])
+        return self._fake_subtrees.get(parent_id, [])
 
 
 class FakeController:
@@ -88,8 +99,10 @@ def patch_dependencies(monkeypatch):
     Replace the concrete table classes and the controller getter *on the module under test*
     so we don't need to mess with sys.modules. Each test starts with a clean in-memory DB.
     """
-    monkeypatch.setattr(dm_mod, "DatasetTable", FakeTable, raising=True)
-    monkeypatch.setattr(dm_mod, "DynamicDatasetTable", FakeTable, raising=True)
+    monkeypatch.setattr(dm_mod, "DatasetTable", FakeDatasetTable, raising=True)
+    monkeypatch.setattr(
+        dm_mod, "DynamicDatasetTable", FakeDynamicDatasetTable, raising=True
+    )
     monkeypatch.setattr(dm_mod, "DlpTable", FakeTable, raising=True)
     monkeypatch.setattr(dm_mod, "DlbTable", FakeTable, raising=True)
 
@@ -247,8 +260,13 @@ def test_get_dataset_entry_from_both_tables():
         {"dataset_id": "dyn1", "parent_dataset_id": "raw1"}
     )
 
-    assert dm.get_dataset_entry_by_id("raw1")["dataset_id"] == raw_id
-    assert dm.get_dataset_entry_by_id("dyn1")["dataset_id"] == dyn_id
+    raw_dataset_entry, raw_table_name = dm.get_dataset_entry_by_id("raw1")
+    dyn_dataset_entry, dyn_table_name = dm.get_dataset_entry_by_id("dyn1")
+
+    assert raw_dataset_entry["dataset_id"] == raw_id
+    assert dyn_dataset_entry["dataset_id"] == dyn_id
+    assert raw_table_name == "Datasets"
+    assert dyn_table_name == "DynamicDatasets"
 
     with pytest.raises(FedbiomedError):
         dm.get_dataset_entry_by_id("does-not-exist")
@@ -314,18 +332,36 @@ def test_delete_dynamic_dataset_recursive():
         processing_id="p2",
         parent_dataset_id=child1,
     )
+    child3 = dm.add_dynamic_dataset(
+        path="/path/to/dynamic/child3",
+        researcher_id="r",
+        experiment_id="e",
+        processing_id="p3",
+        parent_dataset_id=child2,
+    )
+    child4 = dm.add_dynamic_dataset(
+        path="/path/to/dynamic/child4",
+        researcher_id="r",
+        experiment_id="e",
+        processing_id="p4",
+        parent_dataset_id=parent,
+    )
 
     # Inject fake subtree behavior
-    dm.dynamic_dataset_table._fake_subtrees = {child1: [child1, child2]}
+    dm.dynamic_dataset_table._fake_subtrees = {child1: [child2, child3]}
 
     dm.delete_dataset_by_id(child1, recursive=True)
+    # Test recursive works even with no children
+    dm.delete_dataset_by_id(child4, recursive=True)
 
     assert dm.dataset_table.get_by_id(parent) is not None
     assert dm.dynamic_dataset_table.get_by_id(child1) is None
     assert dm.dynamic_dataset_table.get_by_id(child2) is None
+    assert dm.dynamic_dataset_table.get_by_id(child3) is None
+    assert dm.dynamic_dataset_table.get_by_id(child4) is None
 
 
-def test_delete_dynamic_dataset_with_force_reassigns_children():
+def test_delete_dynamic_dataset_with_reassign_children():
     dm = dm_mod.DatasetManager(path="/db")
 
     parent = dm.dataset_table.insert({"dataset_id": "raw1", "data_type": "tabular"})
@@ -345,7 +381,7 @@ def test_delete_dynamic_dataset_with_force_reassigns_children():
         parent_dataset_id=child1,
     )
 
-    dm.delete_dataset_by_id(child1, force=True)
+    dm.delete_dataset_by_id(child1, reassign_children=True)
 
     # child2 should now point to raw parent
     updated = dm.dynamic_dataset_table.get_by_id(child2)
@@ -379,7 +415,7 @@ def test_delete_dataset_by_id_raises():
     with pytest.raises(FedbiomedError):
         dm.delete_dataset_by_id(parent)
     with pytest.raises(FedbiomedError):
-        dm.delete_dataset_by_id(parent, force=True)
+        dm.delete_dataset_by_id(parent, reassign_children=True)
 
 
 def test_delete_dataset_without_children():
@@ -416,7 +452,7 @@ def test_delete_dataset_with_children_recursive():
     )
 
     # Inject fake subtree behavior
-    dm.dynamic_dataset_table._fake_subtrees = {parent: [parent, child]}
+    dm.dynamic_dataset_table._fake_subtrees = {parent: [child]}
 
     dm.delete_dataset_by_id(parent, recursive=True)
 


### PR DESCRIPTION
**PR description**

First draft implementation of a new generic entry in the database for dynamic datasets (datasets created by researchers through pre-processing or post-processing operations for example).

**Questions / Feedback needed:**
- Need to cross-check all entries in the new `DynamicDatasetEntry`.
- Should the `DatasetManager` also be responsible for saving new dataset files? Currently, in this draft, DatasetManager saves a new CSV file when creating a Dynamic Dataset.
- Who should be responsible for setting the path for saving new files from a Dynamic Dataset?
- How should we manage different types of datasets? The current draft only considers CSV files.
- When deleting a dataset in `DatasetTable`, should we recursively delete all entries in `DynamicDatasetTable` and the corresponding files created from this dataset ? Currently, `delete_dataset_by_id` in `DatasetManager` handles recursive deletion for both datasets in `DatasetTable` and `DynamicDatasetTable`, but there are no changes in `delete_by_id` of DatasetTable. Should we replace `delete_by_id` by the new `delete_dataset_by_id` in gui or cli ?

**Missing:**
- [x] Unit tests

Related issue: #1609 