### PR TITLE
361-Security-Logs-DBTable

### DIFF
--- a/fedbiomed/common/db.py
+++ b/fedbiomed/common/db.py
@@ -45,6 +45,80 @@ def cast_(func):
     return wrapped
 
 
+def _security_log(operation: str, default_stacklevel: int = 3):
+    """Decorator for DBTable methods to add security logging."""
+
+    def _security_log(func):
+        """The actual decorator function that will be applied to the method.
+        It takes the method as an argument and returns a wrapped version of it with security logging."""
+
+        def wrapper(self, *args, **kwargs):
+            """Wrapper function of the actual decorator
+            This wrapper will be called with the same args/kwargs as the original method, and is responsible for:
+            Extracting/logging relevant information from args/kwargs for security events."""
+
+            logging_stacklevel = kwargs.pop("stacklevel", default_stacklevel)
+
+            LOG_VALUE_MAX_LENGTH = 50
+
+            # Reuse your helpers
+            kwargs_stripped = _strip_forbidden_keys(kwargs)
+            args_stripped = _strip_forbidden_keys(args)
+
+            # Log fields from args like you do today
+            arg_fields: dict[str, Any] = {}
+            if len(args_stripped) == 1 and isinstance(args_stripped[0], dict):
+                arg_fields.update(args_stripped[0])
+            else:
+                for i, v in enumerate(args_stripped):
+                    arg_fields[f"arg{i}"] = v
+
+            kwargs_for_log = _truncate_for_logging(
+                kwargs_stripped, max_len=LOG_VALUE_MAX_LENGTH
+            )
+            args_for_log = _truncate_for_logging(
+                arg_fields, max_len=LOG_VALUE_MAX_LENGTH
+            )
+
+            with logger.security_context(operation=operation, table=self.name):
+                try:
+                    result = func(self, *args, **kwargs)
+
+                    result_for_log = result
+                    if operation in {"get", "all", "search"}:
+                        if isinstance(result, list):
+                            result_for_log = f"{len(result)} documents"
+                        elif result is not None:
+                            result_for_log = "1 document"
+                        else:
+                            result_for_log = "0 documents"
+
+                except Exception as e:
+                    logger.security_event(
+                        status="failure",
+                        details=str(e),
+                        **args_for_log,
+                        **kwargs_for_log,
+                        stacklevel=logging_stacklevel,
+                    )
+                    raise FedbiomedError(
+                        f"Failed to {operation} in table {self.name} with error: {e}"
+                    ) from e
+
+                logger.security_event(
+                    status="success",
+                    doc_id=result_for_log,
+                    **args_for_log,
+                    **kwargs_for_log,
+                    stacklevel=logging_stacklevel,
+                )
+            return result
+
+        return wrapper
+
+    return _security_log
+
+
 def _is_forbidden(key: str) -> bool:
     """Set of keys/strings that are not allowed in the database entries"""
     forbidden_strings = {"certificate", "key", "secagg_elem"}
@@ -93,137 +167,36 @@ def _truncate_for_logging(value: Any, max_len: int) -> Any:
 class DBTable(Table):
     """Extends TinyDB table to cast Document type to dict"""
 
