### PR TITLE
Correct link to download IXI dataset and improve script

### DIFF
--- a/docs/tutorials/medical/download_and_split_ixi.py
+++ b/docs/tutorials/medical/download_and_split_ixi.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
+import argparse
 import hashlib
 import os
-import requests
-from tqdm import tqdm
-import argparse
-from zipfile import ZipFile
 import shutil
+from zipfile import ZipFile
+
 import pandas as pd
+import requests
 from sklearn.model_selection import train_test_split
+from tqdm import tqdm
 
 from fedbiomed.node.config import node_component
 
@@ -36,15 +37,25 @@ def has_correct_checksum_md5(filename, hash):
 
 def download_file(url, filename):
     """
-    Helper method handling downloading large files from `url` to `filename`. Returns a pointer to `filename`.
+    Download a large file from `url` and save it to `filename`.
+    Raises requests.HTTPError if the server returns an error status.
     """
-    print("Downloading file from:", url)
-    print("File will be saved as:", filename)
-    chunkSize = 1024
+    print(f"Downloading file from: {url}")
+    print(f"File will be saved as: {filename}")
+    chunk_size = 1024
     r = requests.get(url, stream=True)
+    r.raise_for_status()
+
+    content_length = r.headers.get("Content-Length")
+    total = int(content_length) if content_length is not None else None
+    if total is None:
+        print(
+            "Warning: server did not provide Content-Length; progress bar will be indeterminate."
+        )
+
     with open(filename, "wb") as f:
-        pbar = tqdm(unit="B", total=int(r.headers["Content-Length"]))
-        for chunk in r.iter_content(chunk_size=chunkSize):
+        pbar = tqdm(unit="B", total=total, unit_scale=True)
+        for chunk in r.iter_content(chunk_size=chunk_size):
             if chunk:  # filter out keep-alive new chunks
                 pbar.update(len(chunk))
                 f.write(chunk)
@@ -52,73 +63,102 @@ def download_file(url, filename):
 
 
 def download_and_extract_ixi_sample(root_folder):
-    url = "https://prod-dcd-datasets-cache-zipfiles.s3.eu-west-1.amazonaws.com/7kd5wj7v7p-3.zip"
+    url = "https://data.mendeley.com/public-api/zip/7kd5wj7v7p/download/3"
     zip_filename = os.path.join(root_folder, "notebooks", "data", "7kd5wj7v7p-3.zip")
     data_folder = os.path.join(root_folder, "notebooks", "data")
     extracted_folder = os.path.join(data_folder, "7kd5wj7v7p-3", "IXI_sample")
 
-    # Extract if ZIP exists but not folder
     if not os.path.exists(zip_filename):
-        # Download if it does not exist
         download_file(url, zip_filename)
 
-    # Check if extracted folder exists
+    # Skip extraction if already done
     if os.path.isdir(extracted_folder):
-        print(f"Dataset folder already exists in {extracted_folder}")
+        print(f"Dataset folder already exists at: {extracted_folder}")
         return extracted_folder
 
-    assert has_correct_checksum_md5(zip_filename, "eecb83422a2685937a955251fa45cb03")
+    print("Verifying checksum of downloaded ZIP...")
+    expected_md5 = "eecb83422a2685937a955251fa45cb03"
+    if not has_correct_checksum_md5(zip_filename, expected_md5):
+        raise ValueError(
+            f"MD5 checksum mismatch for '{zip_filename}'. "
+            "The file may be corrupted or incomplete. "
+            "Delete it and re-run the script to download it again."
+        )
+    print("Checksum OK. Extracting ZIP...")
+
     with ZipFile(zip_filename, "r") as zip_obj:
         zip_obj.extractall(data_folder)
 
