### PR TITLE
avoid triggering tests on push on develop, scheduled at night

### DIFF
--- a/.github/workflows/build-test-all-py-versions.yml
+++ b/.github/workflows/build-test-all-py-versions.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Setup python
         if: steps.filter.outputs.docs == 'true'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
@@ -107,7 +107,7 @@ jobs:
 
       - name: Install Python on Windows
         if: matrix.os == 'windows-latest'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Setup python
         if: steps.filter.outputs.docs == 'true'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -107,7 +107,7 @@ jobs:
 
       - name: Install Python on Windows
         if: matrix.os == 'windows-latest'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.github/workflows/doc-github-io-main-build.yml
+++ b/.github/workflows/doc-github-io-main-build.yml
@@ -30,7 +30,7 @@ jobs:
           git checkout master
           git tag -l
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
@@ -54,6 +54,5 @@ jobs:
           if [ ! git commit -a -m "Pulling recent changes" ]; then
             echo "o changes to commit"
           fi
-          git push
           git push
           cd ../

--- a/.github/workflows/doc-github-io-version-build.yml
+++ b/.github/workflows/doc-github-io-version-build.yml
@@ -31,7 +31,7 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -4,11 +4,10 @@ run-name: fedbiomed-e2e-tests
 permissions: write-all
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: '0 1 * * *'  # Run every day at 1 am on default branch: develop
   workflow_dispatch:
   push:
     branches:
-      - 'develop'
       - 'master'
       - 'feature/ci-runner-reconfiguration'
 jobs:

--- a/.github/workflows/endurance-tests.yml
+++ b/.github/workflows/endurance-tests.yml
@@ -4,11 +4,10 @@ run-name: endurance-tests
 
 on:
   schedule:
-    - cron: "0 1 * * 6"  # Run everyweekend at 1 am
+    - cron: "0 1 * * *"  # Run every day at 1 am on default branch: develop
   workflow_dispatch:
   push:
     branches:
-      - 'develop'
       - 'master'
 
 jobs:

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -3,9 +3,10 @@ name: Fed-BioMed VPN Docker Image and Container Test
 run-name: fedbiomed-docker-container-test
 
 on:
+  schedule:
+    - cron: '0 1 * * *'  # Run every day at 1 am on default branch: develop
   push:
     branches:
-      - "develop"
       - "master"
   workflow_dispatch:
 


### PR DESCRIPTION
Changes:
- actions/setup-python v4 → v5 (all workflows)
- cron → 0 1 * * *, removes develop from push triggers for: `end-to-end.yml`, `endurance-tests.yml`, `test-docker.yml`
- `doc-github-io-main-build.yml`: removes a duplicate git push call

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`