-    def _run_with_security_logging(
-        self,
-        *,
-        operation: str,
-        fn: Callable[..., Any],
-        args: tuple[Any, ...],
-        kwargs: Dict[str, Any],
-    ) -> Any:
-        """Runs a TinyDB operation with consistent security logging.
-
-        Args:
-            operation: Logical operation name (eg. 'insert', 'search').
-            fn: Function to execute.
-            args: Positional args forwarded to fn.
-            kwargs: Keyword args forwarded to fn.
-        """
-        logging_stacklevel = kwargs.pop(
-            "stacklevel", 4
-        )  # Adjust stack level to point to caller of DBTable method
-
-        LOG_VALUE_MAX_LENGTH = 50
-
-        kwargs_stripped = _strip_forbidden_keys(kwargs)
-        args_stripped = _strip_forbidden_keys(args)
-
-        # Build log fields from ARGS:
-        # - If it's a single dict positional arg (TinyDB insert/update common case),
-        #   log its items as top-level fields (after stripping) so you get key:value entries.
-        # - Otherwise, log each positional argument separately as arg0, arg1, ...
-        arg_fields: dict[str, Any] = {}
-        if len(args_stripped) == 1 and isinstance(args_stripped[0], dict):
-            # merge payload fields (already stripped)
-            arg_fields.update(args_stripped[0])
-        else:
-            for i, v in enumerate(args_stripped):
-                arg_fields[f"arg{i}"] = v
-
-        kwargs_for_log = _truncate_for_logging(
-            kwargs_stripped, max_len=LOG_VALUE_MAX_LENGTH
-        )
-        args_for_log = _truncate_for_logging(arg_fields, max_len=LOG_VALUE_MAX_LENGTH)
-
-        with logger.security_context(operation=operation, table=self.name):
-            try:
-                doc_id = fn(*args, **kwargs)
-                doc_id_for_log = doc_id
-                if operation in {"get", "all", "search"}:
-                    # For read operations, log the number of documents returned
-                    if isinstance(doc_id, list):
-                        doc_id_for_log = f"{len(doc_id)} documents"
-                    elif doc_id is not None:
-                        doc_id_for_log = "1 document"
-                    else:
-                        doc_id_for_log = "0 documents"
-            except Exception as e:
-                logger.security_event(
-                    status="failure",
-                    details=str(e),
-                    **args_for_log,
-                    **kwargs_for_log,
-                    stacklevel=logging_stacklevel,
-                )
-                raise FedbiomedError(
-                    f"Failed to {operation} in table {self.name} with error: {e}"
-                ) from e
-            logger.security_event(
-                status="success",
-                doc_id=doc_id_for_log,
-                **args_for_log,
-                **kwargs_for_log,
-                stacklevel=logging_stacklevel,
-            )
-
-        return doc_id
-
     @cast_
+    @_security_log("insert", default_stacklevel=3)
     def insert(self, *args, **kwargs):
-        # insert may receive the document as positional arg; sanitize payload to
-        # avoid forbidden keys reaching the DB storage.
-        return self._run_with_security_logging(
-            operation="insert",
-            fn=super().insert,
-            args=args,
-            kwargs=kwargs,
-        )
+        return super().insert(*args, **kwargs)
 
     @cast_
+    @_security_log("search", default_stacklevel=3)
     def search(self, *args, **kwargs):
-        return self._run_with_security_logging(
-            operation="search",
-            fn=super().search,
-            args=args,
-            kwargs=kwargs,
-        )
+        return super().search(*args, **kwargs)
 
     @cast_
+    @_security_log("get", default_stacklevel=3)
     def get(self, *args, **kwargs):
-        return self._run_with_security_logging(
-            operation="get",
-            fn=super().get,
-            args=args,
-            kwargs=kwargs,
-        )
+        return super().get(*args, **kwargs)
 
     @cast_
+    @_security_log("all", default_stacklevel=3)
     def all(self, *args, **kwargs):
-        return self._run_with_security_logging(
-            operation="all",
-            fn=super().all,
-            args=args,
-            kwargs=kwargs,
-        )
+        return super().all(*args, **kwargs)
 
     @cast_
+    @_security_log("update", default_stacklevel=3)
     def update(self, *args, **kwargs):
         # update takes a dict of fields as positional arg in the common case
-        return self._run_with_security_logging(
-            operation="update",
-            fn=super().update,
-            args=args,
-            kwargs=kwargs,
-        )
+        return super().update(*args, **kwargs)
 
     @cast_
+    @_security_log("remove", default_stacklevel=3)
     def remove(self, *args, **kwargs):
-        return self._run_with_security_logging(
-            operation="delete",
-            fn=super().remove,
-            args=args,
-            kwargs=kwargs,
-        )
+        return super().remove(*args, **kwargs)
 
 
 class TinyDBConnector:
@@ -274,7 +247,7 @@ class TinyTableConnector:
             The document if found, otherwise None.
         """
         response = self._table.search(
-            self._query[self._id_name] == id_value, stacklevel=5
+            self._query[self._id_name] == id_value, stacklevel=4
         )
         assert len(response) < 2, (
             f"Multiple entries found for {self._id_name}={id_value}, "
@@ -299,7 +272,7 @@ class TinyTableConnector:
             raise KeyError(
                 f"Entry with {self._id_name}={entry[self._id_name]} already exists."
             )
-        _ = self._table.insert(entry, stacklevel=5)
+        _ = self._table.insert(entry, stacklevel=4)
         return entry[self._id_name]
 
     def all(self) -> List[dict]:
@@ -308,7 +281,7 @@ class TinyTableConnector:
         Returns:
             The list of entries as dicts, or empty list if none found.
         """
-        return self._table.all(stacklevel=5)
+        return self._table.all(stacklevel=4)
 
     def get_all_by_value(self, by: str, value: Any) -> List[dict]:
         """Get all entries by a field value (or empty list if none found).
@@ -324,7 +297,7 @@ class TinyTableConnector:
             self._query[by].one_of(value)
             if isinstance(value, (list, tuple))
             else self._query[by] == value,
-            stacklevel=5,
+            stacklevel=4,
         )
 
     def get_all_by_condition(self, by: str, cond: Callable) -> List[dict]:
@@ -337,7 +310,7 @@ class TinyTableConnector:
         Returns:
             The list of entries as dicts, or empty list if none found.
         """
-        return self._table.search(self._query[by].test(cond), stacklevel=5)
+        return self._table.search(self._query[by].test(cond), stacklevel=4)
 
     def delete_by_id(self, id_value: Union[str, list[str]]) -> List[int]:
         """Delete a document by its ID.
@@ -357,7 +330,7 @@ class TinyTableConnector:
                 raise ValueError("Expected id not to be an empty str.")
 
         return self._table.remove(
-            self._query[self._id_name].one_of(id_value), stacklevel=5
+            self._query[self._id_name].one_of(id_value), stacklevel=4
         )
 
     def update_by_id(self, id_value: str, update: Dict[str, Any]) -> dict:
@@ -374,7 +347,7 @@ class TinyTableConnector:
             raise KeyError(f"No entry found with {self._id_name}={id_value}")
 
         _ = self._table.update(
-            update, self._query[self._id_name] == id_value, stacklevel=5
+            update, self._query[self._id_name] == id_value, stacklevel=4
         )
 
         return self.get_by_id(id_value)

--- a/fedbiomed/common/db.py
+++ b/fedbiomed/common/db.py
@@ -101,11 +101,25 @@ def _security_log(operation: str, default_stacklevel: int = 3):
                         **kwargs_for_log,
                         stacklevel=logging_stacklevel,
                     )
+                    logger.debug(
+                        status="failure",
+                        details=str(e),
+                        **args_for_log,
+                        **kwargs_for_log,
+                        stacklevel=logging_stacklevel,
+                    )
                     raise FedbiomedError(
                         f"Failed to {operation} in table {self.name} with error: {e}"
                     ) from e
 
                 logger.security_event(
+                    status="success",
+                    doc_id=result_for_log,
+                    **args_for_log,
+                    **kwargs_for_log,
+                    stacklevel=logging_stacklevel,
+                )
+                logger.debug(
                     status="success",
                     doc_id=result_for_log,
                     **args_for_log,

--- a/fedbiomed/common/db.py
+++ b/fedbiomed/common/db.py
@@ -97,13 +97,16 @@ def _security_log(operation: str, default_stacklevel: int = 3):
                     logger.security_event(
                         status="failure",
                         details=str(e),
-                        **args_for_log,
-                        **kwargs_for_log,
+                        db_args={**args_for_log},
+                        db_kwargs={**kwargs_for_log},
                         stacklevel=logging_stacklevel,
                     )
                     logger.debug(
                         f"Failed to {operation} in table {self.name} with error: {repr(e)}",
-                        extra={**args_for_log, **kwargs_for_log},
+                        extra={
+                            "db_args": {**args_for_log},
+                            "db_kwargs": {**kwargs_for_log},
+                        },
                         stacklevel=logging_stacklevel,
                     )
                     raise FedbiomedError(
@@ -113,13 +116,16 @@ def _security_log(operation: str, default_stacklevel: int = 3):
                 logger.security_event(
                     status="success",
                     doc_id=result_for_log,
-                    **args_for_log,
-                    **kwargs_for_log,
+                    db_args={**args_for_log},
+                    db_kwargs={**kwargs_for_log},
                     stacklevel=logging_stacklevel,
                 )
                 logger.debug(
                     f"Successfully performed {operation} in table {self.name}, result: {result_for_log}",
-                    extra={**args_for_log, **kwargs_for_log},
+                    extra={
+                        "db_args": {**args_for_log},
+                        "db_kwargs": {**kwargs_for_log},
+                    },
                     stacklevel=logging_stacklevel,
                 )
             return result

--- a/fedbiomed/common/db.py
+++ b/fedbiomed/common/db.py
@@ -102,10 +102,8 @@ def _security_log(operation: str, default_stacklevel: int = 3):
                         stacklevel=logging_stacklevel,
                     )
                     logger.debug(
-                        status="failure",
-                        details=str(e),
-                        **args_for_log,
-                        **kwargs_for_log,
+                        f"Failed to {operation} in table {self.name} with error: {repr(e)}",
+                        extra={**args_for_log, **kwargs_for_log},
                         stacklevel=logging_stacklevel,
                     )
                     raise FedbiomedError(
@@ -120,10 +118,8 @@ def _security_log(operation: str, default_stacklevel: int = 3):
                     stacklevel=logging_stacklevel,
                 )
                 logger.debug(
-                    status="success",
-                    doc_id=result_for_log,
-                    **args_for_log,
-                    **kwargs_for_log,
+                    f"Successfully performed {operation} in table {self.name}, result: {result_for_log}",
+                    extra={**args_for_log, **kwargs_for_log},
                     stacklevel=logging_stacklevel,
                 )
             return result

--- a/fedbiomed/common/db.py
+++ b/fedbiomed/common/db.py
@@ -5,10 +5,15 @@
 Interfaces with a tinyDB database for converting search results to dict.
 """
 
