### PR TITLE
refactor node jobs to avoid _build_dataset_args as abstract method

### DIFF
--- a/fedbiomed/node/jobs/_base_job.py
+++ b/fedbiomed/node/jobs/_base_job.py
@@ -6,12 +6,8 @@ implementation of the base Job class of the node component
 """
 
 from abc import ABC, abstractmethod
-from typing import List, Optional
 
-from fedbiomed.common.constants import DatasetTypes, ErrorNumbers
-from fedbiomed.common.dataloadingplan import DataLoadingPlan
-from fedbiomed.common.dataset import REGISTRY_CONTROLLERS, Dataset
-from fedbiomed.common.dataset_types import DataReturnFormat
+from fedbiomed.common.constants import ErrorNumbers
 from fedbiomed.common.exceptions import FedbiomedError
 from fedbiomed.common.message import ErrorMessage, RequestReply
 from fedbiomed.node.dataset_manager import DatasetManager
@@ -64,81 +60,6 @@ class _BaseJob(ABC):
             extra_msg=msg,
             errnum=errnum,
         )
-
-    def _build_dataset(
-        self,
-        return_type: DataReturnFormat,
-        data_types: Optional[List[str]] = None,
-    ) -> Dataset:
-        """Build dataset instance ready-to-use from dataset id.
-
-        Args:
-            return_type: format in which data should be returned
-            data_types: list of accepted data types for the dataset
-
-        Raises:
-            _InternalJobError: if dataset cannot be recovered or initialized.
-        """
-        # Note: assumes that self._dataset_id is set during job initialization
-
-        # recover dataset entry
-        dataset_entry = self._dataset_manager.dataset_table.get_by_id(self._dataset_id)
-        if dataset_entry is None:
-            raise _InternalJobError(
-                f"Cannot found request dataset in local datasets: dataset_id='{self._dataset_id}' "
-                f"on node='{self._node_id}'"
-            )
-
-        # validate data type
-        data_type = dataset_entry.get("data_type")
-        if data_types and data_type not in data_types:
-            raise _InternalJobError(
-                f"{data_type} not supported. {self.__class__.__name__} job currently "
-                f"only supports data_types: {data_types}, got '{data_type}'"
-            )
-
-        data_type = DatasetTypes.get_type_by_value(data_type)
-        if data_type not in REGISTRY_CONTROLLERS:
-            raise _InternalJobError(
-                f"Data type '{data_type}' not supported in jobs, available types: "
-                f"{list(REGISTRY_CONTROLLERS.keys())}"
-            )
-
-        # get controller parameters
-        controller_kwargs = {
-            "root": dataset_entry.get("path"),
-            **dataset_entry.get("dataset_parameters", {}),
-        }
-
-        # recover dlp if any
-        if "dlp_id" in dataset_entry:
-            dlp_metadata = self._dataset_manager.get_dlp_by_id(dataset_entry["dlp_id"])
-            try:
-                controller_kwargs["dlp"] = DataLoadingPlan().deserialize(*dlp_metadata)
-            except FedbiomedError as e:
-                raise _InternalJobError(
-                    f"Cannot recover dlp on node={self._node_id}: {repr(e)}"
-                ) from e
-
-        _, _, dataset_cls = REGISTRY_CONTROLLERS[data_type]
-
-        # dataset = dataset_cls(input_columns=input_columns)
-        dataset = dataset_cls(**self._build_args_for_dataset(dataset_entry))
-
-        dataset.complete_initialization(controller_kwargs, return_type)
-
-        return dataset
-
-    @abstractmethod
-    def _build_args_for_dataset(self, dataset_entry: dict) -> dict:
-        """Build arguments for dataset initialization.
-
-        Args:
-            dataset_entry: dataset entry from dataset manager
-
-        Returns:
-            Dict of arguments for dataset initialization
-        """
 
     @abstractmethod
     def run(self) -> RequestReply | ErrorMessage:

--- a/fedbiomed/node/jobs/_fa_job.py
+++ b/fedbiomed/node/jobs/_fa_job.py
@@ -8,6 +8,8 @@ Implementation of Federated Analytics Job class of the node component
 from typing import Dict
 
 from fedbiomed.common.constants import DatasetTypes, ErrorNumbers, FedbiomedError, Stats
+from fedbiomed.common.dataloadingplan import DataLoadingPlan
+from fedbiomed.common.dataset import REGISTRY_CONTROLLERS, Dataset
 from fedbiomed.common.dataset_types import DataReturnFormat
 from fedbiomed.common.logger import logger
 from fedbiomed.common.message import ErrorMessage, FAReply, FARequest
@@ -18,7 +20,7 @@ from ._base_job import _BaseJob, _InternalJobError
 
 class FAJob(_BaseJob):
     """