-    assert os.path.isdir(extracted_folder)
+    if not os.path.isdir(extracted_folder):
+        raise RuntimeError(
+            f"Extraction completed but expected folder was not found: '{extracted_folder}'. "
+            "The ZIP archive may have a different internal structure than expected."
+        )
+
+    print(f"Extraction complete. Dataset located at: {extracted_folder}")
     return extracted_folder
 
 
 if __name__ == "__main__":
     args = parse_args()
     root_folder = os.path.abspath(os.path.expanduser(args.root_folder))
-    assert os.path.isdir(root_folder), f"Folder does not exist: {root_folder}"
 
-    # Centralized dataset
+    if not os.path.isdir(root_folder):
+        raise SystemExit(f"Error: root folder does not exist: '{root_folder}'")
+
+    # Download and extract the centralized dataset
+    print("--- Step 1: Downloading and extracting IXI sample dataset ---")
     centralized_data_folder = download_and_extract_ixi_sample(root_folder)
 
-    # Federated Dataset
+    # Prepare the federated split output folder
     federated_data_folder = os.path.join(
         root_folder, "notebooks", "data", "Hospital-Centers"
     )
     shutil.rmtree(federated_data_folder, ignore_errors=True)
 
     csv_global = os.path.join(centralized_data_folder, "participants.csv")
+    if not os.path.isfile(csv_global):
+        raise FileNotFoundError(
+            f"Expected participants CSV not found: '{csv_global}'. "
+            "The dataset may not have been extracted correctly."
+        )
     allcenters = pd.read_csv(csv_global)
 
-    # Split centers
+    # Split into per-center federated nodes
+    print("\n--- Step 2: Splitting dataset into federated center nodes ---")
     center_names = ["Guys", "HH", "IOP"]
     center_dfs = list()
 
     for center_name in center_names:
-        cfg_folder = os.path.join(args.root_folder, f"{center_name}")
-        os.makedirs(cfg_folder, exist_ok=True)
-        cfg_file = os.path.join(cfg_folder, f"{center_name.lower()}.ini")
+        component_folder = os.path.join(os.getcwd(), center_name.lower())
 
-        print(f"Creating node at: {cfg_file}")
-        node_component.initiate()
-        if node_component.is_component_existing(root_folder):
-            print(f"**Warning: component {root_folder} already exists")
+        print(f"\nProcessing center '{center_name}' -> {component_folder}")
+        if node_component.is_component_existing(component_folder) and not args.force:
+            print(
+                f"Warning: component '{component_folder}' already exists. "
+                "Skipping node initialisation. Use --force to overwrite."
+            )
         else:
-            node_component.initiate(root_folder)
+            node_component.initiate(component_folder)
 
         df = allcenters[allcenters.SITE_NAME == center_name]
+        if df.empty:
+            raise ValueError(
+                f"No subjects found for center '{center_name}' in '{csv_global}'. "
+                "Check that SITE_NAME values match the expected center names."
+            )
         center_dfs.append(df)
 
         train, test = train_test_split(df, test_size=0.1, random_state=21)
+        print(f"  Train subjects: {len(train)}, holdout subjects: {len(test)}")
 
-        train_folder = os.path.join(federated_data_folder, center_name, "train")
-        holdout_folder = os.path.join(federated_data_folder, center_name, "holdout")
-        if not os.path.exists(train_folder):
-            os.makedirs(train_folder)
-        if not os.path.exists(holdout_folder):
-            os.makedirs(holdout_folder)
+        train_folder = os.path.join(os.getcwd(), center_name.lower(), "data", "train")
+        holdout_folder = os.path.join(
+            os.getcwd(), center_name.lower(), "data", "holdout"
+        )
+
+        os.makedirs(train_folder, exist_ok=True)
+        os.makedirs(holdout_folder, exist_ok=True)
 
         for subject_folder in train.FOLDER_NAME.values:
             shutil.copytree(
@@ -126,9 +166,7 @@ if __name__ == "__main__":
                 dst=os.path.join(train_folder, subject_folder),
                 dirs_exist_ok=True,
             )