+from __future__ import annotations
+
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from tinydb import Query, TinyDB
 from tinydb.table import Document, Table
+
+from fedbiomed.common.exceptions import FedbiomedError
+from fedbiomed.common.logger import logger
 
 
 def cast_(func):
@@ -40,32 +45,185 @@ def cast_(func):
     return wrapped
 
 
+def _is_forbidden(key: str) -> bool:
+    """Set of keys/strings that are not allowed in the database entries"""
+    forbidden_strings = {"certificate", "key", "secagg_elem"}
+    for forbidden in forbidden_strings:
+        if forbidden in key.lower():
+            return True
+    return False
+
+
+def _strip_forbidden_keys(value: Any) -> Any:
+    """Recursively removes forbidden keys from dict-like payloads.
+
+    This is used to avoid storing or logging sensitive material such as
+    private keys or certificates.
+    """
+    if isinstance(value, dict):
+        return {
+            k: _strip_forbidden_keys(v)
+            for k, v in value.items()
+            if not _is_forbidden(str(k))
+        }
+    if isinstance(value, (list, tuple)):
+        stripped = [_strip_forbidden_keys(v) for v in value]
+        return tuple(stripped) if isinstance(value, tuple) else stripped
+    return value
+
+
+def _truncate_for_logging(value: Any, max_len: int) -> Any:
+    """Recursively truncates long stringified values for logging."""
+    if isinstance(value, dict):
+        out: dict[Any, Any] = {}
+        for k, v in value.items():
+            out[k] = _truncate_for_logging(v, max_len=max_len)
+        return out
+
+    if isinstance(value, (list, tuple)):
+        truncated = [_truncate_for_logging(v, max_len=max_len) for v in value]
+        return tuple(truncated) if isinstance(value, tuple) else truncated
+
+    s = str(value)
+    if len(s) > max_len:
+        return s[:max_len] + "..."
+    return value
+
+
 class DBTable(Table):
     """Extends TinyDB table to cast Document type to dict"""
 