-    This class represents the training part execute by a node in a given Federated Analytics job.
+    Represents the analytics execution performed by a node in a Federated Analytics job.
     """
 
     def __init__(
@@ -51,14 +53,29 @@ class FAJob(_BaseJob):
         self._allow_fa = allow_fa
 
     def _build_args_for_dataset(self, dataset_entry: dict) -> dict:
-        """Generate dataset arguments based on the dataset type by default."""
+        """Extract dataset constructor arguments from a dataset registry entry.
+
+        Reads the ``data_type`` field of ``dataset_entry`` and returns a kwargs
+        dict suitable for passing to the corresponding dataset class constructor.
+
+        Args:
+            dataset_entry: Dataset metadata dict as stored in the node dataset
+                table. Expected keys vary by data type.
+
+        Returns:
+            A kwargs dict for the dataset class constructor, e.g.
+            ``{"input_columns": ["age", "weight"]}`` for tabular data.
+
+        Raises:
+            _InternalJobError: if ``data_type`` is unknown or not yet supported.
+        """
         data_type = dataset_entry.get("data_type")
         dataset_type = DatasetTypes.get_type_by_value(data_type)
 
         match dataset_type:
             case None:
                 # This should not happen, but this check is added for safety
-                raise FedbiomedError(
+                raise _InternalJobError(
                     f"Dataset entry contains unsupported dataset type '{data_type}'."
                 )
             case DatasetTypes.TABULAR:
@@ -71,9 +88,72 @@ class FAJob(_BaseJob):
                 # Take keys in 'shape' and pass them as ``data_modalities`` to the dataset constructor
                 return {"data_modalities": list(dataset_entry.get("shape", {}))}
             case _:
-                raise FedbiomedError(
+                raise _InternalJobError(
                     f"Dataset arguments by default are not implemented for dataset type '{data_type}'."
                 )
+
+    def _build_dataset(
+        self,
+        return_type: DataReturnFormat = DataReturnFormat.SKLEARN,
+    ) -> Dataset:
+        """Build a ready-to-use dataset instance from ``self._dataset_id``.
+
+        Args:
+            return_type: Output format for the data loader.
+
+        Returns:
+            Fully initialised ``Dataset`` instance.
+
+        Raises:
+            _InternalJobError: if the dataset entry cannot be found, its type is
+                unsupported, the DLP cannot be deserialised, or initialisation fails.
+        """
+        # recover dataset entry
+        dataset_entry = self._dataset_manager.dataset_table.get_by_id(self._dataset_id)
+        if dataset_entry is None:
+            raise _InternalJobError(
+                f"Cannot find requested dataset in local datasets: dataset_id='{self._dataset_id}' "
+                f"on node='{self._node_id}'"
+            )
+
+        # check that data type is supported and get dataset class
+        data_type = dataset_entry.get("data_type")
+        dataset_type = DatasetTypes.get_type_by_value(data_type)
+        if dataset_type not in REGISTRY_CONTROLLERS:
+            raise _InternalJobError(
+                f"Data type '{dataset_type}' not supported in jobs, available types: "
+                f"{list(REGISTRY_CONTROLLERS.keys())}"
+            )
+
+        # get controller parameters
+        controller_kwargs = {
+            "root": dataset_entry.get("path"),
+            **dataset_entry.get("dataset_parameters", {}),
+        }
+
+        # recover dlp if any
+        if "dlp_id" in dataset_entry:
+            dlp_metadata = self._dataset_manager.get_dlp_by_id(dataset_entry["dlp_id"])
+            try:
+                controller_kwargs["dlp"] = DataLoadingPlan().deserialize(*dlp_metadata)
+            except FedbiomedError as e:
+                raise _InternalJobError(
+                    f"Cannot recover dlp on node={self._node_id}: {repr(e)}"
+                ) from e
+
+        # REGISTRY_CONTROLLERS maps dataset_type -> (controller_cls, loader_cls, dataset_cls)
+        _, _, dataset_cls = REGISTRY_CONTROLLERS[dataset_type]
+
+        try:
+            # build with type-specific args then attach controller config and output format
+            dataset = dataset_cls(**self._build_args_for_dataset(dataset_entry))
+            dataset.complete_initialization(controller_kwargs, return_type)
+        except FedbiomedError as e:
+            raise _InternalJobError(
+                f"Cannot initialize dataset on node='{self._node_id}': {repr(e)}"
+            ) from e
+
+        return dataset
 
     def run(self) -> FAReply | ErrorMessage:
         """Run FA job and return FAReply message or ErrorMessage in case of failure."""

--- a/fedbiomed/node/jobs/_preproc_job.py
+++ b/fedbiomed/node/jobs/_preproc_job.py
@@ -47,9 +47,6 @@ class PreprocJob(_BaseJob):
         self._state_id = request.state_id
         self._allow_preproc = allow_preproc
 
-    def _build_args_for_dataset(self, dataset_entry):
-        pass
-
     def run(self) -> PreprocReply | ErrorMessage:
         """Execute preprocessing job.
 