-
-        train_participants_csv = os.path.join(train_folder, "participants.csv")
-        train.to_csv(train_participants_csv)
+        train.to_csv(os.path.join(train_folder, "participants.csv"))
 
         for subject_folder in test.FOLDER_NAME.values:
             shutil.copytree(
@@ -138,15 +176,16 @@ if __name__ == "__main__":
             )
         test.to_csv(os.path.join(holdout_folder, "participants.csv"))
 
-    print(f"Centralized dataset located at: {centralized_data_folder}")
-    print(f"Federated dataset located at: {federated_data_folder}")
+    print("\n--- Setup complete ---")
+    print(f"Centralized dataset: {centralized_data_folder}")
+    print(f"Federated dataset:   {federated_data_folder}")
 
-    print()
-    print("Please add the data to your nodes executing and using the `ixi-train` tag:")
+    print(
+        "\nTo add data to each node (select 'medical folder dataset' and use tag 'ixi-train'):"
+    )
     for center_name in center_names:
-        print(f"\tfedbiomed node --path ./{center_name.lower()} dataset add")
+        print(f"\tfedbiomed node -p {center_name.lower()} dataset add")
 
-    print()
-    print("Then start your nodes by executing:")
+    print("\nTo start each node:")
     for center_name in center_names:
-        print(f"\tfedbiomed node --path ./{center_name.lower()} start")
+        print(f"\tfedbiomed node -p {center_name.lower()} start")

--- a/notebooks/medical-image-segmentation/download_and_split_ixi.py
+++ b/notebooks/medical-image-segmentation/download_and_split_ixi.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
+import argparse
 import hashlib
 import os
-import requests
-from tqdm import tqdm
-import argparse
-from zipfile import ZipFile
 import shutil
+from zipfile import ZipFile
+
 import pandas as pd
+import requests
 from sklearn.model_selection import train_test_split
+from tqdm import tqdm
 
 from fedbiomed.node.config import node_component
 
@@ -36,15 +37,25 @@ def has_correct_checksum_md5(filename, hash):
 
 def download_file(url, filename):
     """
-    Helper method handling downloading large files from `url` to `filename`. Returns a pointer to `filename`.
+    Download a large file from `url` and save it to `filename`.
+    Raises requests.HTTPError if the server returns an error status.
     """
-    print("Downloading file from:", url)
-    print("File will be saved as:", filename)
-    chunkSize = 1024
+    print(f"Downloading file from: {url}")
+    print(f"File will be saved as: {filename}")
+    chunk_size = 1024
     r = requests.get(url, stream=True)
+    r.raise_for_status()
+
+    content_length = r.headers.get("Content-Length")
+    total = int(content_length) if content_length is not None else None
+    if total is None:
+        print(
+            "Warning: server did not provide Content-Length; progress bar will be indeterminate."
+        )
+
     with open(filename, "wb") as f:
-        pbar = tqdm(unit="B", total=int(r.headers["Content-Length"]))
-        for chunk in r.iter_content(chunk_size=chunkSize):
+        pbar = tqdm(unit="B", total=total, unit_scale=True)
+        for chunk in r.iter_content(chunk_size=chunk_size):
             if chunk:  # filter out keep-alive new chunks
                 pbar.update(len(chunk))
                 f.write(chunk)
@@ -52,75 +63,102 @@ def download_file(url, filename):
 
 
 def download_and_extract_ixi_sample(root_folder):
-    url = "https://prod-dcd-datasets-cache-zipfiles.s3.eu-west-1.amazonaws.com/7kd5wj7v7p-3.zip"
+    url = "https://data.mendeley.com/public-api/zip/7kd5wj7v7p/download/3"
     zip_filename = os.path.join(root_folder, "notebooks", "data", "7kd5wj7v7p-3.zip")
     data_folder = os.path.join(root_folder, "notebooks", "data")
     extracted_folder = os.path.join(data_folder, "7kd5wj7v7p-3", "IXI_sample")
 
-    # Extract if ZIP exists but not folder
     if not os.path.exists(zip_filename):