+    def _run_with_security_logging(
+        self,
+        *,
+        operation: str,
+        fn: Callable[..., Any],
+        args: tuple[Any, ...],
+        kwargs: Dict[str, Any],
+    ) -> Any:
+        """Runs a TinyDB operation with consistent security logging.
+
+        Args:
+            operation: Logical operation name (eg. 'insert', 'search').
+            fn: Function to execute.
+            args: Positional args forwarded to fn.
+            kwargs: Keyword args forwarded to fn.
+        """
+        logging_stacklevel = kwargs.pop(
+            "stacklevel", 4
+        )  # Adjust stack level to point to caller of DBTable method
+
+        LOG_VALUE_MAX_LENGTH = 50
+
+        kwargs_stripped = _strip_forbidden_keys(kwargs)
+        args_stripped = _strip_forbidden_keys(args)
+
+        # Build log fields from ARGS:
+        # - If it's a single dict positional arg (TinyDB insert/update common case),
+        #   log its items as top-level fields (after stripping) so you get key:value entries.
+        # - Otherwise, log each positional argument separately as arg0, arg1, ...
+        arg_fields: dict[str, Any] = {}
+        if len(args_stripped) == 1 and isinstance(args_stripped[0], dict):
+            # merge payload fields (already stripped)
+            arg_fields.update(args_stripped[0])
+        else:
+            for i, v in enumerate(args_stripped):
+                arg_fields[f"arg{i}"] = v
+
+        kwargs_for_log = _truncate_for_logging(
+            kwargs_stripped, max_len=LOG_VALUE_MAX_LENGTH
+        )
+        args_for_log = _truncate_for_logging(arg_fields, max_len=LOG_VALUE_MAX_LENGTH)
+
+        with logger.security_context(operation=operation, table=self.name):
+            try:
+                doc_id = fn(*args, **kwargs)
+                doc_id_for_log = doc_id
+                if operation in {"get", "all", "search"}:
+                    # For read operations, log the number of documents returned
+                    if isinstance(doc_id, list):
+                        doc_id_for_log = f"{len(doc_id)} documents"
+                    elif doc_id is not None:
+                        doc_id_for_log = "1 document"
+                    else:
+                        doc_id_for_log = "0 documents"
+            except Exception as e:
+                logger.security_event(
+                    status="failure",
+                    details=str(e),
+                    **args_for_log,
+                    **kwargs_for_log,
+                    stacklevel=logging_stacklevel,
+                )
+                raise FedbiomedError(
+                    f"Failed to {operation} in table {self.name} with error: {e}"
+                ) from e
+            logger.security_event(
+                status="success",
+                doc_id=doc_id_for_log,
+                **args_for_log,
+                **kwargs_for_log,
+                stacklevel=logging_stacklevel,
+            )
+
+        return doc_id
+
     @cast_
     def insert(self, *args, **kwargs):
-        return super().insert(*args, **kwargs)
+        # insert may receive the document as positional arg; sanitize payload to
+        # avoid forbidden keys reaching the DB storage.
+        return self._run_with_security_logging(
+            operation="insert",
+            fn=super().insert,
+            args=args,
+            kwargs=kwargs,
+        )
 
     @cast_
     def search(self, *args, **kwargs):
-        return super().search(*args, **kwargs)
+        return self._run_with_security_logging(
+            operation="search",
+            fn=super().search,
+            args=args,
+            kwargs=kwargs,
+        )
 
     @cast_
     def get(self, *args, **kwargs):
-        return super().get(*args, **kwargs)
+        return self._run_with_security_logging(
+            operation="get",
+            fn=super().get,
+            args=args,
+            kwargs=kwargs,
+        )
 
     @cast_
     def all(self, *args, **kwargs):
-        return super().all(*args, **kwargs)
+        return self._run_with_security_logging(
+            operation="all",
+            fn=super().all,
+            args=args,
+            kwargs=kwargs,
+        )
 
     @cast_
     def update(self, *args, **kwargs):
-        return super().update(*args, **kwargs)
+        # update takes a dict of fields as positional arg in the common case
+        return self._run_with_security_logging(
+            operation="update",
+            fn=super().update,
+            args=args,
+            kwargs=kwargs,
+        )
 
     @cast_
-    def delete(self, *args, **kwargs):
-        return super().remove(*args, **kwargs)
+    def remove(self, *args, **kwargs):
+        return self._run_with_security_logging(
+            operation="delete",
+            fn=super().remove,
+            args=args,
+            kwargs=kwargs,
+        )
 
 
 class TinyDBConnector:
@@ -115,7 +273,9 @@ class TinyTableConnector:
         Returns:
             The document if found, otherwise None.
         """
-        response = self._table.search(self._query[self._id_name] == id_value)
+        response = self._table.search(
+            self._query[self._id_name] == id_value, stacklevel=5
+        )
         assert len(response) < 2, (
             f"Multiple entries found for {self._id_name}={id_value}, "
             "which should be unique."
@@ -139,7 +299,7 @@ class TinyTableConnector:
             raise KeyError(
                 f"Entry with {self._id_name}={entry[self._id_name]} already exists."
             )
-        _ = self._table.insert(entry)
+        _ = self._table.insert(entry, stacklevel=5)
         return entry[self._id_name]
 
     def all(self) -> List[dict]:
@@ -148,7 +308,7 @@ class TinyTableConnector:
         Returns:
             The list of entries as dicts, or empty list if none found.
         """
-        return self._table.all()
+        return self._table.all(stacklevel=5)
 
     def get_all_by_value(self, by: str, value: Any) -> List[dict]:
         """Get all entries by a field value (or empty list if none found).
@@ -163,7 +323,8 @@ class TinyTableConnector:
         return self._table.search(
             self._query[by].one_of(value)
             if isinstance(value, (list, tuple))
-            else self._query[by] == value
+            else self._query[by] == value,
+            stacklevel=5,
         )
 
     def get_all_by_condition(self, by: str, cond: Callable) -> List[dict]:
@@ -176,7 +337,7 @@ class TinyTableConnector:
         Returns:
             The list of entries as dicts, or empty list if none found.
         """
-        return self._table.search(self._query[by].test(cond))
+        return self._table.search(self._query[by].test(cond), stacklevel=5)
 
     def delete_by_id(self, id_value: Union[str, list[str]]) -> List[int]:
         """Delete a document by its ID.
@@ -195,7 +356,9 @@ class TinyTableConnector:
             if not id_value:
                 raise ValueError("Expected id not to be an empty str.")
 
-        return self._table.delete(self._query[self._id_name].one_of(id_value))
+        return self._table.remove(
+            self._query[self._id_name].one_of(id_value), stacklevel=5
+        )
 
     def update_by_id(self, id_value: str, update: Dict[str, Any]) -> dict:
         """Update a document by its ID.
@@ -210,6 +373,8 @@ class TinyTableConnector:
         if self.get_by_id(id_value) is None:
             raise KeyError(f"No entry found with {self._id_name}={id_value}")
 
-        _ = self._table.update(update, self._query[self._id_name] == id_value)
+        _ = self._table.update(
+            update, self._query[self._id_name] == id_value, stacklevel=5
+        )
 
         return self.get_by_id(id_value)

--- a/fedbiomed/common/logger.py
+++ b/fedbiomed/common/logger.py
@@ -92,6 +92,14 @@ class _SecurityOnlyFilter(logging.Filter):
         return bool(getattr(record, "is_security", False))
 
 
+class _ExcludeSecurityFilter(logging.Filter):
+    """Filter that blocks security log records (is_security=True)."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        # If record.is_security is True, drop it from this handler.
+        return not bool(getattr(record, "is_security", False))
+
+
 class _SecurityFormatter(logging.Formatter):
     """Formats security log records as JSON with consistent structure."""
 
@@ -583,6 +591,10 @@ class FedLogger(metaclass=SingletonMeta):
 
         formatter = logging.Formatter(format.replace(LOG_PREFIX, ""))
         handler.setFormatter(formatter)
+
+        # Prevent security audit logs from appearing in interactive console (e.g., IPython).
+        handler.addFilter(_ExcludeSecurityFilter())
+
         self._internal_add_handler("CONSOLE", handler, format)
 
         pass
@@ -609,6 +621,10 @@ class FedLogger(metaclass=SingletonMeta):
         formatter = _GrpcFormatter(node_id)
 
         handler.setFormatter(formatter)
+
+        # Never transmit security audit logs to the researcher via gRPC.
+        handler.addFilter(_ExcludeSecurityFilter())
+
         self._internal_add_handler("GRPC", handler)
 
         # as a side effect this will set the minimal level to ERROR

--- a/fedbiomed/common/logger.py
+++ b/fedbiomed/common/logger.py
@@ -378,6 +378,7 @@ class FedLogger(metaclass=SingletonMeta):
         operation: Optional[str] = None,
         status: Optional[str] = None,
         researcher_id: Optional[str] = None,
+        stacklevel: int = 1,
         **fields: Any,
     ) -> None:
         """