--- a/tests/test_analytics/test_node_fa_job.py
+++ b/tests/test_analytics/test_node_fa_job.py
@@ -48,7 +48,7 @@ def fa_job(fa_job_args):
 @pytest.fixture
 def mocked_dataset_manager():
     """Fixture for mocked DatasetManager with common setup."""
-    with patch("fedbiomed.node.jobs._base_job.DatasetManager") as mock_dm_cls:
+    with patch("fedbiomed.node.jobs._fa_job.DatasetManager") as mock_dm_cls:
         mock_dm = mock_dm_cls.return_value
         mock_dm.dataset_table.get_by_id.return_value = {
             "data_type": "csv",
@@ -61,7 +61,7 @@ def mocked_dataset_manager():
 @pytest.fixture
 def mocked_dlp():
     """Fixture for mocked DataLoadingPlan."""
-    with patch("fedbiomed.node.jobs._base_job.DataLoadingPlan") as mock_dlp_cls:
+    with patch("fedbiomed.node.jobs._fa_job.DataLoadingPlan") as mock_dlp_cls:
         mock_dlp = mock_dlp_cls.return_value
         mock_dlp.deserialize.return_value = mock_dlp
         yield mock_dlp_cls, mock_dlp
@@ -108,7 +108,7 @@ def test_build_error_msg(fa_job):
     assert error.request_id == fa_job._request_id
 
 
-@patch("fedbiomed.node.jobs._base_job.REGISTRY_CONTROLLERS")
+@patch("fedbiomed.node.jobs._fa_job.REGISTRY_CONTROLLERS")
 def test_build_dataset_success(mock_registry, fa_job, mocked_dataset_manager):
     """Test _build_dataset success scenario."""
     mock_dm_cls, mock_dm = mocked_dataset_manager
@@ -136,7 +136,7 @@ def test_build_dataset_success(mock_registry, fa_job, mocked_dataset_manager):
     # Return 3 values as expected by unpacking: _, _, dataset_cls
     mock_registry.__getitem__.return_value = (None, None, mock_dataset_cls)
 
-    dataset = fa_job._build_dataset(DataReturnFormat.SKLEARN, ["csv"])
+    dataset = fa_job._build_dataset(DataReturnFormat.SKLEARN)
 
     # Verify dataset creation and initialization
     assert dataset == mock_dataset_instance
@@ -153,25 +153,25 @@ def test_build_dataset_not_found(mocked_dataset_manager, fa_job):
     fa_job._dataset_manager = mock_dm
 
     with pytest.raises(_InternalJobError) as exc_info:
-        fa_job._build_dataset(DataReturnFormat.SKLEARN, ["csv"])
+        fa_job._build_dataset(DataReturnFormat.SKLEARN)
 
-    assert "Cannot found request dataset in local datasets" in str(exc_info.value)
+    assert "Cannot find requested dataset in local datasets" in str(exc_info.value)
 
 
-@patch("fedbiomed.node.jobs._base_job.REGISTRY_CONTROLLERS", {})
+@patch("fedbiomed.node.jobs._fa_job.REGISTRY_CONTROLLERS", {})
 def test_build_dataset_invalid_type(mocked_dataset_manager, fa_job):
     """Test _build_dataset when data type is not supported."""
     mock_dm_cls, mock_dm = mocked_dataset_manager
     mock_dm.dataset_table.get_by_id.return_value = {"data_type": "unknown_type"}
 
     with pytest.raises(_InternalJobError) as exc_info:
-        fa_job._build_dataset(DataReturnFormat.SKLEARN, ["not_a_dataset_supported"])
+        fa_job._build_dataset(DataReturnFormat.SKLEARN)
 
     assert "not supported" in str(exc_info.value)
 
 
-@patch("fedbiomed.node.jobs._base_job.REGISTRY_CONTROLLERS")
-@patch("fedbiomed.node.jobs._base_job.DataLoadingPlan")
+@patch("fedbiomed.node.jobs._fa_job.REGISTRY_CONTROLLERS")
+@patch("fedbiomed.node.jobs._fa_job.DataLoadingPlan")
 def test_build_dataset_with_dlp_success(
     mock_dlp_cls, mock_reg_cont, fa_job, mocked_dataset_manager
 ):
@@ -203,7 +203,7 @@ def test_build_dataset_with_dlp_success(
     # Setup DATASET_CLASSES_PER_TYPE
     # mock_dataset_cli not needed since _BaseJob uses REGISTRY_CONTROLLERS
 
-    dataset = fa_job._build_dataset(DataReturnFormat.SKLEARN, ["csv"])
+    dataset = fa_job._build_dataset(DataReturnFormat.SKLEARN)
 
     assert dataset == mock_dataset_instance
     # Check if DLP was passed to complete_initialization
@@ -211,8 +211,8 @@ def test_build_dataset_with_dlp_success(
     assert call_args[0][0]["dlp"] == mock_dlp
 
 
-@patch("fedbiomed.node.jobs._base_job.REGISTRY_CONTROLLERS")
-@patch("fedbiomed.node.jobs._base_job.DataLoadingPlan")
+@patch("fedbiomed.node.jobs._fa_job.REGISTRY_CONTROLLERS")
+@patch("fedbiomed.node.jobs._fa_job.DataLoadingPlan")
 def test_build_dataset_dlp_error(
     mock_dlp_cls, mock_registry, fa_job, mocked_dataset_manager
 ):
@@ -229,7 +229,7 @@ def test_build_dataset_dlp_error(
     mock_registry.__contains__.return_value = True
 
     with pytest.raises(_InternalJobError) as exc_info:
-        fa_job._build_dataset(DataReturnFormat.SKLEARN, ["csv"])
+        fa_job._build_dataset(DataReturnFormat.SKLEARN)
 
     assert "Cannot recover dlp" in str(exc_info.value)
 
@@ -429,3 +429,66 @@ def test_build_args_for_dataset_methods(fa_job):
         with pytest.raises(FedbiomedError) as exc_info:
             fa_job._build_args_for_dataset(entry)
         assert "Dataset entry contains unsupported dataset type" in str(exc_info.value)
+
+
+@patch("fedbiomed.node.jobs._fa_job.REGISTRY_CONTROLLERS")
+def test_build_dataset_initialization_error(
+    mock_registry, fa_job, mocked_dataset_manager
+):
+    """Test _build_dataset when dataset initialization fails."""
+    mock_dm_cls, mock_dm = mocked_dataset_manager
+    mock_dm.dataset_table.get_by_id.return_value = {
+        "data_type": "csv",
+        "path": "/path/to/data",
+        "dataset_parameters": {},
+    }
+    fa_job._dataset_manager = mock_dm
+
+    # Mock dataset class that raises FedbiomedError
+    mock_dataset_cls = MagicMock()
+    mock_dataset_cls.side_effect = FedbiomedError("Init Error")
+
+    mock_registry.__contains__.return_value = True
+    mock_registry.__getitem__.return_value = (None, None, mock_dataset_cls)
+
+    with pytest.raises(_InternalJobError) as exc_info:
+        fa_job._build_dataset(DataReturnFormat.SKLEARN)
+
+    assert "Cannot initialize dataset" in str(exc_info.value)
+    assert "Init Error" in str(exc_info.value)
+
+
+def test_run_no_stats_provided(fa_job_args, request_args):
+    """Test run method when neither stats nor stats_args are provided."""
+    req_args = request_args.copy()
+    req_args["stats"] = None
+    req_args["stats_args"] = {}
+    request = FARequest(**req_args)
+
+    args = fa_job_args.copy()
+    args["request"] = request
+    job = FAJob(**args)
+
+    reply = job.run()
+
+    assert isinstance(reply, ErrorMessage)
+    assert reply.errnum == ErrorNumbers.FB325.value
+    assert "At least one of 'stats' or 'stats_args' must be provided" in reply.extra_msg
+
+
+def test_run_invalid_stats_args_keys(fa_job_args, request_args):
+    """Test run method with invalid keys in stats_args."""
+    req_args = request_args.copy()
+    req_args["stats"] = None
+    req_args["stats_args"] = {"invalid_key": {}}
+    request = FARequest(**req_args)
+
+    args = fa_job_args.copy()
+    args["request"] = request
+    job = FAJob(**args)
+
+    reply = job.run()
+
+    assert isinstance(reply, ErrorMessage)
+    assert reply.errnum == ErrorNumbers.FB325.value
+    assert "contains unsupported keys" in reply.extra_msg

--- a/tests/test_node_preproc_job.py
+++ b/tests/test_node_preproc_job.py
@@ -71,12 +71,6 @@ def test_preproc_job_init(preproc_request, preproc_job_args):
     assert job._state_id == preproc_request.state_id
 
 
-def test_build_args_for_dataset(preproc_job_args):
-    # Dummy test to cover _build_args_for_dataset, nothing to check
-    job = PreprocJob(**preproc_job_args)
-    job._build_args_for_dataset(None)
-
-
 def test_run_success(monkeypatch, preproc_request, preproc_job_args):
     """Test successful run of PreprocJob."""
 


### PR DESCRIPTION
Relocated `_build_dataset` in node/*_jobs for clarity of interactions with datasets. The behavior of fa datasets is quite specific and should be validated for other cases. `_build_dataset_args` was removed as abstract method from `_base_job.py`

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`