-        # Download if it does not exist
         download_file(url, zip_filename)
 
-    # Check if extracted folder exists
+    # Skip extraction if already done
     if os.path.isdir(extracted_folder):
-        print(f"Dataset folder already exists in {extracted_folder}")
+        print(f"Dataset folder already exists at: {extracted_folder}")
         return extracted_folder
 
-    assert has_correct_checksum_md5(zip_filename, "eecb83422a2685937a955251fa45cb03")
+    print("Verifying checksum of downloaded ZIP...")
+    expected_md5 = "eecb83422a2685937a955251fa45cb03"
+    if not has_correct_checksum_md5(zip_filename, expected_md5):
+        raise ValueError(
+            f"MD5 checksum mismatch for '{zip_filename}'. "
+            "The file may be corrupted or incomplete. "
+            "Delete it and re-run the script to download it again."
+        )
+    print("Checksum OK. Extracting ZIP...")
+
     with ZipFile(zip_filename, "r") as zip_obj:
         zip_obj.extractall(data_folder)
 
-    assert os.path.isdir(extracted_folder)
+    if not os.path.isdir(extracted_folder):
+        raise RuntimeError(
+            f"Extraction completed but expected folder was not found: '{extracted_folder}'. "
+            "The ZIP archive may have a different internal structure than expected."
+        )
+
+    print(f"Extraction complete. Dataset located at: {extracted_folder}")
     return extracted_folder
 
 
 if __name__ == "__main__":
     args = parse_args()
     root_folder = os.path.abspath(os.path.expanduser(args.root_folder))
-    assert os.path.isdir(root_folder), f"Folder does not exist: {root_folder}"
 
-    # Centralized dataset
+    if not os.path.isdir(root_folder):
+        raise SystemExit(f"Error: root folder does not exist: '{root_folder}'")
+
+    # Download and extract the centralized dataset
+    print("--- Step 1: Downloading and extracting IXI sample dataset ---")
     centralized_data_folder = download_and_extract_ixi_sample(root_folder)
 
-    # Federated Dataset
+    # Prepare the federated split output folder
     federated_data_folder = os.path.join(
         root_folder, "notebooks", "data", "Hospital-Centers"
     )
     shutil.rmtree(federated_data_folder, ignore_errors=True)
 
     csv_global = os.path.join(centralized_data_folder, "participants.csv")
+    if not os.path.isfile(csv_global):
+        raise FileNotFoundError(
+            f"Expected participants CSV not found: '{csv_global}'. "
+            "The dataset may not have been extracted correctly."
+        )
     allcenters = pd.read_csv(csv_global)
 
-    # Split centers
+    # Split into per-center federated nodes
+    print("\n--- Step 2: Splitting dataset into federated center nodes ---")
     center_names = ["Guys", "HH", "IOP"]
     center_dfs = list()
 
     for center_name in center_names:
         component_folder = os.path.join(os.getcwd(), center_name.lower())
 
-        print(f"Creating node at: {component_folder}")
+        print(f"\nProcessing center '{center_name}' -> {component_folder}")
         if node_component.is_component_existing(component_folder) and not args.force:
             print(
-                f"**Warning: component {component_folder} already exists. To overwrite, please specify `--force` option"
+                f"Warning: component '{component_folder}' already exists. "
+                "Skipping node initialisation. Use --force to overwrite."
             )
         else:
             node_component.initiate(component_folder)
 
         df = allcenters[allcenters.SITE_NAME == center_name]
+        if df.empty:
+            raise ValueError(
+                f"No subjects found for center '{center_name}' in '{csv_global}'. "
+                "Check that SITE_NAME values match the expected center names."
+            )
         center_dfs.append(df)
 
         train, test = train_test_split(df, test_size=0.1, random_state=21)
+        print(f"  Train subjects: {len(train)}, holdout subjects: {len(test)}")
 
         train_folder = os.path.join(os.getcwd(), center_name.lower(), "data", "train")
         holdout_folder = os.path.join(
             os.getcwd(), center_name.lower(), "data", "holdout"
         )
 