@@ -394,6 +395,8 @@ class FedLogger(metaclass=SingletonMeta):
             operation: Name of the operation being logged (e.g., 'dataset_search', 'training_execute')
             status: Status of the operation (e.g., 'success', 'failure', 'pending')
             researcher_id: ID of the researcher performing the operation
+            stacklevel: How many frames to skip when attributing the caller.
+                Use higher values when calling `security_event` from within wrappers.
             **fields: Additional fields to log (e.g., dataset_id, experiment_id, node_id)
         """
         ctx = dict(SECURITY_CONTEXT.get() or {})
@@ -402,10 +405,15 @@ class FedLogger(metaclass=SingletonMeta):
         st = status or ctx.get("status")
         rid = researcher_id or ctx.get("researcher_id")
 
-        # Capture caller information from the stack
+        # Capture caller information from the stack.
+        # `stacklevel` follows Python logging semantics: stacklevel=2 points to the
+        # caller of this wrapper method.
         try:
             frame = inspect.currentframe()
-            caller_frame = frame.f_back if frame else None
+            caller_frame = frame
+            steps = max(int(stacklevel), 0)
+            for _ in range(steps):
+                caller_frame = caller_frame.f_back if caller_frame else None
             caller_info = {
                 "caller_function": caller_frame.f_code.co_name
                 if caller_frame
@@ -470,6 +478,7 @@ class FedLogger(metaclass=SingletonMeta):
         self._logger.info(
             json.dumps(entry, default=str, separators=(",", ":")),
             extra={"is_security": True},
+            stacklevel=stacklevel,
         )
 
     def _internal_add_handler(

--- a/tests/test_db_security_log.py
+++ b/tests/test_db_security_log.py
@@ -52,16 +52,16 @@ def test_security_log_success_strips_forbidden_and_truncates(
     assert logged["stacklevel"] == 42
 
     # Forbidden keys stripped from payload/kwargs logging
-    assert "certificate" not in logged
-    assert "key" not in logged
-    assert logged["nested"] == {"keep": 1}
+    assert "certificate" not in logged["db_args"]
+    assert "key" not in logged["db_args"]
+    assert logged["db_args"]["nested"] == {"keep": 1}
 
     # Truncation applied (50 chars + '...')
-    assert isinstance(logged["long"], str)
-    assert logged["long"].endswith("...")
-    assert len(logged["long"]) <= 53
-    assert isinstance(logged["extra_kw"], str)
-    assert logged["extra_kw"].endswith("...")
+    assert isinstance(logged["db_args"]["long"], str)
+    assert logged["db_args"]["long"].endswith("...")
+    assert len(logged["db_args"]["long"]) <= 53
+    assert isinstance(logged["db_kwargs"]["extra_kw"], str)
+    assert logged["db_kwargs"]["extra_kw"].endswith("...")
 
 
 def test_security_log_success_summarizes_search_results(
@@ -85,7 +85,7 @@ def test_security_log_success_summarizes_search_results(
     logged = security_event.call_args.kwargs
     assert logged["status"] == "success"
     assert logged["doc_id"] == "3 documents"
-    assert logged["arg0"] == "hello"
+    assert logged["db_args"]["arg0"] == "hello"
     assert logged["stacklevel"] == 3
 
 
@@ -117,5 +117,5 @@ def test_security_log_failure_logs_and_wraps_exception(
     assert logged["stacklevel"] == 9
 
     # Forbidden keys stripped from args logging even on failure
-    assert "certificate" not in logged
-    assert logged["keep"] == "ok"
+    assert "certificate" not in logged["db_args"]
+    assert logged["db_args"]["keep"] == "ok"

--- a/tests/test_db_security_log.py
+++ b/tests/test_db_security_log.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+from unittest.mock import Mock
+
+import pytest
+
+import fedbiomed.common.db as db_mod
+from fedbiomed.common.db import _security_log
+from fedbiomed.common.exceptions import FedbiomedError
+
+
+def test_security_log_success_strips_forbidden_and_truncates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    security_event = Mock()
+    security_context = Mock(side_effect=lambda **_: nullcontext())
+
+    monkeypatch.setattr(db_mod.logger, "security_event", security_event)
+    monkeypatch.setattr(db_mod.logger, "security_context", security_context)
+
+    class _FakeTable:
+        name = "my_table"
+
+        @_security_log("insert", default_stacklevel=3)
+        def insert(self, payload: dict, **kwargs):
+            # Ensure decorator popped stacklevel and didn't pass it through.
+            self.kwargs_seen = dict(kwargs)
+            return 7
+
+    table = _FakeTable()
+
+    payload = {
+        "ok": "value",
+        "certificate": "SUPER-SECRET",
+        "key": "ALSO-SECRET",
+        "nested": {"secagg_elem": "SECRET", "keep": 1},
+        "long": "x" * 200,
+    }
+
+    result = table.insert(payload, stacklevel=42, extra_kw="y" * 200)
+
+    assert result == 7
+    assert "stacklevel" not in table.kwargs_seen
+
+    security_context.assert_called_once_with(operation="insert", table="my_table")
+    security_event.assert_called_once()
+
+    logged = security_event.call_args.kwargs
+    assert logged["status"] == "success"
+    assert logged["doc_id"] == 7
+    assert logged["stacklevel"] == 42
+
+    # Forbidden keys stripped from payload/kwargs logging
+    assert "certificate" not in logged
+    assert "key" not in logged
+    assert logged["nested"] == {"keep": 1}
+
+    # Truncation applied (50 chars + '...')
+    assert isinstance(logged["long"], str)
+    assert logged["long"].endswith("...")
+    assert len(logged["long"]) <= 53
+    assert isinstance(logged["extra_kw"], str)
+    assert logged["extra_kw"].endswith("...")
+
+
+def test_security_log_success_summarizes_search_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    security_event = Mock()
+    monkeypatch.setattr(db_mod.logger, "security_event", security_event)
+    monkeypatch.setattr(db_mod.logger, "security_context", lambda **_: nullcontext())
+
+    class _FakeTable:
+        name = "my_table"
+
+        @_security_log("search", default_stacklevel=3)
+        def search(self, query: str, **kwargs):
+            return ["a", "b", "c"]
+
+    table = _FakeTable()
+
+    _ = table.search("hello")
+
+    logged = security_event.call_args.kwargs
+    assert logged["status"] == "success"
+    assert logged["doc_id"] == "3 documents"
+    assert logged["arg0"] == "hello"
+    assert logged["stacklevel"] == 3
+
+
+def test_security_log_failure_logs_and_wraps_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    security_event = Mock()
+    monkeypatch.setattr(db_mod.logger, "security_event", security_event)
+    monkeypatch.setattr(db_mod.logger, "security_context", lambda **_: nullcontext())
+
+    class _FakeTable:
+        name = "my_table"
+
+        @_security_log("remove", default_stacklevel=3)
+        def remove(self, payload: dict, **kwargs):
+            raise ValueError("boom")
+
+    table = _FakeTable()
+
+    with pytest.raises(FedbiomedError) as excinfo:
+        table.remove({"certificate": "SECRET", "keep": "ok"}, stacklevel=9)
+
+    assert "Failed to remove in table my_table" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, ValueError)
+
+    logged = security_event.call_args.kwargs
+    assert logged["status"] == "failure"
+    assert logged["details"] == "boom"
+    assert logged["stacklevel"] == 9
+
+    # Forbidden keys stripped from args logging even on failure
+    assert "certificate" not in logged
+    assert logged["keep"] == "ok"


### PR DESCRIPTION
This PR implements security logging on all CRUD operations on the database. Therefore, it covers operations on:

- Datasets
- Training Plans
- and Certificates