-        if not os.path.exists(train_folder):
-            os.makedirs(train_folder)
-        if not os.path.exists(holdout_folder):
-            os.makedirs(holdout_folder)
+        os.makedirs(train_folder, exist_ok=True)
+        os.makedirs(holdout_folder, exist_ok=True)
 
         for subject_folder in train.FOLDER_NAME.values:
             shutil.copytree(
@@ -128,9 +166,7 @@ if __name__ == "__main__":
                 dst=os.path.join(train_folder, subject_folder),
                 dirs_exist_ok=True,
             )
-
-        train_participants_csv = os.path.join(train_folder, "participants.csv")
-        train.to_csv(train_participants_csv)
+        train.to_csv(os.path.join(train_folder, "participants.csv"))
 
         for subject_folder in test.FOLDER_NAME.values:
             shutil.copytree(
@@ -140,16 +176,16 @@ if __name__ == "__main__":
             )
         test.to_csv(os.path.join(holdout_folder, "participants.csv"))
 
-    print(f"Centralized dataset located at: {centralized_data_folder}")
-    print(f"Federated dataset located at: {federated_data_folder}")
+    print("\n--- Setup complete ---")
+    print(f"Centralized dataset: {centralized_data_folder}")
+    print(f"Federated dataset:   {federated_data_folder}")
 
-    print()
     print(
-        "Please add the data to your nodes executing and using the `ixi-train` tag (selecting option medical folder dataset):"
+        "\nTo add data to each node (select 'medical folder dataset' and use tag 'ixi-train'):"
     )
     for center_name in center_names:
         print(f"\tfedbiomed node -p {center_name.lower()} dataset add")
 
-    print("Then start your nodes by executing:")
+    print("\nTo start each node:")
     for center_name in center_names:
         print(f"\tfedbiomed node -p {center_name.lower()} start")

--- a/tests/end2end/e2e_ixi_brain_segmentation.py
+++ b/tests/end2end/e2e_ixi_brain_segmentation.py
@@ -1,29 +1,27 @@
-import pandas as pd
-import time
-import tqdm
 import os
-import pytest
-import requests
 import shutil
-from sklearn.model_selection import train_test_split
+import time
 from zipfile import ZipFile
 
-
+import pandas as pd
+import pytest
+import requests
+import tqdm
+from experiments.training_plans.ixi_brain_segmentation import UNetTrainingPlan
 from helpers import (
     add_dataset_to_node,
-    start_nodes,
-    kill_subprocesses,
-    clear_experiment_data,
     clear_component_data,
-    get_data_folder,
-    create_researcher,
+    clear_experiment_data,
     create_multiple_nodes,
+    create_researcher,
+    get_data_folder,
+    kill_subprocesses,
+    start_nodes,
 )
+from sklearn.model_selection import train_test_split
 
-from experiments.training_plans.ixi_brain_segmentation import UNetTrainingPlan
-
-from fedbiomed.researcher.experiment import Experiment
 from fedbiomed.researcher.aggregators.fedavg import FedAverage
+from fedbiomed.researcher.experiment import Experiment
 
 
 def download_file(url, filename):
@@ -42,7 +40,7 @@ def download_file(url, filename):
 
 
 def download_and_extract_ixi_sample(root_folder):
-    url = "https://prod-dcd-datasets-cache-zipfiles.s3.eu-west-1.amazonaws.com/7kd5wj7v7p-3.zip"
+    url = "https://data.mendeley.com/public-api/zip/7kd5wj7v7p/download/3"
     zip_filename = os.path.join(root_folder, "7kd5wj7v7p-3.zip")
     data_folder = os.path.join(root_folder)
     extracted_folder = os.path.join(data_folder, "7kd5wj7v7p-3", "IXI_sample")


### PR DESCRIPTION
This PR corrects the link to download and split IXI dataset. It does not add or change functionality but better handles and presents errors.
 
**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`