### PR TITLE
Feature/1618 node specific parameters

### DIFF
--- a/docs/user-guide/researcher/training-plan.md
+++ b/docs/user-guide/researcher/training-plan.md
@@ -394,3 +394,102 @@ model_args = {
     }
 }
 ```
+
+## Advanced: tagging model parameters
+
+Fed-BioMed provides a mechanism to customize how individual model parameters are handled during federated training through the `tag_parameters` method. By default, all parameters follow the standard federated learning workflow: they are aggregated globally across nodes and updated each round from the researcher-aggregated values. Overriding `tag_parameters` allows you to exclude specific parameters out of this default behavior.
+
+### Available tags
+
+The `tag_parameters` method currently supports two tags:
+
+- **`local`**: The parameter is never shared with the researcher nor included in aggregation. It remains entirely local to the node.
+- **`persistent`**: The parameter is saved locally on the node at the end of each round.
+
+Tags can be combined: a parameter tagged as both `local` and `persistent` will be kept local *and* saved across rounds, and will be restored at the start of every round. A parameter tagged as `local` only (without `persistent`) is reset to its initial value at the start of every round.
+
+### Defining `tag_parameters`
+
+The `tag_parameters` method takes a parameter name as input and returns a set of tags. Return an empty set (the default) for standard federated behavior.
+
+#### PyTorch example
+
+```python
+import torch
+import torch.nn as nn
+from fedbiomed.common.training_plans import TorchTrainingPlan
+
+class MyTrainingPlan(TorchTrainingPlan):
+
+    class Net(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.shared_layer = nn.Linear(128, 64)
+            self.local_bn = nn.BatchNorm1d(64)
+            self.local_bias = nn.Parameter(torch.zeros(64))
+
+        def forward(self, x):
+            x = self.shared_layer(x)
+            x = self.local_bn(x)
+            return x
+
+    def init_model(self, model_args):
+        return self.Net()
+
+    def tag_parameters(self, name):
+        if name == "local_bias":
+            return {"local", "persistent"}
+        if name == "local_bn":
+            return {"local"}
+        return set()
+
+    # ... rest of the training plan
+```
+
+#### Scikit-learn example
+
+```python
+from fedbiomed.common.training_plans import FedSGDClassifier
+
+class MyTrainingPlan(FedSGDClassifier):
+
+    def tag_parameters(self, name):
+        # Keep the intercept local and persistent across rounds
+        if name == "intercept_":
+            return {"local", "persistent"}
+        return set()
+
+    def training_data(self):
+        # returns a Fed-BioMed DataManager object
+        pass
+
+    def init_optimizer(self, optimizer_args):
+        pass
+
+    def init_dependencies(self):
+        pass
+```
+
+### What happens on the node side during training
+
+The way tagged parameters are handled is determined at the node level during each round, across three key steps.
+
+**At the start of a round**, the node reconstructs the full set of model parameters before loading them into the model. Parameters received from the researcher (i.e., the aggregated global parameters) serve as the base. The node then overrides specific entries depending on their tags:
+
+- Parameters tagged as both `local` and `persistent` are restored from the values saved at the end of the previous round. If no previous round exists (i.e., the first round), they are initialized from the model's initial weights as defined in `init_model`.
+- Parameters tagged as `local` only (without `persistent`) are always reinitialized from the model's initial weights at each round, regardless of any training that may have occurred in previous rounds.
+- All other parameters are taken as-is from the researcher-provided aggregated weights.
+
+**At the end of a round**, the node saves the current values of all parameters tagged as `persistent`. These saved values will be loaded and restored at the beginning of the next round.
+
+**When sending parameters back to the researcher**, parameters tagged as `local` are excluded from the payload. The researcher therefore never sees or aggregates them, and they play no role in the global model update.
+
+### Caution with advanced optimizers
+
+When using a `declearn`-based optimizer, the federated engine also exchanges optimizer auxiliary variables between the node and the researcher at each round (e.g., control variates for Scaffold). Fed-BioMed handles `local` parameters specifically in this exchange:
+
+- **When collecting auxiliary variables** to send back to the researcher (at the end of a round), auxiliary variables corresponding to `local` parameters are stripped from the payload. The researcher therefore never receives nor aggregates the optimizer state associated with local parameters.
+- **When processing auxiliary variables** received from the researcher (at the beginning of a round), the auxiliary variables for `local` parameters are reset to zero vectors on the node side. This prevents any cross-round accumulation of optimizer state for parameters that are not globally shared.
+
+!!! warning "Interaction with Declearn optimizers"
+    Using parameters tagged as `local` in combination with more complex federated optimizers such as those provided by `declearn` (e.g., Scaffold, or other stateful `OptiModule`-based optimizers) may lead to unexpected or incorrect behavior. These optimizers maintain internal auxiliary variables (e.g., gradient moments, control variates) that are tracked per parameter. When a parameter is tagged as `local`, its associated auxiliary variables are not shared nor aggregated. In practice, this may cause training instability or degraded convergence. It is therefore strongly recommended to use `local` parameters only with simple, stateless optimizers, unless you are fully aware of the implications for the optimizer state.

--- a/docs/user-guide/researcher/training-plan.md
+++ b/docs/user-guide/researcher/training-plan.md
@@ -470,7 +470,7 @@ class MyTrainingPlan(FedSGDClassifier):
         pass
 ```
 
-### What happens on the node side during training
+### Handling of parameters tagged as `local` or `persistent` during training
 
 The way tagged parameters are handled is determined at the node level during each round, across three key steps.
 
@@ -483,6 +483,11 @@ The way tagged parameters are handled is determined at the node level during eac
 **At the end of a round**, the node saves the current values of all parameters tagged as `persistent`. These saved values will be loaded and restored at the beginning of the next round.
 
 **When sending parameters back to the researcher**, parameters tagged as `local` are excluded from the payload. The researcher therefore never sees or aggregates them, and they play no role in the global model update.
+
+From the researcher's perspective, this has the following practical implications:
+
+- `local` parameters are absent from aggregation results: they will not appear in `experiment.aggregated_params()`, nor in the raw per-node replies accessible via `experiment.training_replies()`.
+- `local` parameters are still present in the researcher-side training plan: they remain accessible through `experiment.training_plan().get_model_params()` and `experiment.training_plan().model()`. However, these values originate from `init_model`: they reflect the initial weights as defined by the researcher, not the values that were actually trained and retained on each node. In particular, they do not correspond to the local parameter values that nodes will restore at the start of the next round (which, for parameters tagged as both `local` and `persistent`, are the node's own saved values from the previous round).
 
 ### Caution with advanced optimizers
 

--- a/fedbiomed/common/models/_model.py
+++ b/fedbiomed/common/models/_model.py
@@ -98,7 +98,7 @@ class Model(Generic[_MT, DT], metaclass=ABCMeta):
         self,
         only_trainable: bool = False,
         exclude_buffers: bool = True,
-        private_params: Optional[List[str]] = None,
+        local_params: Optional[List[str]] = None,
     ) -> Dict[str, DT]:
         """Return a copy of the model's trainable weights.
 
@@ -108,19 +108,22 @@ class Model(Generic[_MT, DT], metaclass=ABCMeta):
                 or include all model parameters (the default).
             exclude_buffers: Whether to ignore buffers (the default), or
                 include them.
-            private_params: List of parameter names to exclude from the output.
+            local_params: List of parameter names to exclude from the output.
 
         Returns:
             Model weights, as a dict mapping parameters' names to their value.
         """
 
     @abstractmethod
-    def set_weights(self, weights: Dict[str, DT]) -> None:
+    def set_weights(
+        self, weights: Dict[str, DT], local_params: Optional[List[str]] = None
+    ) -> None:
         """Assign new values to the model's trainable weights.
 
         Args:
             weights: Model weights, as a dict mapping parameters' names
                 to their value.
+            local_params: List of parameter names tagged as local.
         """
 
     @abstractmethod
@@ -137,7 +140,7 @@ class Model(Generic[_MT, DT], metaclass=ABCMeta):
         self,
         only_trainable: bool = False,
         exclude_buffers: bool = True,
-        private_params: Optional[List[str]] = None,
+        local_params: Optional[List[str]] = None,
     ) -> List[float]:
         """Flattens model weights
 
@@ -147,7 +150,7 @@ class Model(Generic[_MT, DT], metaclass=ABCMeta):
                 or include all model parameters (the default).
             exclude_buffers: Whether to ignore buffers (the default), or
                 include them.
-            private_params: List of parameter names to exclude from the output.
+            local_params: List of parameter names to exclude from the output.
 
         Returns:
             List of model weights as float.
@@ -169,11 +172,12 @@ class Model(Generic[_MT, DT], metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def reload(self, filename: str) -> None:
+    def reload(self, filename: str, local_params: Optional[List[str]] = None) -> None:
         """Import and replace the wrapped model from a dump file.
 
         Args:
             filename: path to the file where the model has been exported.
+            local_params: List of parameter names tagged as local.
 
         !!! info "Notes":
             This method is designed to load the model from a local dump
@@ -200,7 +204,7 @@ class Model(Generic[_MT, DT], metaclass=ABCMeta):
         weights_vector: List[float],
         only_trainable: bool = False,
         exclude_buffers: bool = True,
-        private_params: Optional[List[str]] = None,
+        local_params: Optional[List[str]] = None,
     ) -> None:
         """Revert flatten model weights back model-dict form.
 
@@ -211,7 +215,7 @@ class Model(Generic[_MT, DT], metaclass=ABCMeta):
                 or include all model parameters (the default).
             exclude_buffers: Whether to ignore buffers (the default), or
                 include them.
-            private_params: List of parameter names to exclude from the output.
+            local_params: List of parameter names to exclude from the output.
 
         Returns:
             Model dictionary

--- a/fedbiomed/common/models/_model.py
+++ b/fedbiomed/common/models/_model.py
@@ -4,7 +4,7 @@
 """'Model' abstract base class defining an API to interface framework-specific models."""
 
 from abc import ABCMeta, abstractmethod
-from typing import Any, ClassVar, Dict, Generic, List, Type, TypeVar
+from typing import Any, ClassVar, Dict, Generic, List, Optional, Type, TypeVar
 
 from fedbiomed.common.constants import ErrorNumbers
 from fedbiomed.common.exceptions import FedbiomedModelError
@@ -95,7 +95,10 @@ class Model(Generic[_MT, DT], metaclass=ABCMeta):
 
     @abstractmethod
     def get_weights(
-        self, only_trainable: bool = False, exclude_buffers: bool = True
+        self,
+        only_trainable: bool = False,
+        exclude_buffers: bool = True,
+        private_params: Optional[List[str]] = None,
     ) -> Dict[str, DT]:
         """Return a copy of the model's trainable weights.
 
@@ -105,6 +108,7 @@ class Model(Generic[_MT, DT], metaclass=ABCMeta):
                 or include all model parameters (the default).
             exclude_buffers: Whether to ignore buffers (the default), or
                 include them.
+            private_params: List of parameter names to exclude from the output.
 
         Returns:
             Model weights, as a dict mapping parameters' names to their value.
@@ -130,7 +134,10 @@ class Model(Generic[_MT, DT], metaclass=ABCMeta):
 
     @abstractmethod
     def flatten(
-        self, only_trainable: bool = False, exclude_buffers: bool = True
+        self,
+        only_trainable: bool = False,
+        exclude_buffers: bool = True,
+        private_params: Optional[List[str]] = None,
     ) -> List[float]:
         """Flattens model weights
 
@@ -140,6 +147,7 @@ class Model(Generic[_MT, DT], metaclass=ABCMeta):
                 or include all model parameters (the default).
             exclude_buffers: Whether to ignore buffers (the default), or
                 include them.
+            private_params: List of parameter names to exclude from the output.
 
         Returns:
             List of model weights as float.
@@ -192,6 +200,7 @@ class Model(Generic[_MT, DT], metaclass=ABCMeta):
         weights_vector: List[float],
         only_trainable: bool = False,
         exclude_buffers: bool = True,
+        private_params: Optional[List[str]] = None,
     ) -> None:
         """Revert flatten model weights back model-dict form.
 
@@ -202,6 +211,7 @@ class Model(Generic[_MT, DT], metaclass=ABCMeta):
                 or include all model parameters (the default).
             exclude_buffers: Whether to ignore buffers (the default), or
                 include them.
+            private_params: List of parameter names to exclude from the output.
 
         Returns:
             Model dictionary

--- a/fedbiomed/common/models/_sklearn.py
+++ b/fedbiomed/common/models/_sklearn.py
@@ -130,8 +130,10 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
 
         unknown = local_params_set - set(self.param_list)
         if unknown:
-            raise FedbiomedModelError(
-                f"{ErrorNumbers.FB622.value}: Unknown local parameters: {unknown}"
+            logger.warning(
+                "'BaseSkLearnModel.get_weights' received unknown local parameters "
+                "that are not part of the model; unknown parameters: %s. ",
+                unknown,
             )
 
         # Gather copies of the model weights.

--- a/fedbiomed/common/models/_sklearn.py
+++ b/fedbiomed/common/models/_sklearn.py
@@ -102,7 +102,7 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
         self,
         only_trainable: bool = False,
         exclude_buffers: bool = True,
-        private_params: Optional[List[str]] = None,
+        local_params: Optional[List[str]] = None,
     ) -> Dict[str, np.ndarray]:
         """Return a copy of the model's trainable weights.
 
@@ -111,7 +111,7 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
                 non-trainable model parameters.)
             exclude_buffers: Unused for scikit-learn models. (Whether to ignore
                 buffers.)
-            private_params: List of parameter names to exclude from the output.
+            local_params: List of parameter names to exclude from the output.
 
         Raises:
             FedbiomedModelError: If the model parameters are not initialized.
@@ -126,17 +126,17 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
                 f"have initialized the model beforehand (try calling `set_init_params`)"
             )
 
-        private_params_set = set(private_params) if private_params else set()
+        local_params_set = set(local_params) if local_params else set()
 
-        unknown = private_params_set - set(self.param_list)
+        unknown = local_params_set - set(self.param_list)
         if unknown:
-            raise ValueError(f"Unknown private parameters: {unknown}")
+            raise ValueError(f"Unknown local parameters: {unknown}")
 
         # Gather copies of the model weights.
         weights = {}  # type: Dict[str, np.ndarray]
         try:
             for key in self.param_list:
-                if key in private_params_set:
+                if key in local_params_set:
                     continue
                 val = getattr(self.model, key)
                 if not isinstance(val, np.ndarray):
@@ -155,7 +155,7 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
         self,
         only_trainable: bool = False,
         exclude_buffers: bool = True,
-        private_params: Optional[List[str]] = None,
+        local_params: Optional[List[str]] = None,
     ) -> List[float]:
         """Gets weights as flatten vector
 
@@ -164,13 +164,13 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
                 non-trainable model parameters.)
             exclude_buffers: Unused for scikit-learn models. (Whether to ignore
                 buffers.)
-            private_params: List of parameter names to exclude from the output.
+            local_params: List of parameter names to exclude from the output.
 
         Returns:
             to_list: Convert np.ndarray to a list if it is True.
         """
 
-        weights = self.get_weights(private_params=private_params)
+        weights = self.get_weights(local_params=local_params)
         flatten = []
         for _, w in weights.items():
             w_: List[float] = list(w.flatten().astype(float))
@@ -183,7 +183,7 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
         weights_vector: List[float],
         only_trainable: bool = False,
         exclude_buffers: bool = True,
-        private_params: Optional[List[str]] = None,
+        local_params: Optional[List[str]] = None,
     ) -> Dict[str, np.ndarray]:
         """Unflatten vectorized model weights
 
@@ -193,18 +193,16 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
                 non-trainable model parameters.)
             exclude_buffers: Unused for scikit-learn models. (Whether to ignore
                 buffers.)
-            private_params: List of parameter names to exclude from the output.
+            local_params: List of parameter names to exclude from the output.
 
         Returns:
             Model dictionary
         """
 
-        super().unflatten(
-            weights_vector, only_trainable, exclude_buffers, private_params
-        )
+        super().unflatten(weights_vector, only_trainable, exclude_buffers, local_params)
 
         weights_vector = np.array(weights_vector)
-        weights = self.get_weights(private_params=private_params)
+        weights = self.get_weights(local_params=local_params)
         pointer = 0
 
         params = {}
@@ -219,12 +217,14 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
     def set_weights(
         self,
         weights: Dict[str, np.ndarray],
+        local_params: Optional[List[str]] = None,
     ) -> None:
         """Assign new values to the model's trainable weights.
 
         Args:
             weights: Model weights, as a dict mapping parameters' names
                 to their numpy array.
+            local_params: List of parameter names tagged as local.
         """
         self._assert_dict_inputs(weights)
         for key, val in weights.items():
@@ -434,11 +434,12 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
         with open(filename, "wb") as file:
             joblib.dump(self.model, file)
 
-    def reload(self, filename: str) -> None:
+    def reload(self, filename: str, local_params: Optional[List[str]] = None) -> None:
         """Import and replace the wrapped model from a dump file.
 
         Args:
             filename: path to the file where the model has been exported.
+            local_params: List of parameter names tagged as local.
 
         !!! info "Notes":
             This method is designed to load the model from a local dump

--- a/fedbiomed/common/models/_sklearn.py
+++ b/fedbiomed/common/models/_sklearn.py
@@ -130,7 +130,9 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
 
         unknown = local_params_set - set(self.param_list)
         if unknown:
-            raise ValueError(f"Unknown local parameters: {unknown}")
+            raise FedbiomedModelError(
+                f"{ErrorNumbers.FB622.value}: Unknown local parameters: {unknown}"
+            )
 
         # Gather copies of the model weights.
         weights = {}  # type: Dict[str, np.ndarray]

--- a/fedbiomed/common/models/_sklearn.py
+++ b/fedbiomed/common/models/_sklearn.py
@@ -204,7 +204,7 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
         )
 
         weights_vector = np.array(weights_vector)
-        weights = self.get_weights(private_params)
+        weights = self.get_weights(private_params=private_params)
         pointer = 0
 
         params = {}

--- a/fedbiomed/common/models/_sklearn.py
+++ b/fedbiomed/common/models/_sklearn.py
@@ -99,7 +99,10 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
             )
 
     def get_weights(
-        self, only_trainable: bool = False, exclude_buffers: bool = True
+        self,
+        only_trainable: bool = False,
+        exclude_buffers: bool = True,
+        private_params: Optional[List[str]] = None,
     ) -> Dict[str, np.ndarray]:
         """Return a copy of the model's trainable weights.
 
@@ -108,6 +111,7 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
                 non-trainable model parameters.)
             exclude_buffers: Unused for scikit-learn models. (Whether to ignore
                 buffers.)
+            private_params: List of parameter names to exclude from the output.
 
         Raises:
             FedbiomedModelError: If the model parameters are not initialized.
@@ -121,10 +125,19 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
                 f"{ErrorNumbers.FB622.value}. Attribute `param_list` is empty. You should "
                 f"have initialized the model beforehand (try calling `set_init_params`)"
             )
+
+        private_params_set = set(private_params) if private_params else set()
+
+        unknown = private_params_set - set(self.param_list)
+        if unknown:
+            raise ValueError(f"Unknown private parameters: {unknown}")
+
         # Gather copies of the model weights.
         weights = {}  # type: Dict[str, np.ndarray]
         try:
             for key in self.param_list:
+                if key in private_params_set:
+                    continue
                 val = getattr(self.model, key)
                 if not isinstance(val, np.ndarray):
                     raise FedbiomedModelError(
@@ -139,7 +152,10 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
         return weights
 
     def flatten(
-        self, only_trainable: bool = False, exclude_buffers: bool = True
+        self,
+        only_trainable: bool = False,
+        exclude_buffers: bool = True,
+        private_params: Optional[List[str]] = None,
     ) -> List[float]:
         """Gets weights as flatten vector
 
@@ -148,12 +164,13 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
                 non-trainable model parameters.)
             exclude_buffers: Unused for scikit-learn models. (Whether to ignore
                 buffers.)
+            private_params: List of parameter names to exclude from the output.
 
         Returns:
             to_list: Convert np.ndarray to a list if it is True.
         """
 
-        weights = self.get_weights()
+        weights = self.get_weights(private_params=private_params)
         flatten = []
         for _, w in weights.items():
             w_: List[float] = list(w.flatten().astype(float))
@@ -166,6 +183,7 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
         weights_vector: List[float],
         only_trainable: bool = False,
         exclude_buffers: bool = True,
+        private_params: Optional[List[str]] = None,
     ) -> Dict[str, np.ndarray]:
         """Unflatten vectorized model weights
 
@@ -175,15 +193,18 @@ class BaseSkLearnModel(Model, metaclass=ABCMeta):
                 non-trainable model parameters.)
             exclude_buffers: Unused for scikit-learn models. (Whether to ignore
                 buffers.)
+            private_params: List of parameter names to exclude from the output.
 
         Returns:
             Model dictionary
         """
 
-        super().unflatten(weights_vector, only_trainable, exclude_buffers)
+        super().unflatten(
+            weights_vector, only_trainable, exclude_buffers, private_params
+        )
 
         weights_vector = np.array(weights_vector)
-        weights = self.get_weights()
+        weights = self.get_weights(private_params)
         pointer = 0
 
         params = {}

--- a/fedbiomed/common/models/_torch.py
+++ b/fedbiomed/common/models/_torch.py
@@ -59,7 +59,7 @@ class TorchModel(Model):
         self,
         only_trainable: bool = False,
         exclude_buffers: bool = True,
-        private_params: Optional[List[str]] = None,
+        local_params: Optional[List[str]] = None,
     ) -> Dict[str, torch.Tensor]:
         """Return the model's parameters.
 
@@ -69,13 +69,13 @@ class TorchModel(Model):
                 or include all model parameters (the default).
             exclude_buffers: Whether to ignore buffers (the default), or
                 include them.
-            private_params: List of parameter names to exclude from the output.
+            local_params: List of parameter names to exclude from the output.
 
         Returns:
             Model weights, as a dictionary mapping parameters' names to their
                 torch tensor.
         """
-        private_params_set = set(private_params) if private_params else set()
+        local_params_set = set(local_params) if local_params else set()
 
         param_iterator = list(
             self.model.named_parameters()
@@ -83,15 +83,15 @@ class TorchModel(Model):
             else self.model.state_dict().items()
         )
 
-        unknown = private_params_set - {name for name, _ in param_iterator}
+        unknown = local_params_set - {name for name, _ in param_iterator}
         if unknown:
-            raise ValueError(f"Unknown private parameters: {unknown}")
+            raise ValueError(f"Unknown local parameters: {unknown}")
 
         parameters = {
             name: param.detach().clone()
             for name, param in param_iterator
             if (param.requires_grad or not only_trainable)
-            and name not in private_params_set
+            and name not in local_params_set
         }
         return parameters
 
@@ -99,7 +99,7 @@ class TorchModel(Model):
         self,
         only_trainable: bool = False,
         exclude_buffers: bool = True,
-        private_params: Optional[List[str]] = None,
+        local_params: Optional[List[str]] = None,
     ) -> List[float]:
         """Gets weights as flatten vector
 
@@ -109,7 +109,7 @@ class TorchModel(Model):
                 or include all model parameters (the default).
             exclude_buffers: Whether to ignore buffers (the default), or
                 include them.
-            private_params: List of parameter names to exclude from the output.
+            local_params: List of parameter names to exclude from the output.
 
         Returns:
             to_list: Convert np.ndarray to a list if it is True.
@@ -118,7 +118,7 @@ class TorchModel(Model):
             self.get_weights(
                 only_trainable=only_trainable,
                 exclude_buffers=exclude_buffers,
-                private_params=private_params,
+                local_params=local_params,
             ).values()
         ).tolist()
 
@@ -129,7 +129,7 @@ class TorchModel(Model):
         weights_vector: List[float],
         only_trainable: bool = False,
         exclude_buffers: bool = True,
-        private_params: Optional[List[str]] = None,
+        local_params: Optional[List[str]] = None,
     ) -> Dict[str, torch.Tensor]:
         """Unflatten vectorized model weights using [`vector_to_parameters`][torch.nn.utils.vector_to_parameters]
 
@@ -142,15 +142,13 @@ class TorchModel(Model):
                 or include all model parameters (the default).
             exclude_buffers: Whether to ignore buffers (the default), or
                 include them.
-            private_params: List of parameter names to exclude from the output.
+            local_params: List of parameter names to exclude from the output.
 
         Returns:
             Model dictionary
         """
 
-        super().unflatten(
-            weights_vector, only_trainable, exclude_buffers, private_params
-        )
+        super().unflatten(weights_vector, only_trainable, exclude_buffers, local_params)
 
         # Copy model to make sure global model parameters won't be overwritten
         model = copy.deepcopy(self)
@@ -158,7 +156,7 @@ class TorchModel(Model):
         weights = model.get_weights(
             only_trainable=only_trainable,
             exclude_buffers=exclude_buffers,
-            private_params=private_params,
+            local_params=local_params,
         )
 
         # Following operation updates model parameters of copied model object
@@ -173,12 +171,14 @@ class TorchModel(Model):
     def set_weights(
         self,
         weights: Dict[str, torch.Tensor],
+        local_params: Optional[List[str]] = None,
     ) -> None:
         """Sets model weights.
 
         Args:
             weights: Model weights, as a dict mapping parameters' names
                 to their torch tensor.
+            local_params: List of parameter names tagged as local.
         """
         self._assert_dict_inputs(weights)
         incompatible = self.model.load_state_dict(weights, strict=False)
@@ -191,11 +191,13 @@ class TorchModel(Model):
                 key for key, prm in self.model.named_parameters() if prm.requires_grad
             }
             missing = params.intersection(incompatible.missing_keys)
+            # Remove local parameters from the warning
+            local_params_set = set(local_params or [])
+            missing = missing - local_params_set
             if missing:
                 logger.warning(
                     "'TorchModel.set_weights' received inputs that did not cover all "
-                    "trainable model parameters; missing weights: %s. "
-                    "This behaviour is expected if some parameters are tagged as private.",
+                    "trainable model parameters; missing weights: %s. ",
                     missing,
                 )
         # Warn about invalid (hence, unused) inputs.
@@ -309,13 +311,14 @@ class TorchModel(Model):
         """
         torch.save(self.model.state_dict(), filename)
 
-    def reload(self, filename: str) -> None:
+    def reload(self, filename: str, local_params: Optional[List[str]] = None) -> None:
         """Import and replace the wrapped model from a dump file.
 
         For PyTorch, only import the model weights.
 
         Args:
             filename: path to the file where the model has been exported.
+            local_params: List of parameter names tagged as local.
 
         !!! info "Notes":
             This method is designed to load the model from a local dump
@@ -328,7 +331,7 @@ class TorchModel(Model):
         """
         weights = torch.load(filename)
         # check format of weights and apply them to the model
-        self.set_weights(weights)
+        self.set_weights(weights, local_params=local_params)
 
     def _reload(self, filename: str) -> None:
         """Model-class-specific backend to the `reload` method.

--- a/fedbiomed/common/models/_torch.py
+++ b/fedbiomed/common/models/_torch.py
@@ -85,8 +85,10 @@ class TorchModel(Model):
 
         unknown = local_params_set - {name for name, _ in param_iterator}
         if unknown:
-            raise FedbiomedModelError(
-                f"{ErrorNumbers.FB622.value}: Unknown local parameters: {unknown}"
+            logger.warning(
+                "'TorchModel.get_weights' received unknown local parameters "
+                "that are not part of the model; unknown parameters: %s. ",
+                unknown,
             )
 
         parameters = {

--- a/fedbiomed/common/models/_torch.py
+++ b/fedbiomed/common/models/_torch.py
@@ -193,8 +193,9 @@ class TorchModel(Model):
             missing = params.intersection(incompatible.missing_keys)
             if missing:
                 logger.warning(
-                    "'TorchModel.set_weights' received inputs that did not cover all"
-                    "trainable model parameters; missing weights: %s",
+                    "'TorchModel.set_weights' received inputs that did not cover all "
+                    "trainable model parameters; missing weights: %s. "
+                    "This behaviour is expected if some parameters are tagged as private.",
                     missing,
                 )
         # Warn about invalid (hence, unused) inputs.

--- a/fedbiomed/common/models/_torch.py
+++ b/fedbiomed/common/models/_torch.py
@@ -85,7 +85,9 @@ class TorchModel(Model):
 
         unknown = local_params_set - {name for name, _ in param_iterator}
         if unknown:
-            raise ValueError(f"Unknown local parameters: {unknown}")
+            raise FedbiomedModelError(
+                f"{ErrorNumbers.FB622.value}: Unknown local parameters: {unknown}"
+            )
 
         parameters = {
             name: param.detach().clone()

--- a/fedbiomed/common/models/_torch.py
+++ b/fedbiomed/common/models/_torch.py
@@ -4,7 +4,7 @@
 """Torch interfacing Model class."""
 
 import copy
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import numpy as np
 import torch
@@ -56,7 +56,10 @@ class TorchModel(Model):
         return gradients
 
     def get_weights(
-        self, only_trainable: bool = False, exclude_buffers: bool = True
+        self,
+        only_trainable: bool = False,
+        exclude_buffers: bool = True,
+        private_params: Optional[List[str]] = None,
     ) -> Dict[str, torch.Tensor]:
         """Return the model's parameters.
 
@@ -66,25 +69,37 @@ class TorchModel(Model):
                 or include all model parameters (the default).
             exclude_buffers: Whether to ignore buffers (the default), or
                 include them.
+            private_params: List of parameter names to exclude from the output.
 
         Returns:
             Model weights, as a dictionary mapping parameters' names to their
                 torch tensor.
         """
-        param_iterator = (
+        private_params_set = set(private_params) if private_params else set()
+
+        param_iterator = list(
             self.model.named_parameters()
             if exclude_buffers
             else self.model.state_dict().items()
         )
+
+        unknown = private_params_set - {name for name, _ in param_iterator}
+        if unknown:
+            raise ValueError(f"Unknown private parameters: {unknown}")
+
         parameters = {
             name: param.detach().clone()
             for name, param in param_iterator
-            if param.requires_grad or not only_trainable
+            if (param.requires_grad or not only_trainable)
+            and name not in private_params_set
         }
         return parameters
 
     def flatten(
-        self, only_trainable: bool = False, exclude_buffers: bool = True
+        self,
+        only_trainable: bool = False,
+        exclude_buffers: bool = True,
+        private_params: Optional[List[str]] = None,
     ) -> List[float]:
         """Gets weights as flatten vector
 
@@ -94,13 +109,16 @@ class TorchModel(Model):
                 or include all model parameters (the default).
             exclude_buffers: Whether to ignore buffers (the default), or
                 include them.
+            private_params: List of parameter names to exclude from the output.
 
         Returns:
             to_list: Convert np.ndarray to a list if it is True.
         """
         params: List[float] = torch.nn.utils.parameters_to_vector(
             self.get_weights(
-                only_trainable=only_trainable, exclude_buffers=exclude_buffers
+                only_trainable=only_trainable,
+                exclude_buffers=exclude_buffers,
+                private_params=private_params,
             ).values()
         ).tolist()
 
@@ -111,6 +129,7 @@ class TorchModel(Model):
         weights_vector: List[float],
         only_trainable: bool = False,
         exclude_buffers: bool = True,
+        private_params: Optional[List[str]] = None,
     ) -> Dict[str, torch.Tensor]:
         """Unflatten vectorized model weights using [`vector_to_parameters`][torch.nn.utils.vector_to_parameters]
 
@@ -123,18 +142,23 @@ class TorchModel(Model):
                 or include all model parameters (the default).
             exclude_buffers: Whether to ignore buffers (the default), or
                 include them.
+            private_params: List of parameter names to exclude from the output.
 
         Returns:
             Model dictionary
         """
 
-        super().unflatten(weights_vector, only_trainable, exclude_buffers)
+        super().unflatten(
+            weights_vector, only_trainable, exclude_buffers, private_params
+        )
 
         # Copy model to make sure global model parameters won't be overwritten
         model = copy.deepcopy(self)
         vector = torch.as_tensor(weights_vector).type(torch.DoubleTensor)
         weights = model.get_weights(
-            only_trainable=only_trainable, exclude_buffers=exclude_buffers
+            only_trainable=only_trainable,
+            exclude_buffers=exclude_buffers,
+            private_params=private_params,
         )
 
         # Following operation updates model parameters of copied model object

--- a/fedbiomed/common/optimizers/generic_optimizers.py
+++ b/fedbiomed/common/optimizers/generic_optimizers.py
@@ -176,8 +176,11 @@ class DeclearnOptimizer(BaseOptimizer):
         # Therefore, it is necessary to disable the sklearn internal optimizer beforehand
         # otherwise, computation will be incorrect
         grad = declearn.model.api.Vector.build(self._model.get_gradients())
+        # TODO: check how this step method is used, and if private_params must be considered or not
         weights = declearn.model.api.Vector.build(
-            self._model.get_weights(only_trainable=False, exclude_buffers=True)
+            self._model.get_weights(
+                only_trainable=False, exclude_buffers=True, private_params=None
+            )
         )
         updates = self.optimizer.step(grad, weights)
         self._model.apply_updates(updates.coefs)

--- a/fedbiomed/common/optimizers/generic_optimizers.py
+++ b/fedbiomed/common/optimizers/generic_optimizers.py
@@ -176,10 +176,9 @@ class DeclearnOptimizer(BaseOptimizer):
         # Therefore, it is necessary to disable the sklearn internal optimizer beforehand
         # otherwise, computation will be incorrect
         grad = declearn.model.api.Vector.build(self._model.get_gradients())
-        # TODO: check how this step method is used, and if private_params must be considered or not
         weights = declearn.model.api.Vector.build(
             self._model.get_weights(
-                only_trainable=False, exclude_buffers=True, private_params=None
+                only_trainable=False, exclude_buffers=True, local_params=None
             )
         )
         updates = self.optimizer.step(grad, weights)

--- a/fedbiomed/common/optimizers/optimizer.py
+++ b/fedbiomed/common/optimizers/optimizer.py
@@ -206,6 +206,145 @@ class Optimizer:
                 f"{ErrorNumbers.FB621.value}: `Optimizer.set_aux`: {exc}"
             ) from exc
 
+    def filter_aux(
+        self, aux_vars: Dict[str, AuxVar], private_params: list[str]
+    ) -> Dict[str, AuxVar]:
+        """Remove selected parameter entries from Declearn auxiliary variables.
+
+        Iterates over optimizer auxiliary variables collected from Declearn
+        modules and removes the specified parameter names from any contained
+        Vector objects (e.g. TorchVector, NumpyVector). The filtering is applied
+        to every module present in the auxiliary variable dictionary.
+
+        Args:
+            aux_vars: Dictionary of auxiliary variables,
+                mapping module names to their corresponding ``AuxVar`` objects.
+            private_params: List of parameter names to remove from auxiliary
+                vectors (e.g. ``"conv1.weight"``).
+
+        Returns:
+            The modified auxiliary variables dictionary with the selected
+            parameters removed from any contained vectors.
+
+        Raises:
+            FedbiomedOptimizerError: If ``aux_vars`` is not a dictionary, if an
+                unexpected vector structure is encountered, or if an error occurs
+                while processing auxiliary variables for a module.
+        """
+
+        if not isinstance(aux_vars, dict):
+            raise FedbiomedOptimizerError(
+                f"{ErrorNumbers.FB621.value}: Auxiliary variables must be a dict"
+            )
+
+        for module_name, auxvar in aux_vars.items():
+            try:
+                # Iterate through AuxVar attributes
+                for attr_name in vars(auxvar):
+                    attr_val = getattr(auxvar, attr_name)
+
+                    # Identify Declearn vectors by presence of `.coefs`
+                    if hasattr(attr_val, "coefs"):
+                        vector = attr_val
+
+                        if not isinstance(vector.coefs, dict):
+                            raise FedbiomedOptimizerError(
+                                f"{ErrorNumbers.FB621.value}: Unexpected vector structure in module '{module_name}', "
+                                f"attribute '{attr_name}'"
+                            )
+
+                        for layer in private_params:
+                            vector.coefs.pop(layer, None)
+
+            except Exception as exc:
+                raise FedbiomedOptimizerError(
+                    f"{ErrorNumbers.FB621.value}: Failed while processing auxiliary variables for module "
+                    f"'{module_name}': {exc}"
+                ) from exc
+
+        return aux_vars
+
+    def restore_aux(
+        self,
+        aux_vars: Dict[str, AuxVar],
+        reference_params: Dict[str, Any],
+        private_params: list[str],
+    ) -> Dict[str, AuxVar]:
+        """Restore missing auxiliary variables for private model parameters.
+
+        Ensures that auxiliary variables received from the researcher contain
+        entries for parameters that are kept private on the node side. For each
+        missing parameter name, a zero-valued tensor matching the local model
+        parameter shape is inserted into the corresponding Declearn Vector.
+
+        Args:
+            aux_vars: Dictionary of auxiliary variables received from the
+                researcher.
+            reference_vector: local model weights providing reference tensors
+                for model parameters (used to infer tensor shapes and dtypes).
+            private_params: List of parameter names that are private to the node
+                and therefore absent from researcher auxiliary variables
+                (e.g. ``"conv1.weight"``).
+
+        Returns:
+            The modified auxiliary variables dictionary where missing private
+            parameters have been restored with zero-valued tensors.
+
+        Raises:
+            FedbiomedOptimizerError: If ``aux_vars`` is not a dictionary, if
+                reference tensors cannot be mapped to Declearn Vector, if
+                reference tensors cannot be found for private parameters, or
+                if an unexpected auxiliary-variable structure is encountered.
+        """
+
+        if not isinstance(aux_vars, dict):
+            raise FedbiomedOptimizerError(
+                f"{ErrorNumbers.FB621.value}: Auxiliary variables must be a dict"
+            )
+
+        # Try to convert reference parameters to Declearn Vector
+        try:
+            reference_vector = Vector.build(reference_params)
+        except Exception as exc:
+            raise FedbiomedOptimizerError(
+                f"{ErrorNumbers.FB621.value}: Failed while instantiating Declearn "
+                f"Vector: {exc}"
+            ) from exc
+
+        for module_name, auxvar in aux_vars.items():
+            try:
+                for attr_name in vars(auxvar):
+                    attr_val = getattr(auxvar, attr_name)
+
+                    if hasattr(attr_val, "coefs"):
+                        vector = attr_val
+
+                        if not isinstance(vector.coefs, dict):
+                            raise FedbiomedOptimizerError(
+                                f"{ErrorNumbers.FB621.value}: Unexpected vector structure "
+                                f"in module '{module_name}', attribute '{attr_name}'"
+                            )
+
+                        for layer in private_params:
+                            # If layer missing, recreate zero tensor
+                            if layer not in vector.coefs:
+                                if layer not in reference_vector.coefs:
+                                    raise FedbiomedOptimizerError(
+                                        f"{ErrorNumbers.FB621.value}: Cannot infer shape "
+                                        f"for private parameter '{layer}'"
+                                    )
+
+                                ref_tensor = reference_vector.coefs[layer]
+                                vector.coefs[layer] = ref_tensor.clone().zero_()
+
+            except Exception as exc:
+                raise FedbiomedOptimizerError(
+                    f"{ErrorNumbers.FB621.value}: Failed while restoring auxiliary "
+                    f"variables for module '{module_name}': {exc}"
+                ) from exc
+
+        return aux_vars
+
     def get_aux_names(self) -> List[str]:
         """Gathers list of names of modules requiring auxiliary variables"""
         aux_names = []

--- a/fedbiomed/common/optimizers/optimizer.py
+++ b/fedbiomed/common/optimizers/optimizer.py
@@ -207,7 +207,7 @@ class Optimizer:
             ) from exc
 
     def filter_aux(
-        self, aux_vars: Dict[str, AuxVar], private_params: list[str]
+        self, aux_vars: Dict[str, AuxVar], local_params: list[str]
     ) -> Dict[str, AuxVar]:
         """Remove selected parameter entries from Declearn auxiliary variables.
 
@@ -219,7 +219,7 @@ class Optimizer:
         Args:
             aux_vars: Dictionary of auxiliary variables,
                 mapping module names to their corresponding ``AuxVar`` objects.
-            private_params: List of parameter names to remove from auxiliary
+            local_params: List of parameter names to remove from auxiliary
                 vectors (e.g. ``"conv1.weight"``).
 
         Returns:
@@ -253,7 +253,7 @@ class Optimizer:
                                 f"attribute '{attr_name}'"
                             )
 
-                        for layer in private_params:
+                        for layer in local_params:
                             vector.coefs.pop(layer, None)
 
             except Exception as exc:
@@ -268,12 +268,12 @@ class Optimizer:
         self,
         aux_vars: Dict[str, AuxVar],
         reference_params: Dict[str, Any],
-        private_params: list[str],
+        local_params: list[str],
     ) -> Dict[str, AuxVar]:
-        """Restore missing auxiliary variables for private model parameters.
+        """Restore missing auxiliary variables for local model parameters.
 
         Ensures that auxiliary variables received from the researcher contain
-        entries for parameters that are kept private on the node side. For each
+        entries for parameters that are kept local on the node side. For each
         missing parameter name, a zero-valued tensor matching the local model
         parameter shape is inserted into the corresponding Declearn Vector.
 
@@ -282,18 +282,18 @@ class Optimizer:
                 researcher.
             reference_vector: local model weights providing reference tensors
                 for model parameters (used to infer tensor shapes and dtypes).
-            private_params: List of parameter names that are private to the node
+            local_params: List of parameter names that are local to the node
                 and therefore absent from researcher auxiliary variables
                 (e.g. ``"conv1.weight"``).
 
         Returns:
-            The modified auxiliary variables dictionary where missing private
+            The modified auxiliary variables dictionary where missing local
             parameters have been restored with zero-valued tensors.
 
         Raises:
             FedbiomedOptimizerError: If ``aux_vars`` is not a dictionary, if
                 reference tensors cannot be mapped to Declearn Vector, if
-                reference tensors cannot be found for private parameters, or
+                reference tensors cannot be found for local parameters, or
                 if an unexpected auxiliary-variable structure is encountered.
         """
 
@@ -325,13 +325,13 @@ class Optimizer:
                                 f"in module '{module_name}', attribute '{attr_name}'"
                             )
 
-                        for layer in private_params:
+                        for layer in local_params:
                             # If layer missing, recreate zero tensor
                             if layer not in vector.coefs:
                                 if layer not in reference_vector.coefs:
                                     raise FedbiomedOptimizerError(
                                         f"{ErrorNumbers.FB621.value}: Cannot infer shape "
-                                        f"for private parameter '{layer}'"
+                                        f"for local parameter '{layer}'"
                                     )
 
                                 ref_tensor = reference_vector.coefs[layer]

--- a/fedbiomed/common/privacy/_dp_controller.py
+++ b/fedbiomed/common/privacy/_dp_controller.py
@@ -102,11 +102,12 @@ class DPController:
                 ) from e
         return optimizer, loader
 
-    def after_training(self, params: Dict) -> Dict:
+    def after_training(self, params: Dict, renaming: bool = True) -> Dict:
         """DP actions after the training.
 
         Args:
             params: Contains model parameters after training with DP
+            renaming: whether to modify parameters names
         Returns:
             `params` fixed model parameters after applying differential privacy
         """
@@ -116,7 +117,7 @@ class DPController:
                 self._dp_args.get("type"),
                 len(params),
             )
-            params = self._postprocess_dp(params)
+            params = self._postprocess_dp(params, renaming)
         return params
 
     def _configure_dp_args(self) -> None:
@@ -182,7 +183,7 @@ class DPController:
         )
         return eps, alpha
 
-    def _postprocess_dp(self, params: Dict) -> Dict:
+    def _postprocess_dp(self, params: Dict, renaming: bool = True) -> Dict:
         """Postprocess of model's parameters after training with DP.
 
         **Postprocess of DP parameters implies**
@@ -196,6 +197,8 @@ class DPController:
 
         Args:
             params: Contains model parameters after training with DP
+            renaming: whether to modify parameters names
+
         Returns:
             Contains (post processed) parameters
         """
@@ -207,7 +210,8 @@ class DPController:
             len(params),
         )
         # Rename parameters when needed.
-        params = {key.replace("_module.", ""): param for key, param in params.items()}
+        if renaming:
+            params, _ = self.rename_params(params)
         # When using central DP, postprocess the parameters.
         if self._dp_args["type"] == "central":
             logger.debug("Applying central DP noise during postprocessing")
@@ -216,3 +220,37 @@ class DPController:
                 noise = sigma * self._dp_args["clip"] * torch.randn_like(param)
                 params[key] = param + noise
         return params
+
+    def rename_params(self, params: Dict) -> Tuple[Dict, Dict[str, str]]:
+        """Rename the model parameters modified by Opacus
+
+        Args:
+            params: Contains model parameters after training with DP
+
+        Returns:
+            renamed_params: parameters with Opacus prefix stripped.
+            rename_mapping: maps new names to original Opacus names,
+                only for parameters whose names were actually modified.
+        """
+        renamed_params = {}
+        rename_mapping = {}
+        for key, param in params.items():
+            new_key = key.replace("_module.", "")
+            renamed_params[new_key] = param
+            if new_key != key:
+                rename_mapping[new_key] = key
+        return renamed_params, rename_mapping
+
+    def revert_rename_params(
+        self, params: Dict, rename_mapping: Dict[str, str]
+    ) -> Dict:
+        """Restore the original Opacus parameter names using a rename mapping.
+
+        Args:
+            params: Contains model parameters with stripped names.
+            rename_mapping: Maps stripped names back to original Opacus names,
+                as returned by rename_params.
+        Returns:
+            Parameters with original Opacus names restored.
+        """
+        return {rename_mapping.get(key, key): param for key, param in params.items()}

--- a/fedbiomed/common/serializer.py
+++ b/fedbiomed/common/serializer.py
@@ -164,6 +164,12 @@ class Serializer:
             return VectorSpec(**obj["value"])
         if objtype == "AuxVar":
             return json_unpack(obj["value"])
+        if objtype.startswith("AuxVar"):
+            try:
+                return json_unpack(obj)
+            except Exception:
+                logger.warning("Failed to unpack AuxVar subtype.")
+                return obj
         if objtype == "MetricTypes":
             return MetricTypes.get_metric_type_by_name(obj["value"])
         if objtype == "EncryptedAuxVar":

--- a/fedbiomed/common/serializer.py
+++ b/fedbiomed/common/serializer.py
@@ -128,7 +128,9 @@ class Serializer:
         if isinstance(obj, VectorSpec):
             return {"__type__": "VectorSpec", "value": dataclasses.asdict(obj)}
         if isinstance(obj, AuxVar):
-            return {"__type__": "AuxVar", "value": json_pack(obj)}
+            return json_pack(
+                obj
+            )  # json_pack of Declearn already adds the "__type__" field
         if isinstance(obj, MetricTypes):
             return {"__type__": "MetricTypes", "value": obj.name}
         if isinstance(obj, EncryptedAuxVar):
@@ -162,10 +164,11 @@ class Serializer:
             return Vector.build(obj["value"])
         if objtype == "VectorSpec":
             return VectorSpec(**obj["value"])
-        if objtype == "AuxVar":
-            return json_unpack(obj["value"])
-        if objtype.startswith("AuxVar"):
+        if objtype.startswith(
+            "AuxVar"
+        ):  # Declearn scaffold aux var type is AuxVar>ScaffoldAuxVar
             try:
+                # json_upack of Declearn expects the "__type__" field to be present in the dict
                 return json_unpack(obj)
             except Exception:
                 logger.warning("Failed to unpack AuxVar subtype.")

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -76,7 +76,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
     _type = TrainingPlans.NoneTrainingPlan
 
     # Allowed tags for parameter behavior customization
-    _allowed_tags: Set[str] = {"private", "persistent"}
+    _allowed_tags: Set[str] = {"local", "persistent"}
 
     def __init__(self) -> None:
         """Construct the base training plan."""
@@ -93,7 +93,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         self._loader_args: Dict[str, Any] = None
         self._training_args: Dict[str, Any] = None
         self._node_id: Optional[str] = None
-        self._private_params: Optional[List[str]] = None
+        self._local_params: Optional[List[str]] = None
 
         self._error_msg_import_model: str = (
             f"{ErrorNumbers.FB605.value}: Training Plan's Model is not initialized.\n"
@@ -337,7 +337,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         self,
         only_trainable: bool = False,
         exclude_buffers: bool = True,
-        private_params: Optional[List[str]] = None,
+        local_params: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """Return a copy of the model's trainable weights.
 
@@ -350,7 +350,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
                 or include all model parameters (the default).
             exclude_buffers: Whether to ignore buffers (the default), or
                 include them.
-            private_params: List of parameter names to exclude from the output.
+            local_params: List of parameter names to exclude from the output.
 
         Returns:
             Model weights, as a dictionary mapping parameters' names to their value.
@@ -358,10 +358,12 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         return self._model.get_weights(
             only_trainable=only_trainable,
             exclude_buffers=exclude_buffers,
-            private_params=private_params,
+            local_params=local_params,
         )
 
-    def set_model_params(self, params: Dict[str, Any]) -> None:
+    def set_model_params(
+        self, params: Dict[str, Any], local_params: Optional[List[str]] = None
+    ) -> None:
         """Assign new values to the model's trainable parameters.
 
         The type of data structure used to store weights depends on the actual
@@ -370,8 +372,9 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         Args:
             params: model weights, as a dictionary mapping parameters' names
                 to their value.
+            local_params: List of parameter names tagged as local.
         """
-        self._model.set_weights(params)
+        self._model.set_weights(params, local_params=local_params)
 
     def set_aggregator_args(self, aggregator_args: Dict[str, Any]):
         raise FedbiomedTrainingPlanError("method not implemented and needed")
@@ -708,9 +711,9 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         have multiple tags.
 
         Valid Tags:
-        private:
+        local:
             The parameter is never shared nor aggregated.
-        persistent
+        persistent:
             The parameter is saved on the client and is persisted locally
             across federated rounds.
 
@@ -856,10 +859,10 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         )
         if flatten:
             return self._model.flatten(
-                exclude_buffers=exclude_buffers, private_params=self._private_params
+                exclude_buffers=exclude_buffers, local_params=self._local_params
             )
         return self.get_model_params(
-            exclude_buffers=exclude_buffers, private_params=self._private_params
+            exclude_buffers=exclude_buffers, local_params=self._local_params
         )
 
     def export_model(self, filename: str) -> None:
@@ -915,7 +918,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         if self._model is None:
             raise FedbiomedTrainingPlanError(self._error_msg_import_model % "import")
         try:
-            self._model.reload(filename)
+            self._model.reload(filename, self._local_params)
         except FedbiomedModelError as exc:
             msg = (
                 f"{ErrorNumbers.FB304.value}: failed to import a model from "

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -117,6 +117,10 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         """
         return self._model
 
+    def get_dp_controller(self) -> Optional[Any]:
+        """Getter for dp controller"""
+        return None
+
     def type(self) -> TrainingPlans:
         """Getter for training plan type"""
         return self._type

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -6,7 +6,17 @@
 import random
 from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, TypedDict, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Set,
+    TypedDict,
+    Union,
+)
 
 import numpy as np
 import torch
@@ -65,6 +75,9 @@ class BaseTrainingPlan(metaclass=ABCMeta):
     # Training plan type needs to be defined for every framework
     _type = TrainingPlans.NoneTrainingPlan
 
+    # Allowed tags for parameter behavior customization
+    _allowed_tags: Set[str] = {"private", "persistent"}
+
     def __init__(self) -> None:
         """Construct the base training plan."""
         self._dependencies: List[str] = []
@@ -80,6 +93,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         self._loader_args: Dict[str, Any] = None
         self._training_args: Dict[str, Any] = None
         self._node_id: Optional[str] = None
+        self._private_params: Optional[List[str]] = None
 
         self._error_msg_import_model: str = (
             f"{ErrorNumbers.FB605.value}: Training Plan's Model is not initialized.\n"
@@ -316,7 +330,10 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         raise FedbiomedTrainingPlanError(msg)
 
     def get_model_params(
-        self, only_trainable: bool = False, exclude_buffers: bool = True
+        self,
+        only_trainable: bool = False,
+        exclude_buffers: bool = True,
+        private_params: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
         """Return a copy of the model's trainable weights.
 
@@ -329,12 +346,15 @@ class BaseTrainingPlan(metaclass=ABCMeta):
                 or include all model parameters (the default).
             exclude_buffers: Whether to ignore buffers (the default), or
                 include them.
+            private_params: List of parameter names to exclude from the output.
 
         Returns:
             Model weights, as a dictionary mapping parameters' names to their value.
         """
         return self._model.get_weights(
-            only_trainable=only_trainable, exclude_buffers=exclude_buffers
+            only_trainable=only_trainable,
+            exclude_buffers=exclude_buffers,
+            private_params=private_params,
         )
 
     def set_model_params(self, params: Dict[str, Any]) -> None:
@@ -671,6 +691,117 @@ class BaseTrainingPlan(metaclass=ABCMeta):
             f"samples={n_samples}"
         )
 
+    def tag_parameters(self, name: str) -> Set[str]:
+        """Assign tags to a model parameter.
+
+        This method allows researchers to override the default federated
+        behavior of specific parameters by assigning them one or more tags.
+        Parameters that are not tagged follow the default behavior
+        (i.e., globally shared, aggregated, and trainable).
+
+        Tags define how the federated engine should treat the parameter
+        during training, aggregation, and persistence. A parameter may
+        have multiple tags.
+
+        Valid Tags:
+        private:
+            The parameter is never shared nor aggregated.
+        persistent
+            The parameter is saved on the client and is persisted locally
+            across federated rounds.
+
+        Args:
+            name: The name of the parameter to tag (e.g. `"encoder.layer3.1.conv2.weight"`
+            for a PyTorch model, or `"intercept_"` for a sklearn model).
+
+        Returns:
+            A set of tags associated with the parameter. Must be a subset of
+            `self._allowed_tags`. Return an empty set for default federated behavior
+        """
+        return set()
+
+    def _validate_parameter_tags(self, name: str, tags: Set[str]) -> Set[str]:
+        """Validate that a set of parameter tags is correct.
+
+        Checks that the `tags` argument is a set and contains only allowed tags.
+        Raises an error if the input is invalid.
+
+        Args:
+            name: The name of the parameter whose tags are being validated.
+            tags: The set of tags returned by `tag_parameters`.
+
+        Returns:
+            The validated set of tags.
+
+        Raises:
+            FedbiomedTrainingPlanError if `tags` is not a set or contains invalid tags.
+        """
+        if not isinstance(tags, set):
+            raise FedbiomedTrainingPlanError(
+                f"{ErrorNumbers.FB605}: tag_parameters must return a set, "
+                f"got: {type(tags)} for parameter '{name}'"
+            )
+
+        invalid_tags = tags - self._allowed_tags
+        if invalid_tags:
+            raise FedbiomedTrainingPlanError(
+                f"{ErrorNumbers.FB605}: Invalid tags {invalid_tags} for parameter '{name}'. "
+                f"Allowed tags are {self._allowed_tags}"
+            )
+
+        return tags
+
+    def get_parameter_tags(self, name: str) -> Set[str]:
+        """Retrieve and validate the tags for a given parameter.
+
+        Args:
+            name: The name of the parameter whose tags are being retrieved.
+
+        Returns:
+            The validated set of tags associated with the parameter.
+        """
+        tags = self.tag_parameters(name)
+        return self._validate_parameter_tags(name, tags)
+
+    def filter_model_params_by_tags(
+        self,
+        params: Dict[str, Any],
+        required_tags: Optional[Set[str]] = None,
+        forbidden_tags: Optional[Set[str]] = None,
+    ) -> Dict[str, Any]:
+        """Filters a given parameter dict based on required or forbidden tags.
+
+        Args:
+            params: Dictionary of model parameters (e.g. output of get_model_params)
+            required_tags: Set of tags that parameters must include (AND logic)
+            forbidden_tags: Set of tags that parameters must NOT include
+
+        Returns:
+            Filtered dictionary of parameters
+        """
+        filtered_params = {}
+
+        required_tags = required_tags or set()
+        forbidden_tags = forbidden_tags or set()
+
+        if not isinstance(required_tags, set) or not isinstance(forbidden_tags, set):
+            raise FedbiomedTrainingPlanError(
+                f"{ErrorNumbers.FB605}: required_tags and forbidden_tags must be sets"
+            )
+
+        for name, value in params.items():
+            tags = self.get_parameter_tags(name)
+
+            if required_tags and not required_tags.issubset(tags):
+                continue
+
+            if forbidden_tags and not tags.isdisjoint(forbidden_tags):
+                continue
+
+            filtered_params[name] = value
+
+        return filtered_params
+
     @staticmethod
     def _infer_batch_size(
         data: Union[dict, list, tuple, "torch.Tensor", "np.ndarray"],
@@ -720,8 +851,12 @@ class BaseTrainingPlan(metaclass=ABCMeta):
             f"exclude_buffers={exclude_buffers}"
         )
         if flatten:
-            return self._model.flatten(exclude_buffers=exclude_buffers)
-        return self.get_model_params(exclude_buffers=exclude_buffers)
+            return self._model.flatten(
+                exclude_buffers=exclude_buffers, private_params=self._private_params
+            )
+        return self.get_model_params(
+            exclude_buffers=exclude_buffers, private_params=self._private_params
+        )
 
     def export_model(self, filename: str) -> None:
         """Export the wrapped model to a dump file.

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -974,3 +974,12 @@ class BaseTrainingPlan(metaclass=ABCMeta):
             Node id
         """
         return self._node_id
+
+    @property
+    def local_params(self) -> Optional[List[str]]:
+        """Retrieves local parameters
+
+        Returns:
+            Parameters tagged as local in the training plan
+        """
+        return self._local_params

--- a/fedbiomed/common/training_plans/_sklearn_training_plan.py
+++ b/fedbiomed/common/training_plans/_sklearn_training_plan.py
@@ -130,13 +130,13 @@ class SKLearnTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
             f"optimizer_wrapper={type(self._optimizer).__name__ if self._optimizer is not None else None} "
             f"initialize_optimizer={initialize_optimizer}"
         )
-        # Configure the parameters tagged as private
-        self._private_params = list(
+        # Configure the parameters tagged as local
+        self._local_params = list(
             self.filter_model_params_by_tags(
                 self.get_model_params(
-                    only_trainable=False, exclude_buffers=False, private_params=None
+                    only_trainable=False, exclude_buffers=False, local_params=None
                 ),
-                required_tags={"private"},
+                required_tags={"local"},
             ).keys()
         )
 

--- a/fedbiomed/common/training_plans/_sklearn_training_plan.py
+++ b/fedbiomed/common/training_plans/_sklearn_training_plan.py
@@ -130,6 +130,15 @@ class SKLearnTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
             f"optimizer_wrapper={type(self._optimizer).__name__ if self._optimizer is not None else None} "
             f"initialize_optimizer={initialize_optimizer}"
         )
+        # Configure the parameters tagged as private
+        self._private_params = list(
+            self.filter_model_params_by_tags(
+                self.get_model_params(
+                    only_trainable=False, exclude_buffers=False, private_params=None
+                ),
+                required_tags={"private"},
+            ).keys()
+        )
 
     def set_data_loaders(
         self,

--- a/fedbiomed/common/training_plans/_torchnn.py
+++ b/fedbiomed/common/training_plans/_torchnn.py
@@ -797,20 +797,25 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
             "Collected raw training parameters: parameter_count=%s",
             len(params),
         )
-        ## TODO: What is this postprocess method, and how to deal with it ??
         # Check whether postprocess method exists, and use it.
         if hasattr(self, "postprocess"):
             logger.debug("running model.postprocess() method")
             try:
-                params = self.postprocess(
+                all_params = self.postprocess(
                     self._model.model.state_dict()
                 )  # Post process
+                # Exclude private parameters
+                params = self.filter_model_params_by_tags(
+                    all_params,
+                    forbidden_tags={"private"},
+                )
             except Exception as e:
                 raise FedbiomedTrainingPlanError(
                     f"{ErrorNumbers.FB605.value}: Error while running post-process {e}"
                 ) from e
 
         # Run (optional) DP controller adjustments as well.
+        # TODO: params after DP do not seem used if flatten is True
         params = self._dp_controller.after_training(params)
         logger.debug(
             "Applied DP/postprocess adjustments to parameters: parameter_count=%s flatten=%s",

--- a/fedbiomed/common/training_plans/_torchnn.py
+++ b/fedbiomed/common/training_plans/_torchnn.py
@@ -127,6 +127,10 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         # Add dependencies
         self._configure_dependencies()
 
+    def get_dp_controller(self) -> Optional[DPController]:
+        """Getter for dp controller"""
+        return self._dp_controller
+
     def post_init(
         self,
         model_args: Dict[str, Any],
@@ -792,45 +796,64 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         )
         # Either include non-parameter buffers to the outputs or not.
         # Note: this is mostly about sharing statistics from BatchNorm layers.
-        params = super().after_training_params()
+        exclude_buffers = not self._share_persistent_buffers
+        all_params = self.get_model_params(
+            exclude_buffers=exclude_buffers, private_params=None
+        )
         logger.debug(
             "Collected raw training parameters: parameter_count=%s",
-            len(params),
+            len(all_params),
         )
+        # Deal with DP first, that may change names of parameters in case OPACUS is used
+        renamed_all_params, rename_mapping = self._dp_controller.rename_params(
+            all_params
+        )
+
         # Check whether postprocess method exists, and use it.
         if hasattr(self, "postprocess"):
             logger.debug("running model.postprocess() method")
             try:
-                all_params = self.postprocess(
-                    self._model.model.state_dict()
-                )  # Post process
-                # Exclude private parameters
-                params = self.filter_model_params_by_tags(
-                    all_params,
-                    forbidden_tags={"private"},
+                all_params = self.postprocess(renamed_all_params)  # Post process
+                # Retrieve original OPACUS naming to update model
+                all_params = self._dp_controller.revert_rename_params(
+                    all_params, rename_mapping
                 )
             except Exception as e:
                 raise FedbiomedTrainingPlanError(
                     f"{ErrorNumbers.FB605.value}: Error while running post-process {e}"
                 ) from e
 
-        # Run (optional) DP controller adjustments as well.
-        # TODO: params after DP do not seem used if flatten is True
-        params = self._dp_controller.after_training(params)
+        # Run (optional) central DP controller adjustments as well to all parameters.
+        # Do not rename parameters yet, because the model parameters need to be updated first
+        all_params = self._dp_controller.after_training(all_params, renaming=False)
         logger.debug(
             "Applied DP/postprocess adjustments to parameters: parameter_count=%s flatten=%s",
-            len(params),
+            len(all_params),
             flatten,
+        )
+        # Update the model (needed to use flatten)
+        self._model.set_weights(all_params)
+        # Remove private params
+        private_params = (
+            [rename_mapping.get(name, name) for name in self._private_params]
+            if self._private_params is not None
+            else None
         )
         if flatten:
             params = self._model.flatten(
-                exclude_buffers=not self._share_persistent_buffers,
-                private_params=self._private_params,
+                exclude_buffers=exclude_buffers, private_params=private_params
             )
             logger.debug(
                 "Flattened training parameters for aggregation: flattened_count=%s",
                 len(params),
             )
+        else:
+            params = self.get_model_params(
+                exclude_buffers=exclude_buffers, private_params=private_params
+            )
+            # Final renaming before being sent to the researcher
+            params, _ = self._dp_controller.rename_params(params)
+
         return params
 
     def __norm_l2(self) -> float:

--- a/fedbiomed/common/training_plans/_torchnn.py
+++ b/fedbiomed/common/training_plans/_torchnn.py
@@ -188,6 +188,15 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         )
 
         self._configure_model_and_optimizer(initialize_optimizer)
+        # Configure the parameters tagged as private
+        self._private_params = list(
+            self.filter_model_params_by_tags(
+                self.get_model_params(
+                    only_trainable=False, exclude_buffers=False, private_params=None
+                ),
+                required_tags={"private"},
+            ).keys()
+        )
 
     @abstractmethod
     def init_model(self):
@@ -767,6 +776,8 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         training arguments, then we return only the output of
         [Model.get_weights][fedbiomed.common.models.TorchModel.get_weights],
         which considers only the trainable parameters.
+        If the researcher specified some parameters tagged as 'private', then these
+        parameters are not returned
         Otherwise, the default behaviour is to return the complete `state_dict`.
 
         Returns:
@@ -786,6 +797,7 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
             "Collected raw training parameters: parameter_count=%s",
             len(params),
         )
+        ## TODO: What is this postprocess method, and how to deal with it ??
         # Check whether postprocess method exists, and use it.
         if hasattr(self, "postprocess"):
             logger.debug("running model.postprocess() method")
@@ -807,7 +819,8 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         )
         if flatten:
             params = self._model.flatten(
-                exclude_buffers=not self._share_persistent_buffers
+                exclude_buffers=not self._share_persistent_buffers,
+                private_params=self._private_params,
             )
             logger.debug(
                 "Flattened training parameters for aggregation: flattened_count=%s",

--- a/fedbiomed/common/training_plans/_torchnn.py
+++ b/fedbiomed/common/training_plans/_torchnn.py
@@ -192,13 +192,13 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         )
 
         self._configure_model_and_optimizer(initialize_optimizer)
-        # Configure the parameters tagged as private
-        self._private_params = list(
+        # Configure the parameters tagged as local
+        self._local_params = list(
             self.filter_model_params_by_tags(
                 self.get_model_params(
-                    only_trainable=False, exclude_buffers=False, private_params=None
+                    only_trainable=False, exclude_buffers=False, local_params=None
                 ),
-                required_tags={"private"},
+                required_tags={"local"},
             ).keys()
         )
 
@@ -780,7 +780,7 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         training arguments, then we return only the output of
         [Model.get_weights][fedbiomed.common.models.TorchModel.get_weights],
         which considers only the trainable parameters.
-        If the researcher specified some parameters tagged as 'private', then these
+        If the researcher specified some parameters tagged as 'local', then these
         parameters are not returned
         Otherwise, the default behaviour is to return the complete `state_dict`.
 
@@ -798,7 +798,7 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         # Note: this is mostly about sharing statistics from BatchNorm layers.
         exclude_buffers = not self._share_persistent_buffers
         all_params = self.get_model_params(
-            exclude_buffers=exclude_buffers, private_params=None
+            exclude_buffers=exclude_buffers, local_params=None
         )
         logger.debug(
             "Collected raw training parameters: parameter_count=%s",
@@ -832,16 +832,16 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
             flatten,
         )
         # Update the model (needed to use flatten)
-        self._model.set_weights(all_params)
-        # Remove private params
-        private_params = (
-            [rename_mapping.get(name, name) for name in self._private_params]
-            if self._private_params is not None
+        self._model.set_weights(all_params, local_params=None)
+        # Remove local params
+        local_params = (
+            [rename_mapping.get(name, name) for name in self._local_params]
+            if self._local_params is not None
             else None
         )
         if flatten:
             params = self._model.flatten(
-                exclude_buffers=exclude_buffers, private_params=private_params
+                exclude_buffers=exclude_buffers, local_params=local_params
             )
             logger.debug(
                 "Flattened training parameters for aggregation: flattened_count=%s",
@@ -849,7 +849,7 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
             )
         else:
             params = self.get_model_params(
-                exclude_buffers=exclude_buffers, private_params=private_params
+                exclude_buffers=exclude_buffers, local_params=local_params
             )
             # Final renaming before being sent to the researcher
             params, _ = self._dp_controller.rename_params(params)

--- a/fedbiomed/node/node_state_manager.py
+++ b/fedbiomed/node/node_state_manager.py
@@ -31,6 +31,7 @@ class NodeStateFileName(_BaseEnum):
     """
 
     OPTIMIZER: str = "optim_state_%s_%s"
+    MODEL_WEIGHTS: str = "model_weights_%s_%s"
 
 
 class NodeStateManager:

--- a/fedbiomed/node/node_state_manager.py
+++ b/fedbiomed/node/node_state_manager.py
@@ -31,7 +31,7 @@ class NodeStateFileName(_BaseEnum):
     """
 
     OPTIMIZER: str = "optim_state_%s_%s"
-    MODEL_WEIGHTS: str = "model_weights_%s_%s"
+    MODEL_WEIGHTS: str = "persistent_model_weights_%s_%s"
 
 
 class NodeStateManager:

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -923,6 +923,11 @@ class Round:
         full_model_weights = self.training_plan.get_model_params(
             only_trainable=False, exclude_buffers=False, private_params=None
         )
+        # Deal with potential differential privacy, that change model parameters names
+        dp_controller = self.training_plan.get_dp_controller()
+        if dp_controller is not None:
+            full_model_weights, _ = dp_controller.rename_params(full_model_weights)
+
         persistent_model_weights = self.training_plan.filter_model_params_by_tags(
             params=full_model_weights, required_tags={"persistent"}
         )

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -762,6 +762,7 @@ class Round:
 
     def process_optim_aux_var(self) -> Optional[str]:
         """Process researcher-emitted Optimizer auxiliary variables, if any.
+        Reset auxiliary variables to zero vectors for private parameters.
 
         Returns:
             Error message, empty if the operation was successful.
@@ -782,6 +783,16 @@ class Round:
             )
         # Pass auxiliary variables to the Optimizer.
         try:
+            full_model_weights = self.training_plan.get_model_params(
+                only_trainable=False, exclude_buffers=False, private_params=None
+            )
+            private = self.training_plan.filter_model_params_by_tags(
+                full_model_weights,
+                required_tags={"private"},
+            )
+            self.aux_vars = optimizer.optimizer.restore_aux(
+                self.aux_vars, full_model_weights, private
+            )
             optimizer.optimizer.set_aux(self.aux_vars)
         except FedbiomedOptimizerError as exc:
             return (
@@ -959,7 +970,8 @@ class Round:
     def collect_optim_aux_var(
         self,
     ) -> Dict[str, AuxVar]:
-        """Collect auxiliary variables from the wrapped Optimizer, if any.
+        """Collect auxiliary variables from the wrapped Optimizer, if any,
+        and remove auxiliary variables related to private parameters, if any.
 
         If the TrainingPlan does not use a Fed-BioMed Optimizer, return an
         empty dict. If it does not hold any BaseOptimizer however, raise a
@@ -970,7 +982,18 @@ class Round:
         """
         optimizer = self._get_base_optimizer()
         if isinstance(optimizer.optimizer, Optimizer):
-            return optimizer.optimizer.get_aux()
+            full_aux_var = optimizer.optimizer.get_aux()
+            # Remove auxiliary variables related to private parameters
+            full_model_weights = self.training_plan.get_model_params(
+                only_trainable=False, exclude_buffers=False, private_params=None
+            )
+            private = self.training_plan.filter_model_params_by_tags(
+                full_model_weights,
+                required_tags={"private"},
+            )
+            aux_var = optimizer.optimizer.filter_aux(full_aux_var, private)
+
+            return aux_var
         return {}
 
     def _get_base_optimizer(self) -> BaseOptimizer:

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -1178,9 +1178,8 @@ class Round:
             initial_model_weights,
             required_tags={"private", "persistent"},
         )
-
-        for name in private_persistent:
-            if name in persistent_model_weights:
+        for name in private_persistent.keys():
+            if name in persistent_model_weights.keys():
                 full_params[name] = persistent_model_weights[name]
             else:
                 # First round: use initial model weight
@@ -1193,7 +1192,7 @@ class Round:
             forbidden_tags={"persistent"},
         )
 
-        for name in private_only:
+        for name in private_only.keys():
             full_params[name] = initial_model_weights[name]
 
         return full_params

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -786,14 +786,15 @@ class Round:
             full_model_weights = self.training_plan.get_model_params(
                 only_trainable=False, exclude_buffers=False, local_params=None
             )
-            local_params = self.training_plan.filter_model_params_by_tags(
-                full_model_weights,
-                required_tags={"local"},
+            local_params = list(
+                self.training_plan.filter_model_params_by_tags(
+                    full_model_weights, required_tags={"local"}
+                ).keys()
             )
-            self.aux_vars = optimizer.optimizer.restore_aux(
+            aux_vars = optimizer.optimizer.restore_aux(
                 self.aux_vars, full_model_weights, local_params
             )
-            optimizer.optimizer.set_aux(self.aux_vars)
+            optimizer.optimizer.set_aux(aux_vars)
         except FedbiomedOptimizerError as exc:
             return (
                 "TrainingPlan Optimizer failed to ingest the provided "
@@ -987,9 +988,10 @@ class Round:
             full_model_weights = self.training_plan.get_model_params(
                 only_trainable=False, exclude_buffers=False, local_params=None
             )
-            local_params = self.training_plan.filter_model_params_by_tags(
-                full_model_weights,
-                required_tags={"local"},
+            local_params = list(
+                self.training_plan.filter_model_params_by_tags(
+                    full_model_weights, required_tags={"local"}
+                ).keys()
             )
             aux_var = optimizer.optimizer.filter_aux(full_aux_var, local_params)
 

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -138,6 +138,7 @@ class Round:
         )
         self._temp_dir = tempfile.TemporaryDirectory()
         self._keep_files_dir = self._temp_dir.name
+        self._persistent_model_weights = None
 
     def __del__(self):
         """Class destructor"""
@@ -339,6 +340,11 @@ class Round:
             )
             return self._send_round_reply(success=False, message=error_message)
 
+        # load all initial models weights
+        initial_model_weights = self.training_plan.get_model_params(
+            only_trainable=False, exclude_buffers=False, private_params=None
+        )
+
         # load node state
         previous_state_id = self._node_state_manager.previous_state_id
         if previous_state_id is not None:
@@ -354,9 +360,14 @@ class Round:
                     success=False, message="Can't read previous node state."
                 )
 
-        # Load model parameters received from researcher
+        # Reconstruct full parameters
+        full_model_weights = self._reconstruct_full_params(
+            initial_model_weights, self.params, self._persistent_model_weights
+        )
+
+        # Load full model parameters
         try:
-            self.training_plan.set_model_params(self.params)
+            self.training_plan.set_model_params(full_model_weights)
         except Exception as e:
             error_message = "Cannot initialize model parameters."
             logger.error(f"{error_message} Details: {repr(e)}")
@@ -787,12 +798,13 @@ class Round:
         return None
 
     def _load_round_state(self, state_id: str) -> None:
-        """Loads optimizer state of previous `Round`, given a `state_id`.
+        """Loads state of previous `Round`, given a `state_id`.
 
         Loads optimizer with default values if optimizer entry has not been found
         or if Optimizer type has changed between current and previous `Round`. Should
         be called at the beginning of a `Round`, before training a model.
         If loading fails, skip the loading part and loads `Optimizer` with default values.
+        Also load persistent parameters saved locally during the previous `Round`
 
         Args:
             state_id: state_id from which to recover `Node`'s state
@@ -819,7 +831,7 @@ class Round:
 
                 optimizer_wrapper.load_state(optim_state, load_from_state=True)
                 logger.debug(f"Optimizer loaded state {optim_state}")
-                logger.info(f"State {state_id} loaded")
+                logger.info(f"Optimizer from state {state_id} loaded")
 
             except Exception as err:
                 logger.warning(
@@ -832,19 +844,30 @@ class Round:
         if state["testing_dataset"] and not self.is_test_data_shuffled:
             self._testing_indexes = state["testing_dataset"]
 
+        ## load the persistent parameters
+        if state["persistent_model_weights"]:
+            model_weights_path = state["persistent_model_weights"].get("state_path")
+            persistent_model_weights = Serializer.load(model_weights_path)
+            self._persistent_model_weights = persistent_model_weights
+        else:
+            self._persistent_model_weights = dict()
+
         # add below other components that need to be reloaded from node state database
 
     def _save_round_state(self) -> Dict:
-        """Saves `Round` state (mainly Optimizer state) in database through
-        [`NodeStateManager`][fedbiomed.node.node_state_manager.NodeStateManager].
+        """Saves `Round` state (mainly Optimizer state, and persistent parameters) in database
+        through [`NodeStateManager`][fedbiomed.node.node_state_manager.NodeStateManager].
 
-        Some piece of information such as Optimizer state are also aved in files (located under
-        <fedbiomed-node>/var/node_state<node_id>/experiment_id_<experiment_id>/).
+        Some piece of information such as Optimizer state and persistent parameters are also
+        saved in files
+        (located under <fedbiomed-node>/var/node_state<node_id>/experiment_id_<experiment_id>/).
         Should be called at the end of a `Round`, once the model has been trained.
 
         Entries saved in State:
         - optimizer_state:
             - optimizer_type (str)
+            - state_path (str)
+        - persistent_model_weights:
             - state_path (str)
 
         Returns:
@@ -894,6 +917,28 @@ class Round:
             logger.info("testing dataset saved in database")
         else:
             logger.info("testing data will be reshuffled next rounds")
+
+        # save model weights with "persistent" tag
+        state["persistent_model_weights"] = None
+        full_model_weights = self.training_plan.get_model_params(
+            only_trainable=False, exclude_buffers=False, private_params=None
+        )
+        persistent_model_weights = self.training_plan.filter_model_params_by_tags(
+            params=full_model_weights, required_tags={"persistent"}
+        )
+        if persistent_model_weights:
+            model_weights_path = (
+                self._node_state_manager.generate_folder_and_create_file_name(
+                    self.experiment_id, self._round, NodeStateFileName.MODEL_WEIGHTS
+                )
+            )
+            Serializer.dump(persistent_model_weights, path=model_weights_path)
+            logger.debug("Saving persistent model weights")
+            model_weights_state_entry: Dict = {
+                "state_path": model_weights_path,
+            }
+            state["persistent_model_weights"] = model_weights_state_entry
+
         # add here other object states (ie model state, ...)
 
         # save completed node state
@@ -1093,3 +1138,62 @@ class Round:
         self._testing_indexes = data_manager.save_state()
 
         return training_loader, testing_loader
+
+    def _reconstruct_full_params(
+        self,
+        initial_model_weights: Dict[str, Any],
+        weights_from_researcher: Dict[str, Any],
+        persistent_model_weights: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Reconstructs the full set of model parameters before training.
+
+        This method merges parameters received from the researcher (typically
+        aggregated global parameters) with locally managed parameters based on
+        their associated tags ("private", "persistent").
+
+        The reconstruction follows these rules:
+            - Parameters tagged as both "private" and "persistent" are restored
+            from `persistent_model_weights` if available. If not (e.g., first
+            round), they are initialized from `initial_model_weights`.
+            - Parameters tagged as "private" but not "persistent" are always
+            reinitialized from `initial_model_weights` at each round.
+            - All other parameters are kept as provided in `weights_from_researcher`.
+
+        Args:
+            initial_model_weights: initial values of all model parameters (before any training)
+            weights_from_researcher: parameters received from the researcher
+            persistent_model_weights: locally stored parameters saved from previous rounds
+
+        Returns:
+            the complete set of parameters to be loaded into the model before training
+        """
+        # Deal with the case where persistent_model_weights is None
+        persistent_model_weights = persistent_model_weights or {}
+
+        # Start from parameters received by researcher
+        full_params = dict(weights_from_researcher)
+
+        # private and persistent parameters: override with saved values
+        private_persistent = self.training_plan.filter_model_params_by_tags(
+            initial_model_weights,
+            required_tags={"private", "persistent"},
+        )
+
+        for name in private_persistent:
+            if name in persistent_model_weights:
+                full_params[name] = persistent_model_weights[name]
+            else:
+                # First round: use initial model weight
+                full_params[name] = initial_model_weights[name]
+
+        # private only parameters: override with initial values
+        private_only = self.training_plan.filter_model_params_by_tags(
+            initial_model_weights,
+            required_tags={"private"},
+            forbidden_tags={"persistent"},
+        )
+
+        for name in private_only:
+            full_params[name] = initial_model_weights[name]
+
+        return full_params

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -1198,31 +1198,12 @@ class Round:
             the complete set of parameters to be loaded into the model before training
         """
         # Deal with the case where persistent_model_weights is None
-        persistent_model_weights = persistent_model_weights or {}
-
-        # Start from parameters received by researcher
-        full_params = dict(weights_from_researcher)
-
-        # local and persistent parameters: override with saved values
-        local_persistent = self.training_plan.filter_model_params_by_tags(
-            initial_model_weights,
-            required_tags={"local", "persistent"},
-        )
-        for name in local_persistent.keys():
-            if name in persistent_model_weights.keys():
-                full_params[name] = persistent_model_weights[name]
-            else:
-                # First round: use initial model weight
-                full_params[name] = initial_model_weights[name]
-
-        # local only parameters: override with initial values
-        local_only = self.training_plan.filter_model_params_by_tags(
-            initial_model_weights,
-            required_tags={"local"},
-            forbidden_tags={"persistent"},
+        persistent_model_weights = (
+            persistent_model_weights if persistent_model_weights is not None else {}
         )
 
-        for name in local_only.keys():
-            full_params[name] = initial_model_weights[name]
-
-        return full_params
+        return {
+            **initial_model_weights,
+            **persistent_model_weights,
+            **weights_from_researcher,
+        }

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -342,7 +342,7 @@ class Round:
 
         # load all initial models weights
         initial_model_weights = self.training_plan.get_model_params(
-            only_trainable=False, exclude_buffers=False, private_params=None
+            only_trainable=False, exclude_buffers=False, local_params=None
         )
 
         # load node state
@@ -367,7 +367,7 @@ class Round:
 
         # Load full model parameters
         try:
-            self.training_plan.set_model_params(full_model_weights)
+            self.training_plan.set_model_params(full_model_weights, local_params=None)
         except Exception as e:
             error_message = "Cannot initialize model parameters."
             logger.error(f"{error_message} Details: {repr(e)}")
@@ -762,7 +762,7 @@ class Round:
 
     def process_optim_aux_var(self) -> Optional[str]:
         """Process researcher-emitted Optimizer auxiliary variables, if any.
-        Reset auxiliary variables to zero vectors for private parameters.
+        Reset auxiliary variables to zero vectors for local parameters.
 
         Returns:
             Error message, empty if the operation was successful.
@@ -784,14 +784,14 @@ class Round:
         # Pass auxiliary variables to the Optimizer.
         try:
             full_model_weights = self.training_plan.get_model_params(
-                only_trainable=False, exclude_buffers=False, private_params=None
+                only_trainable=False, exclude_buffers=False, local_params=None
             )
-            private = self.training_plan.filter_model_params_by_tags(
+            local_params = self.training_plan.filter_model_params_by_tags(
                 full_model_weights,
-                required_tags={"private"},
+                required_tags={"local"},
             )
             self.aux_vars = optimizer.optimizer.restore_aux(
-                self.aux_vars, full_model_weights, private
+                self.aux_vars, full_model_weights, local_params
             )
             optimizer.optimizer.set_aux(self.aux_vars)
         except FedbiomedOptimizerError as exc:
@@ -932,7 +932,7 @@ class Round:
         # save model weights with "persistent" tag
         state["persistent_model_weights"] = None
         full_model_weights = self.training_plan.get_model_params(
-            only_trainable=False, exclude_buffers=False, private_params=None
+            only_trainable=False, exclude_buffers=False, local_params=None
         )
         # Deal with potential differential privacy, that change model parameters names
         dp_controller = self.training_plan.get_dp_controller()
@@ -971,7 +971,7 @@ class Round:
         self,
     ) -> Dict[str, AuxVar]:
         """Collect auxiliary variables from the wrapped Optimizer, if any,
-        and remove auxiliary variables related to private parameters, if any.
+        and remove auxiliary variables related to local parameters, if any.
 
         If the TrainingPlan does not use a Fed-BioMed Optimizer, return an
         empty dict. If it does not hold any BaseOptimizer however, raise a
@@ -983,15 +983,15 @@ class Round:
         optimizer = self._get_base_optimizer()
         if isinstance(optimizer.optimizer, Optimizer):
             full_aux_var = optimizer.optimizer.get_aux()
-            # Remove auxiliary variables related to private parameters
+            # Remove auxiliary variables related to local parameters
             full_model_weights = self.training_plan.get_model_params(
-                only_trainable=False, exclude_buffers=False, private_params=None
+                only_trainable=False, exclude_buffers=False, local_params=None
             )
-            private = self.training_plan.filter_model_params_by_tags(
+            local_params = self.training_plan.filter_model_params_by_tags(
                 full_model_weights,
-                required_tags={"private"},
+                required_tags={"local"},
             )
-            aux_var = optimizer.optimizer.filter_aux(full_aux_var, private)
+            aux_var = optimizer.optimizer.filter_aux(full_aux_var, local_params)
 
             return aux_var
         return {}
@@ -1177,13 +1177,13 @@ class Round:
 
         This method merges parameters received from the researcher (typically
         aggregated global parameters) with locally managed parameters based on
-        their associated tags ("private", "persistent").
+        their associated tags ("local", "persistent").
 
         The reconstruction follows these rules:
-            - Parameters tagged as both "private" and "persistent" are restored
+            - Parameters tagged as both "local" and "persistent" are restored
             from `persistent_model_weights` if available. If not (e.g., first
             round), they are initialized from `initial_model_weights`.
-            - Parameters tagged as "private" but not "persistent" are always
+            - Parameters tagged as "local" but not "persistent" are always
             reinitialized from `initial_model_weights` at each round.
             - All other parameters are kept as provided in `weights_from_researcher`.
 
@@ -1201,26 +1201,26 @@ class Round:
         # Start from parameters received by researcher
         full_params = dict(weights_from_researcher)
 
-        # private and persistent parameters: override with saved values
-        private_persistent = self.training_plan.filter_model_params_by_tags(
+        # local and persistent parameters: override with saved values
+        local_persistent = self.training_plan.filter_model_params_by_tags(
             initial_model_weights,
-            required_tags={"private", "persistent"},
+            required_tags={"local", "persistent"},
         )
-        for name in private_persistent.keys():
+        for name in local_persistent.keys():
             if name in persistent_model_weights.keys():
                 full_params[name] = persistent_model_weights[name]
             else:
                 # First round: use initial model weight
                 full_params[name] = initial_model_weights[name]
 
-        # private only parameters: override with initial values
-        private_only = self.training_plan.filter_model_params_by_tags(
+        # local only parameters: override with initial values
+        local_only = self.training_plan.filter_model_params_by_tags(
             initial_model_weights,
-            required_tags={"private"},
+            required_tags={"local"},
             forbidden_tags={"persistent"},
         )
 
-        for name in private_only.keys():
+        for name in local_only.keys():
             full_params[name] = initial_model_weights[name]
 
         return full_params

--- a/fedbiomed/researcher/aggregators/aggregator.py
+++ b/fedbiomed/researcher/aggregators/aggregator.py
@@ -89,7 +89,7 @@ class Aggregator:
 
         # Convert model params
         model = training_plan.get_model_wrapper_class()
-        # TODO: check here !
+        # TODO: to be updated with private_params here ?
         model_params = model.unflatten(aggregated_params)
 
         return model_params

--- a/fedbiomed/researcher/aggregators/aggregator.py
+++ b/fedbiomed/researcher/aggregators/aggregator.py
@@ -89,6 +89,7 @@ class Aggregator:
 
         # Convert model params
         model = training_plan.get_model_wrapper_class()
+        # TODO: check here !
         model_params = model.unflatten(aggregated_params)
 
         return model_params

--- a/fedbiomed/researcher/aggregators/aggregator.py
+++ b/fedbiomed/researcher/aggregators/aggregator.py
@@ -89,7 +89,7 @@ class Aggregator:
 
         # Convert model params
         model = training_plan.get_model_wrapper_class()
-        # TODO: to be updated with private_params here ?
+        # TODO: to be updated with local_params here ?
         model_params = model.unflatten(aggregated_params)
 
         return model_params

--- a/fedbiomed/researcher/aggregators/scaffold.py
+++ b/fedbiomed/researcher/aggregators/scaffold.py
@@ -381,7 +381,7 @@ class Scaffold(Aggregator):
             Dict[str, List[float]]: dictionary mapping node_id and a list of float, as many as
                 the number of layers contained in the model (in Pytroch, each layer can have a specific learning rate).
         """
-        local_params = training_plan._local_params
+        local_params = training_plan.local_params
         n_model_layers = len(
             training_plan.get_model_params(
                 only_trainable=False,

--- a/fedbiomed/researcher/aggregators/scaffold.py
+++ b/fedbiomed/researcher/aggregators/scaffold.py
@@ -381,12 +381,12 @@ class Scaffold(Aggregator):
             Dict[str, List[float]]: dictionary mapping node_id and a list of float, as many as
                 the number of layers contained in the model (in Pytroch, each layer can have a specific learning rate).
         """
-        private_params = training_plan._private_params
+        local_params = training_plan._local_params
         n_model_layers = len(
             training_plan.get_model_params(
                 only_trainable=False,
                 exclude_buffers=True,
-                private_params=private_params,
+                local_params=local_params,
             )
         )
         for node_id in self._fds.node_ids():

--- a/fedbiomed/researcher/aggregators/scaffold.py
+++ b/fedbiomed/researcher/aggregators/scaffold.py
@@ -381,9 +381,13 @@ class Scaffold(Aggregator):
             Dict[str, List[float]]: dictionary mapping node_id and a list of float, as many as
                 the number of layers contained in the model (in Pytroch, each layer can have a specific learning rate).
         """
-
+        private_params = training_plan._private_params
         n_model_layers = len(
-            training_plan.get_model_params(only_trainable=False, exclude_buffers=True)
+            training_plan.get_model_params(
+                only_trainable=False,
+                exclude_buffers=True,
+                private_params=private_params,
+            )
         )
         for node_id in self._fds.node_ids():
             lrs: Dict[str, float] = {}

--- a/fedbiomed/researcher/federated_workflows/_experiment.py
+++ b/fedbiomed/researcher/federated_workflows/_experiment.py
@@ -439,6 +439,11 @@ class Experiment(TrainingPlanWorkflow):
                 f"Optimizer instance or None, not {type(agg_optimizer)}."
             )
         self._agg_optimizer = agg_optimizer
+        if isinstance(agg_optimizer, Optimizer) and self.training_plan()._local_params:
+            logger.warning(
+                "Using Declearn optimizers for aggregation and parameters tagged "
+                "as local may lead to unexpected behaviours."
+            )
         return self._agg_optimizer
 
     @exp_exceptions

--- a/fedbiomed/researcher/federated_workflows/_experiment.py
+++ b/fedbiomed/researcher/federated_workflows/_experiment.py
@@ -974,10 +974,11 @@ class Experiment(TrainingPlanWorkflow):
             n_aux_var = encrypted_auxvar.get_num_expected_params()
         # Perform secure aggregation of all encrypted parameters.
         exclude_buffers = not self.training_args()["share_persistent_buffers"]
+        private_params = self.training_plan()._private_params
         num_expected_params = len(
             self.training_plan()
             .get_model_wrapper_class()
-            .flatten(exclude_buffers=exclude_buffers)
+            .flatten(exclude_buffers=exclude_buffers, private_params=private_params)
         )
 
         flattened_model_weights = self._secagg.aggregate(
@@ -1010,7 +1011,11 @@ class Experiment(TrainingPlanWorkflow):
         aggregated_params: Dict[str, Union[torch.Tensor, np.ndarray]] = (
             self.training_plan()
             .get_model_wrapper_class()
-            .unflatten(flattened_model_weights, exclude_buffers=exclude_buffers)
+            .unflatten(
+                flattened_model_weights,
+                exclude_buffers=exclude_buffers,
+                private_params=private_params,
+            )
         )
         # Return aggregated model parameters and optimizer auxiliary variables.
         return aggregated_params, aggregated_auxvar

--- a/fedbiomed/researcher/federated_workflows/_experiment.py
+++ b/fedbiomed/researcher/federated_workflows/_experiment.py
@@ -439,11 +439,13 @@ class Experiment(TrainingPlanWorkflow):
                 f"Optimizer instance or None, not {type(agg_optimizer)}."
             )
         self._agg_optimizer = agg_optimizer
-        if isinstance(agg_optimizer, Optimizer) and self.training_plan().local_params:
-            logger.warning(
-                "Using Declearn optimizers for aggregation and parameters tagged "
-                "as local may lead to unexpected behaviours."
-            )
+        if isinstance(agg_optimizer, Optimizer):
+            tp = self.training_plan()
+            if tp is not None and tp.local_params:
+                logger.warning(
+                    "Using Declearn optimizers for aggregation and parameters tagged "
+                    "as local may lead to unexpected behaviours."
+                )
         return self._agg_optimizer
 
     @exp_exceptions

--- a/fedbiomed/researcher/federated_workflows/_experiment.py
+++ b/fedbiomed/researcher/federated_workflows/_experiment.py
@@ -853,7 +853,10 @@ class Experiment(TrainingPlanWorkflow):
         )
 
         # Update the training plan with the aggregated parameters
-        self.training_plan().set_model_params(aggregated_params)
+        local_params = self.training_plan()._local_params
+        self.training_plan().set_model_params(
+            aggregated_params, local_params=local_params
+        )
 
         # Update experiment's in-memory history
         self.commit_experiment_history(training_replies, aggregated_params)
@@ -974,11 +977,11 @@ class Experiment(TrainingPlanWorkflow):
             n_aux_var = encrypted_auxvar.get_num_expected_params()
         # Perform secure aggregation of all encrypted parameters.
         exclude_buffers = not self.training_args()["share_persistent_buffers"]
-        private_params = self.training_plan()._private_params
+        local_params = self.training_plan()._local_params
         num_expected_params = len(
             self.training_plan()
             .get_model_wrapper_class()
-            .flatten(exclude_buffers=exclude_buffers, private_params=private_params)
+            .flatten(exclude_buffers=exclude_buffers, local_params=local_params)
         )
 
         flattened_model_weights = self._secagg.aggregate(
@@ -1014,7 +1017,7 @@ class Experiment(TrainingPlanWorkflow):
             .unflatten(
                 flattened_model_weights,
                 exclude_buffers=exclude_buffers,
-                private_params=private_params,
+                local_params=local_params,
             )
         )
         # Return aggregated model parameters and optimizer auxiliary variables.
@@ -1050,17 +1053,17 @@ class Experiment(TrainingPlanWorkflow):
         # aggregated_params = agg({w^t - sum_k(eta_{k,i,t} * grad_{k,i,t})}_i)
         # hence aggregated_params = w^t - agg(updates_i)
         # hence agg_gradients = agg_i(updates_i)
-        private_params = training_plan._private_params
+        local_params = training_plan._local_params
         names = set(
             training_plan.get_model_params(
-                only_trainable=True, private_params=private_params
+                only_trainable=True, local_params=local_params
             )
         )
         init_params = Vector.build(
             {
                 k: v
                 for k, v in training_plan.get_model_params(
-                    private_params=private_params
+                    local_params=local_params
                 ).items()
                 if k in names
             }

--- a/fedbiomed/researcher/federated_workflows/_experiment.py
+++ b/fedbiomed/researcher/federated_workflows/_experiment.py
@@ -1050,9 +1050,20 @@ class Experiment(TrainingPlanWorkflow):
         # aggregated_params = agg({w^t - sum_k(eta_{k,i,t} * grad_{k,i,t})}_i)
         # hence aggregated_params = w^t - agg(updates_i)
         # hence agg_gradients = agg_i(updates_i)
-        names = set(training_plan.get_model_params(only_trainable=True))
+        private_params = training_plan._private_params
+        names = set(
+            training_plan.get_model_params(
+                only_trainable=True, private_params=private_params
+            )
+        )
         init_params = Vector.build(
-            {k: v for k, v in training_plan.get_model_params().items() if k in names}
+            {
+                k: v
+                for k, v in training_plan.get_model_params(
+                    private_params=private_params
+                ).items()
+                if k in names
+            }
         )
         agg_gradients = init_params - Vector.build(
             {k: v for k, v in aggregated_params.items() if k in names}

--- a/fedbiomed/researcher/federated_workflows/_experiment.py
+++ b/fedbiomed/researcher/federated_workflows/_experiment.py
@@ -439,7 +439,7 @@ class Experiment(TrainingPlanWorkflow):
                 f"Optimizer instance or None, not {type(agg_optimizer)}."
             )
         self._agg_optimizer = agg_optimizer
-        if isinstance(agg_optimizer, Optimizer) and self.training_plan()._local_params:
+        if isinstance(agg_optimizer, Optimizer) and self.training_plan().local_params:
             logger.warning(
                 "Using Declearn optimizers for aggregation and parameters tagged "
                 "as local may lead to unexpected behaviours."
@@ -858,7 +858,7 @@ class Experiment(TrainingPlanWorkflow):
         )
 
         # Update the training plan with the aggregated parameters
-        local_params = self.training_plan()._local_params
+        local_params = self.training_plan().local_params
         self.training_plan().set_model_params(
             aggregated_params, local_params=local_params
         )
@@ -982,7 +982,7 @@ class Experiment(TrainingPlanWorkflow):
             n_aux_var = encrypted_auxvar.get_num_expected_params()
         # Perform secure aggregation of all encrypted parameters.
         exclude_buffers = not self.training_args()["share_persistent_buffers"]
-        local_params = self.training_plan()._local_params
+        local_params = self.training_plan().local_params
         num_expected_params = len(
             self.training_plan()
             .get_model_wrapper_class()
@@ -1058,7 +1058,7 @@ class Experiment(TrainingPlanWorkflow):
         # aggregated_params = agg({w^t - sum_k(eta_{k,i,t} * grad_{k,i,t})}_i)
         # hence aggregated_params = w^t - agg(updates_i)
         # hence agg_gradients = agg_i(updates_i)
-        local_params = training_plan._local_params
+        local_params = training_plan.local_params
         names = set(
             training_plan.get_model_params(
                 only_trainable=True, local_params=local_params

--- a/fedbiomed/researcher/federated_workflows/_federated_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_workflow.py
@@ -1019,6 +1019,9 @@ class FederatedWorkflow(ABC):
 
         secagg = SecureAggregation.load_state_breakpoint(saved_state.get("secagg"))
         loaded_exp.set_secagg(secagg)
+        loaded_exp._node_state_agent.load_fds_breakpoint(
+            saved_state.get("training_data")
+        )
         loaded_exp._node_state_agent.load_state_breakpoint(
             saved_state.get("node_state")
         )

--- a/fedbiomed/researcher/federated_workflows/_training_plan_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_training_plan_workflow.py
@@ -541,7 +541,7 @@ class TrainingPlanWorkflow(FederatedWorkflow, ABC):
             os.path.join("..", os.path.basename(training_plan_file)),
         )
         params_path = os.path.join(breakpoint_path, f"model_params_{uuid.uuid4()}.mpk")
-        local_params = self.training_plan()._local_params
+        local_params = self.training_plan().local_params
         Serializer.dump(
             self.training_plan()
             .get_model_wrapper_class()
@@ -606,7 +606,7 @@ class TrainingPlanWorkflow(FederatedWorkflow, ABC):
             raise FedbiomedExperimentError(msg)
         param_path = saved_state["model_weights_path"]
         params = Serializer.load(param_path)
-        local_params = training_plan._local_params
+        local_params = training_plan.local_params
         loaded_exp.training_plan().get_model_wrapper_class().set_weights(
             params, local_params=local_params
         )
@@ -657,7 +657,7 @@ class TrainingPlanWorkflow(FederatedWorkflow, ABC):
         """
 
         if keep_weights and self._training_plan is not None:
-            local_params = self.training_plan()._local_params
+            local_params = self.training_plan().local_params
             weights = self._training_plan.get_model_params(
                 exclude_buffers=False, local_params=local_params
             )

--- a/fedbiomed/researcher/federated_workflows/_training_plan_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_training_plan_workflow.py
@@ -541,11 +541,15 @@ class TrainingPlanWorkflow(FederatedWorkflow, ABC):
             os.path.join("..", os.path.basename(training_plan_file)),
         )
         params_path = os.path.join(breakpoint_path, f"model_params_{uuid.uuid4()}.mpk")
-        # TODO: here: should we save the private parameters ?
+        private_params = self.training_plan()._private_params
         Serializer.dump(
             self.training_plan()
             .get_model_wrapper_class()
-            .get_weights(only_trainable=False, exclude_buffers=False),
+            .get_weights(
+                only_trainable=False,
+                exclude_buffers=False,
+                private_params=private_params,
+            ),
             params_path,
         )
         state["model_weights_path"] = params_path

--- a/fedbiomed/researcher/federated_workflows/_training_plan_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_training_plan_workflow.py
@@ -541,14 +541,14 @@ class TrainingPlanWorkflow(FederatedWorkflow, ABC):
             os.path.join("..", os.path.basename(training_plan_file)),
         )
         params_path = os.path.join(breakpoint_path, f"model_params_{uuid.uuid4()}.mpk")
-        private_params = self.training_plan()._private_params
+        local_params = self.training_plan()._local_params
         Serializer.dump(
             self.training_plan()
             .get_model_wrapper_class()
             .get_weights(
                 only_trainable=False,
                 exclude_buffers=False,
-                private_params=private_params,
+                local_params=local_params,
             ),
             params_path,
         )
@@ -606,7 +606,10 @@ class TrainingPlanWorkflow(FederatedWorkflow, ABC):
             raise FedbiomedExperimentError(msg)
         param_path = saved_state["model_weights_path"]
         params = Serializer.load(param_path)
-        loaded_exp.training_plan().get_model_wrapper_class().set_weights(params)
+        local_params = training_plan._local_params
+        loaded_exp.training_plan().get_model_wrapper_class().set_weights(
+            params, local_params=local_params
+        )
 
         return loaded_exp, saved_state, tempo_id
 
@@ -654,10 +657,13 @@ class TrainingPlanWorkflow(FederatedWorkflow, ABC):
         """
 
         if keep_weights and self._training_plan is not None:
-            weights = self._training_plan.get_model_params(exclude_buffers=False)
+            local_params = self.training_plan()._local_params
+            weights = self._training_plan.get_model_params(
+                exclude_buffers=False, local_params=local_params
+            )
             yield
             try:
-                self._training_plan.set_model_params(weights)
+                self._training_plan.set_model_params(weights, local_params=local_params)
             except Exception as e:
                 msg = (
                     f"{ErrorNumbers.FB410.value}. Attempting to keep same weights even though model has changed "

--- a/fedbiomed/researcher/federated_workflows/_training_plan_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_training_plan_workflow.py
@@ -541,6 +541,7 @@ class TrainingPlanWorkflow(FederatedWorkflow, ABC):
             os.path.join("..", os.path.basename(training_plan_file)),
         )
         params_path = os.path.join(breakpoint_path, f"model_params_{uuid.uuid4()}.mpk")
+        # TODO: here: should we save the private parameters ?
         Serializer.dump(
             self.training_plan()
             .get_model_wrapper_class()

--- a/fedbiomed/researcher/federated_workflows/jobs/_training_job.py
+++ b/fedbiomed/researcher/federated_workflows/jobs/_training_job.py
@@ -152,7 +152,8 @@ class TrainingJob(Job):
             "params": self._training_plan.get_model_params(
                 exclude_buffers=not self._training_args.dict()[
                     "share_persistent_buffers"
-                ]
+                ],
+                private_params=self._training_plan._private_params,
             ),
             "secagg_arguments": self._secagg_arguments,
             "aggregator_args": {},

--- a/fedbiomed/researcher/federated_workflows/jobs/_training_job.py
+++ b/fedbiomed/researcher/federated_workflows/jobs/_training_job.py
@@ -153,7 +153,7 @@ class TrainingJob(Job):
                 exclude_buffers=not self._training_args.dict()[
                     "share_persistent_buffers"
                 ],
-                local_params=self._training_plan._local_params,
+                local_params=self._training_plan.local_params,
             ),
             "secagg_arguments": self._secagg_arguments,
             "aggregator_args": {},

--- a/fedbiomed/researcher/federated_workflows/jobs/_training_job.py
+++ b/fedbiomed/researcher/federated_workflows/jobs/_training_job.py
@@ -153,7 +153,7 @@ class TrainingJob(Job):
                 exclude_buffers=not self._training_args.dict()[
                     "share_persistent_buffers"
                 ],
-                private_params=self._training_plan._private_params,
+                local_params=self._training_plan._local_params,
             ),
             "secagg_arguments": self._secagg_arguments,
             "aggregator_args": {},

--- a/fedbiomed/researcher/node_state_agent.py
+++ b/fedbiomed/researcher/node_state_agent.py
@@ -100,3 +100,11 @@ class NodeStateAgent:
             node_state: state of `NodeStateAgent` to be loaded.
         """
         self._collection_state_ids = node_state.get("collection_state_ids")
+
+    def load_fds_breakpoint(self, fds_bkpt: Dict) -> None:
+        """Loads NodeStateAgent's federated dataset state from saved state.
+
+        Args:
+            fds_bkpt: state of `NodeStateAgent` to be loaded.
+        """
+        self._fds = FederatedDataset(fds_bkpt)

--- a/notebooks/pytorch-tag-parameters.ipynb
+++ b/notebooks/pytorch-tag-parameters.ipynb
@@ -1,0 +1,12137 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Node specific parameters with torch training plan\n",
+    "\n",
+    "The goal of this notebook is to test `tag_parameters` feature with torch training plan.\n",
+    "\n",
+    "This example uses MNIST dataset. Please check `README.md` file in `notebooks` directory for the instructions to load MNIST dataset and configure nodes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test 1: simple experiment with breakpoints"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define an experiment model and parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Declare a torch training plan MyTrainingPlan class to send for training on the node"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.functional as F\n",
+    "from torch.optim import Adam\n",
+    "from torchvision import  transforms\n",
+    "\n",
+    "from fedbiomed.common.training_plans import TorchTrainingPlan\n",
+    "from fedbiomed.common.datamanager import DataManager\n",
+    "from fedbiomed.common.optimizers.optimizer import Optimizer\n",
+    "from fedbiomed.common.optimizers.declearn import ScaffoldClientModule\n",
+    "from fedbiomed.common.dataset import MnistDataset\n",
+    "\n",
+    "\n",
+    "# Here we define the training plan to be used.\n",
+    "# You can use any class name (here 'MyTrainingPlan')\n",
+    "class MyTrainingPlan(TorchTrainingPlan):\n",
+    "\n",
+    "    def init_dependencies(self):\n",
+    "        return [\"from torchvision import transforms\",\n",
+    "                \"from fedbiomed.common.dataset import MnistDataset\",\n",
+    "                \"from fedbiomed.common.optimizers.optimizer import Optimizer\",\n",
+    "                \"from fedbiomed.common.optimizers.declearn import ScaffoldClientModule\",\n",
+    "                \"from fedbiomed.common.optimizers.declearn import AdamModule\",\n",
+    "                \"from fedbiomed.common.optimizers.declearn import RidgeRegularizer\",\n",
+    "                \"from torch.optim import Adam\"]\n",
+    "        \n",
+    "    class Net(nn.Module):\n",
+    "        def __init__(self, model_args):\n",
+    "            super().__init__()\n",
+    "            self.conv1 = nn.Conv2d(1, 32, 3, 1)\n",
+    "            self.conv2 = nn.Conv2d(32, 64, 3, 1)\n",
+    "            self.dropout1 = nn.Dropout(0.25)\n",
+    "            self.dropout2 = nn.Dropout(0.5)\n",
+    "            self.fc1 = nn.Linear(9216, 128)\n",
+    "            self.fc2 = nn.Linear(128, 10)\n",
+    "\n",
+    "        def forward(self, x):\n",
+    "            x = self.conv1(x)\n",
+    "            x = F.relu(x)\n",
+    "            x = self.conv2(x)\n",
+    "            x = F.relu(x)\n",
+    "            x = F.max_pool2d(x, 2)\n",
+    "            x = self.dropout1(x)\n",
+    "            x = torch.flatten(x, 1)\n",
+    "            x = self.fc1(x)\n",
+    "            x = F.relu(x)\n",
+    "            x = self.dropout2(x)\n",
+    "            x = self.fc2(x)\n",
+    "            output = F.log_softmax(x, dim=1)\n",
+    "            return output\n",
+    "\n",
+    "    def init_model(self, model_args):\n",
+    "        model = self.Net(model_args = model_args)\n",
+    "        return model\n",
+    "\n",
+    "    def init_optimizer(self, optimizer_args):\n",
+    "        return Adam(self.model().parameters(), lr = optimizer_args[\"lr\"])\n",
+    "\n",
+    "    def training_data(self):\n",
+    "        transform = transforms.Normalize((0.1307,), (0.3081,))\n",
+    "        loader_arguments = { 'shuffle': True}\n",
+    "        \n",
+    "        dataset = MnistDataset(transform=transform)\n",
+    "        return DataManager(dataset, **loader_arguments)\n",
+    "\n",
+    "    def training_step(self, data, target):\n",
+    "        output = self.model().forward(data)\n",
+    "        loss   = torch.nn.functional.nll_loss(output, target)\n",
+    "        return loss\n",
+    "\n",
+    "    def tag_parameters(self, name):\n",
+    "        if name == 'conv1.weight':\n",
+    "            return {'local', 'persistent'}\n",
+    "        if name == 'conv2.bias':\n",
+    "            return {'persistent'}\n",
+    "        return set()\n",
+    "            "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Model arguments and training arguments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "model_args = {}\n",
+    "\n",
+    "training_args = {\n",
+    "    'loader_args': { 'batch_size': 5, }, \n",
+    "    'optimizer_args': {\n",
+    "        \"lr\" : 1e-3\n",
+    "    },\n",
+    "    'num_updates': 20,\n",
+    "    'dry_run': False\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create and run the experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:26,563 fedbiomed INFO - Syslog configuration is disabled or not found in configuration. Disabling syslog logging."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:26,605 fedbiomed INFO - Starting researcher service..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:26,606 fedbiomed INFO - Waiting 3s for nodes to connect..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:29,612 fedbiomed INFO - Updating training data. This action will update FederatedDataset, and the nodes that will participate to the experiment."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:29,686 fedbiomed INFO - Node selected for training -> Default Node Alias\n",
+       "Node ID is -> NODE_5eaa634a-8589-4251-9779-f4435535cb17"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:29,687 fedbiomed INFO - Node selected for training -> Default Node Alias\n",
+       "Node ID is -> NODE_523186bc-f4af-4044-a946-60003cdef368"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/user/lchambon/home/miniconda3/envs/fedbiomed-dev/lib/python3.10/site-packages/opacus/privacy_engine.py:96: UserWarning: Secure RNG turned off. This is perfectly fine for experimentation as it allows for much faster training performance, but remember to turn it on and retrain one last time before production with ``secure_mode`` turned on.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "from fedbiomed.researcher.federated_workflows import Experiment\n",
+    "from fedbiomed.researcher.aggregators.fedavg import FedAverage\n",
+    "from fedbiomed.common.optimizers.optimizer import Optimizer\n",
+    "from fedbiomed.common.optimizers.declearn import ScaffoldServerModule\n",
+    "from fedbiomed.common.optimizers.declearn import YogiModule as FedYogi\n",
+    "\n",
+    "tags =  ['#MNIST', '#dataset']\n",
+    "rounds = 15\n",
+    "\n",
+    "exp = Experiment(tags=tags,\n",
+    "                 model_args=model_args,\n",
+    "                 training_plan_class=MyTrainingPlan,\n",
+    "                 training_args=training_args,\n",
+    "                 round_limit=rounds,\n",
+    "                 aggregator=FedAverage(),\n",
+    "                 tensorboard=True,\n",
+    "                 save_breakpoints=True,\n",
+    "                 node_selection_strategy=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:29,732 fedbiomed INFO - Sampled nodes in round 0 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:29,745 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:29,747 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:29,908 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.330683\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:30,537 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.316147\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:32,775 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.397312\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:33,607 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.965052\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:36,469 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.227121\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:36,535 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.838028\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:36,880 fedbiomed INFO - Nodes that successfully reply in round 0 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:36,905 fedbiomed INFO - breakpoint number 0 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0000/breakpoint_0000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:36,908 fedbiomed INFO - Sampled nodes in round 1 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:36,911 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:36,911 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:37,070 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.234035\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:37,426 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.380980\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:39,577 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.327115\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:40,597 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.606437\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:43,328 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.662495\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:43,392 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.210674\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:43,692 fedbiomed INFO - Nodes that successfully reply in round 1 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:43,715 fedbiomed INFO - breakpoint number 1 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0000/breakpoint_0001"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:43,718 fedbiomed INFO - Sampled nodes in round 2 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:43,722 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:43,723 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:43,912 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.405669\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:44,287 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.792244\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:46,770 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.599973\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:47,194 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.305215\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:50,594 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.965385\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:50,656 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.945999\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:50,964 fedbiomed INFO - Nodes that successfully reply in round 2 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:51,010 fedbiomed INFO - breakpoint number 2 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0000/breakpoint_0002"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:51,016 fedbiomed INFO - Sampled nodes in round 3 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:51,027 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:51,029 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:51,553 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.323617\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:51,702 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.059193\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:54,570 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.906685\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:54,937 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.360987\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:58,223 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.121763\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:58,276 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.285411\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:58,579 fedbiomed INFO - Nodes that successfully reply in round 3 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:58,639 fedbiomed INFO - breakpoint number 3 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0000/breakpoint_0003"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:58,642 fedbiomed INFO - Sampled nodes in round 4 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:58,651 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:58,654 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:58,860 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.424744\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:12:59,239 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.480500\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:01,991 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.062011\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:02,579 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.826037\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:05,838 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.377079\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:05,903 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.525843\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:06,218 fedbiomed INFO - Nodes that successfully reply in round 4 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:06,269 fedbiomed INFO - breakpoint number 4 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0000/breakpoint_0004"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:06,274 fedbiomed INFO - Sampled nodes in round 5 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:06,281 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:06,282 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:06,482 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.064432\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:06,963 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.495422\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:08,901 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.495146\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:09,374 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.457326\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:11,746 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.725460\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:11,802 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.926519\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:12,117 fedbiomed INFO - Nodes that successfully reply in round 5 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:12,221 fedbiomed INFO - breakpoint number 5 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0000/breakpoint_0005"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:12,227 fedbiomed INFO - Sampled nodes in round 6 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:12,235 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:12,236 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:12,472 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.400108\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:13,170 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.548494\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:15,374 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.691988\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:16,873 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.449440\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:18,724 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.936202\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:18,816 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.898899\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:19,113 fedbiomed INFO - Nodes that successfully reply in round 6 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:19,217 fedbiomed INFO - breakpoint number 6 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0000/breakpoint_0006"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:19,221 fedbiomed INFO - Sampled nodes in round 7 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:19,226 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:19,227 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:19,439 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.448558\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:19,901 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.813982\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:23,161 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.548484\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:23,298 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.954535\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:26,603 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.541740\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:26,686 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.723222\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:26,986 fedbiomed INFO - Nodes that successfully reply in round 7 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:27,071 fedbiomed INFO - breakpoint number 7 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0000/breakpoint_0007"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:27,076 fedbiomed INFO - Sampled nodes in round 8 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:27,083 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:27,085 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:27,295 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.012608\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:27,820 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.558223\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:30,259 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.806055\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:30,656 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.882495\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:34,226 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.583100\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:34,359 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.766802\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:34,676 fedbiomed INFO - Nodes that successfully reply in round 8 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:34,746 fedbiomed INFO - breakpoint number 8 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0000/breakpoint_0008"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:34,749 fedbiomed INFO - Sampled nodes in round 9 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:34,754 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:34,755 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:34,962 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.854934\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:35,356 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.377015\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:37,288 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.557329\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:37,804 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.760169\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:40,342 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.218073\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:40,426 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.665676\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:40,756 fedbiomed INFO - Nodes that successfully reply in round 9 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:40,843 fedbiomed INFO - breakpoint number 9 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0000/breakpoint_0009"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:40,846 fedbiomed INFO - Sampled nodes in round 10 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:40,849 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:40,850 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:41,063 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.714869\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:41,544 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.374549\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:44,357 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.945609\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:44,468 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.307966\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:48,339 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.320033\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:48,402 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.361993\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:48,763 fedbiomed INFO - Nodes that successfully reply in round 10 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:48,922 fedbiomed INFO - breakpoint number 10 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0000/breakpoint_0010"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:48,927 fedbiomed INFO - Sampled nodes in round 11 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:48,936 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:48,938 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:49,183 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.533643\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:49,670 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.565149\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:52,266 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.297628\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:52,686 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.513294\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:56,186 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.309694\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:56,243 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.080514\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:56,572 fedbiomed INFO - Nodes that successfully reply in round 11 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:56,643 fedbiomed INFO - breakpoint number 11 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0000/breakpoint_0011"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:56,646 fedbiomed INFO - Sampled nodes in round 12 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:56,650 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:56,651 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:56,856 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.543090\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:57,321 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.369034\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:13:59,671 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.372696\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:00,656 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.106419\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:02,833 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.334266\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:02,956 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.190889\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:03,290 fedbiomed INFO - Nodes that successfully reply in round 12 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:03,366 fedbiomed INFO - breakpoint number 12 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0000/breakpoint_0012"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:03,369 fedbiomed INFO - Sampled nodes in round 13 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:03,378 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:03,378 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:04,058 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.157153\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:04,073 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.399969\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:06,720 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.796825\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:06,840 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.075972\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:10,014 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.618514\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:10,111 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.607550\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:10,459 fedbiomed INFO - Nodes that successfully reply in round 13 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:10,603 fedbiomed INFO - breakpoint number 13 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0000/breakpoint_0013"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:10,605 fedbiomed INFO - Sampled nodes in round 14 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:10,610 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:10,610 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:11,223 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.077925\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:11,350 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.306993\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:14,594 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.797756\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:14,794 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.389446\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:18,467 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.670227\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:18,526 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.569737\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:18,922 fedbiomed INFO - Nodes that successfully reply in round 14 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:14:19,061 fedbiomed INFO - breakpoint number 14 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0000/breakpoint_0014"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "15"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "exp.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Check model parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "List the training rounds :  dict_keys([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14])\n",
+      "\n",
+      "Access the federated params for the last training round :\n",
+      "\t- parameter data:  dict_keys(['conv1.bias', 'conv2.weight', 'conv2.bias', 'fc1.weight', 'fc1.bias', 'fc2.weight', 'fc2.bias'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"\\nList the training rounds : \", exp.aggregated_params().keys())\n",
+    "\n",
+    "print(\"\\nAccess the federated params for the last training round :\")\n",
+    "print(\"\\t- parameter data: \", exp.aggregated_params()[rounds - 1]['params'].keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Breakpoints"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:15:19,975 fedbiomed INFO - Experimentation reload from ../../fbm-researcher/var/experiments/Experiment_0000/breakpoint_0014 successful!"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "new_exp = Experiment.load_breakpoint('../../fbm-researcher/var/experiments/Experiment_0000/breakpoint_0014')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:15:23,310 fedbiomed INFO - Sampled nodes in round 15 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:15:23,317 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:15:23,317 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:15:23,533 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 16 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.210073\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:15:24,024 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 16 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.663331\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:15:27,002 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 16 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.269631\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:15:27,105 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 16 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.480800\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:15:30,198 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 16 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.050097\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:15:30,254 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 16 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m0.153597\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:15:30,591 fedbiomed INFO - Nodes that successfully reply in round 15 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:15:30,687 fedbiomed INFO - breakpoint number 15 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0000/breakpoint_0015"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "new_exp.run_once(increase=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test 2: with secagg and DP"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Model arguments and training arguments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "model_args = {}\n",
+    "\n",
+    "training_args = {\n",
+    "    'loader_args': { 'batch_size': 5, }, \n",
+    "    'optimizer_args': {\n",
+    "        \"lr\" : 1e-3\n",
+    "    },\n",
+    "     'dp_args': # DP Arguments for differential privacy\n",
+    "    {\n",
+    "        \"type\": \"central\", \n",
+    "        \"sigma\": 0.1, \n",
+    "        \"clip\": 0.5\n",
+    "    },\n",
+    "    'num_updates': 20,\n",
+    "    'dry_run': False\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create and run the experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:31:49,673 fedbiomed INFO - Updating training data. This action will update FederatedDataset, and the nodes that will participate to the experiment."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:31:49,739 fedbiomed INFO - Node selected for training -> Default Node Alias\n",
+       "Node ID is -> NODE_5eaa634a-8589-4251-9779-f4435535cb17"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:31:49,740 fedbiomed INFO - Node selected for training -> Default Node Alias\n",
+       "Node ID is -> NODE_523186bc-f4af-4044-a946-60003cdef368"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from fedbiomed.researcher.federated_workflows import Experiment\n",
+    "from fedbiomed.researcher.aggregators.fedavg import FedAverage\n",
+    "from fedbiomed.common.optimizers.optimizer import Optimizer\n",
+    "from fedbiomed.common.optimizers.declearn import ScaffoldServerModule\n",
+    "from fedbiomed.common.optimizers.declearn import YogiModule as FedYogi\n",
+    "\n",
+    "tags =  ['#MNIST', '#dataset']\n",
+    "rounds = 15\n",
+    "\n",
+    "exp = Experiment(tags=tags,\n",
+    "                 model_args=model_args,\n",
+    "                 training_plan_class=MyTrainingPlan,\n",
+    "                 training_args=training_args,\n",
+    "                 round_limit=rounds,\n",
+    "                 aggregator=FedAverage(),\n",
+    "                 tensorboard=True,\n",
+    "                 secagg=True,\n",
+    "                 save_breakpoints=True,\n",
+    "                 node_selection_strategy=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:31:55,021 fedbiomed INFO - Sampled nodes in round 0 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:31:55,039 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:31:55,042 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:31:56,136 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 1/20 (5%) | Samples: 8/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.946982\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:31:56,213 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 1/20 (5%) | Samples: 4/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m4.189320\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:00,757 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 10/20 (50%) | Samples: 47/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.132264\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:00,871 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 10/20 (50%) | Samples: 51/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m3.513491\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:05,554 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 20/20 (100%) | Samples: 85/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.785745\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:05,656 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 20/20 (100%) | Samples: 104/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.445643\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:05,658 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:05,685 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:06,494 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:06,536 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:06,946 fedbiomed INFO - Nodes that successfully reply in round 0 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:06,974 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:06,975 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:06,976 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:06,977 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:07,119 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:08,033 fedbiomed INFO - breakpoint number 0 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0002/breakpoint_0000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:08,041 fedbiomed INFO - Sampled nodes in round 1 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:08,044 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:08,045 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:08,481 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 1/20 (5%) | Samples: 4/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m4.591404\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:09,166 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 1/20 (5%) | Samples: 6/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m9.839849\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:13,071 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 10/20 (50%) | Samples: 46/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m4.565093\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:13,906 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 10/20 (50%) | Samples: 49/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m4.393748\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:17,043 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 20/20 (100%) | Samples: 83/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m4.316134\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:17,125 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:17,535 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 20/20 (100%) | Samples: 103/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.268322\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:17,575 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:18,125 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:18,473 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:18,902 fedbiomed INFO - Nodes that successfully reply in round 1 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:18,937 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:18,938 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:18,939 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:18,939 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:19,085 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:20,547 fedbiomed INFO - breakpoint number 1 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0002/breakpoint_0001"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:20,559 fedbiomed INFO - Sampled nodes in round 2 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:20,563 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:20,564 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:20,800 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 1/20 (5%) | Samples: 2/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m11.139568\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:21,537 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m8.078868\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:24,454 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 10/20 (50%) | Samples: 39/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m7.729427\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:26,244 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m4.782937\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:28,875 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 20/20 (100%) | Samples: 82/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m6.353437\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:28,960 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:29,228 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 20/20 (100%) | Samples: 105/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m3.163126\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:29,250 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:29,923 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:30,083 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:30,487 fedbiomed INFO - Nodes that successfully reply in round 2 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:30,520 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:30,521 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:30,522 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:30,522 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:30,662 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:32,490 fedbiomed INFO - breakpoint number 2 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0002/breakpoint_0002"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:32,499 fedbiomed INFO - Sampled nodes in round 3 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:32,503 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:32,503 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:32,760 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m7.174315\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:33,392 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 1/20 (5%) | Samples: 3/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m9.640534\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:37,030 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m7.577143\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:38,115 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 10/20 (50%) | Samples: 53/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m4.078581\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:41,610 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 20/20 (100%) | Samples: 110/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.579310\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:41,701 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:41,752 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 20/20 (100%) | Samples: 101/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m8.791676\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:41,776 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:42,575 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:42,624 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:43,072 fedbiomed INFO - Nodes that successfully reply in round 3 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:43,108 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:43,109 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:43,109 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:43,110 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:43,252 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:45,551 fedbiomed INFO - breakpoint number 3 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0002/breakpoint_0003"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:45,558 fedbiomed INFO - Sampled nodes in round 4 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:45,561 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:45,564 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:45,801 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 1/20 (5%) | Samples: 3/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m9.373511\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:46,656 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m12.507840\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:49,524 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 10/20 (50%) | Samples: 46/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m6.288833\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:50,774 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 10/20 (50%) | Samples: 54/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m8.089407\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:55,283 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 20/20 (100%) | Samples: 92/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.981925\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:55,348 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:55,387 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 20/20 (100%) | Samples: 101/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.781107\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:55,428 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:56,208 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:56,266 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:56,672 fedbiomed INFO - Nodes that successfully reply in round 4 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:56,700 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:56,701 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:56,701 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:56,702 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:56,846 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:59,572 fedbiomed INFO - breakpoint number 4 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0002/breakpoint_0004"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:59,584 fedbiomed INFO - Sampled nodes in round 5 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:59,589 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:59,589 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:32:59,855 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m10.029535\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:00,566 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 1/20 (5%) | Samples: 2/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m3.739244\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:04,296 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 10/20 (50%) | Samples: 51/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m10.094174\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:04,888 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 10/20 (50%) | Samples: 40/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.554348\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:09,799 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 20/20 (100%) | Samples: 99/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.182650\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:09,873 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:09,891 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 20/20 (100%) | Samples: 108/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m8.361096\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:09,919 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:10,725 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:10,763 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:11,214 fedbiomed INFO - Nodes that successfully reply in round 5 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:11,253 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:11,255 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:11,255 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:11,256 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:11,403 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:14,682 fedbiomed INFO - breakpoint number 5 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0002/breakpoint_0005"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:14,689 fedbiomed INFO - Sampled nodes in round 6 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:14,691 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:14,692 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:15,107 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 1/20 (5%) | Samples: 3/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m6.452803\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:15,380 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.750877\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:20,204 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 10/20 (50%) | Samples: 52/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m11.749866\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:20,472 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 10/20 (50%) | Samples: 51/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m9.393518\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:25,100 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 20/20 (100%) | Samples: 93/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.189611\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:25,162 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m6.245779\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:25,175 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:25,204 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:26,045 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:26,058 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:26,487 fedbiomed INFO - Nodes that successfully reply in round 6 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:26,522 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:26,523 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:26,524 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:26,524 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:26,672 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:30,420 fedbiomed INFO - breakpoint number 6 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0002/breakpoint_0006"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:30,426 fedbiomed INFO - Sampled nodes in round 7 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:30,429 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:30,429 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:31,294 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 1/20 (5%) | Samples: 6/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m15.847168\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:31,323 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 1/20 (5%) | Samples: 4/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.951393\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:34,923 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 10/20 (50%) | Samples: 57/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m5.015724\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:35,524 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 10/20 (50%) | Samples: 41/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m8.189636\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:39,424 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 20/20 (100%) | Samples: 105/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.750744\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:39,498 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:39,516 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 20/20 (100%) | Samples: 105/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m3.418775\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:39,553 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:40,351 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:40,398 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:40,804 fedbiomed INFO - Nodes that successfully reply in round 7 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:40,841 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:40,842 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:40,843 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:40,843 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:40,983 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:45,097 fedbiomed INFO - breakpoint number 7 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0002/breakpoint_0007"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:45,103 fedbiomed INFO - Sampled nodes in round 8 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:45,106 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:45,109 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:45,355 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 1/20 (5%) | Samples: 4/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m5.053550\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:46,008 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 1/20 (5%) | Samples: 3/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m14.507210\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:49,854 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 10/20 (50%) | Samples: 53/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.729129\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:50,092 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 10/20 (50%) | Samples: 57/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m8.331673\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:55,013 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 20/20 (100%) | Samples: 102/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.286296\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:55,074 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:55,100 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 20/20 (100%) | Samples: 111/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.653908\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:55,126 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:55,906 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:55,980 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:56,384 fedbiomed INFO - Nodes that successfully reply in round 8 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:56,412 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:56,413 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:56,414 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:56,414 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:33:56,557 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:01,112 fedbiomed INFO - breakpoint number 8 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0002/breakpoint_0008"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:01,119 fedbiomed INFO - Sampled nodes in round 9 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:01,122 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:01,123 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:01,586 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 1/20 (5%) | Samples: 4/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m4.151591\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:01,836 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 1/20 (5%) | Samples: 9/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m3.809459\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:06,278 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 10/20 (50%) | Samples: 47/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.197696\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:06,442 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 10/20 (50%) | Samples: 55/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.628880\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:10,748 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 20/20 (100%) | Samples: 93/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m3.568674\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:10,809 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:10,834 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 20/20 (100%) | Samples: 109/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.149230\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:10,859 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:11,662 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:11,695 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:12,128 fedbiomed INFO - Nodes that successfully reply in round 9 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:12,158 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:12,159 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:12,160 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:12,160 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:12,307 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:17,350 fedbiomed INFO - breakpoint number 9 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0002/breakpoint_0009"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:17,363 fedbiomed INFO - Sampled nodes in round 10 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:17,368 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:17,368 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:17,826 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 1/20 (5%) | Samples: 6/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m14.872552\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:18,192 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m18.433767\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:23,141 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 10/20 (50%) | Samples: 49/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.284816\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:23,202 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 10/20 (50%) | Samples: 51/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m5.961652\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:28,962 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 20/20 (100%) | Samples: 94/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m8.821248\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:29,058 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 20/20 (100%) | Samples: 95/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m4.029031\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:29,064 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:29,094 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:29,907 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:29,944 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:30,425 fedbiomed INFO - Nodes that successfully reply in round 10 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:30,460 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:30,461 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:30,462 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:30,462 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:30,605 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:36,126 fedbiomed INFO - breakpoint number 10 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0002/breakpoint_0010"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:36,136 fedbiomed INFO - Sampled nodes in round 11 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:36,139 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:36,140 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:36,583 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 1/20 (5%) | Samples: 1/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.142907\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:37,095 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 1/20 (5%) | Samples: 6/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.307280\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:41,114 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.271003\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:41,385 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 10/20 (50%) | Samples: 51/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m3.407359\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:46,515 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 20/20 (100%) | Samples: 105/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m4.437827\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:46,594 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:46,595 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 20/20 (100%) | Samples: 97/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.238382\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:46,616 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:47,445 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:47,458 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:47,887 fedbiomed INFO - Nodes that successfully reply in round 11 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:47,924 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:47,925 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:47,925 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:47,926 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:48,066 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:54,099 fedbiomed INFO - breakpoint number 11 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0002/breakpoint_0011"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:54,112 fedbiomed INFO - Sampled nodes in round 12 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:54,116 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:54,116 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:54,902 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 1/20 (5%) | Samples: 4/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m7.517583\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:55,312 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 1/20 (5%) | Samples: 4/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m47.457626\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:58,049 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 10/20 (50%) | Samples: 40/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m6.703267\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:34:59,460 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 10/20 (50%) | Samples: 58/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.170833\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:03,039 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 20/20 (100%) | Samples: 91/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m26.219484\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:03,108 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:03,164 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 20/20 (100%) | Samples: 110/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m4.235670\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:03,190 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:03,956 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:04,020 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:04,448 fedbiomed INFO - Nodes that successfully reply in round 12 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:04,475 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:04,476 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:04,477 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:04,477 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:04,619 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:11,164 fedbiomed INFO - breakpoint number 12 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0002/breakpoint_0012"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:11,175 fedbiomed INFO - Sampled nodes in round 13 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:11,178 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:11,179 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:11,438 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m11.385376\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:12,311 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 1/20 (5%) | Samples: 4/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.497798\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:15,773 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 10/20 (50%) | Samples: 52/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.286030\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:16,581 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 10/20 (50%) | Samples: 45/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.183292\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:21,088 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 20/20 (100%) | Samples: 98/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m5.102459\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:21,201 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:21,206 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 20/20 (100%) | Samples: 91/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.282042\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:21,242 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:22,052 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:22,092 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:22,519 fedbiomed INFO - Nodes that successfully reply in round 13 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:22,548 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:22,549 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:22,550 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:22,550 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:22,694 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:29,771 fedbiomed INFO - breakpoint number 13 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0002/breakpoint_0013"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:29,783 fedbiomed INFO - Sampled nodes in round 14 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:29,786 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:29,787 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:30,166 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.365886\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:30,665 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 1/20 (5%) | Samples: 3/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.174441\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:35,055 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 10/20 (50%) | Samples: 49/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m4.954432\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:35,609 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 10/20 (50%) | Samples: 46/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.635596\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:39,855 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 20/20 (100%) | Samples: 101/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.684930\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:39,895 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:39,922 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 20/20 (100%) | Samples: 85/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.020058\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:39,960 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:40,727 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:40,785 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:41,202 fedbiomed INFO - Nodes that successfully reply in round 14 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:41,240 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:41,241 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:41,242 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:41,242 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:41,391 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:35:48,896 fedbiomed INFO - breakpoint number 14 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0002/breakpoint_0014"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "15"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "exp.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Check model parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "List the training rounds :  dict_keys([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14])\n",
+      "\n",
+      "Access the federated params for the last training round :\n",
+      "\t- parameter data:  dict_keys(['conv1.bias', 'conv2.weight', 'conv2.bias', 'fc1.weight', 'fc1.bias', 'fc2.weight', 'fc2.bias'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"\\nList the training rounds : \", exp.aggregated_params().keys())\n",
+    "\n",
+    "print(\"\\nAccess the federated params for the last training round :\")\n",
+    "print(\"\\t- parameter data: \", exp.aggregated_params()[rounds - 1]['params'].keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test 3: with Scaffold"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define an experiment model and parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Declare a torch training plan MyTrainingPlan class to send for training on the node"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.functional as F\n",
+    "from torch.optim import Adam\n",
+    "from torchvision import  transforms\n",
+    "\n",
+    "from fedbiomed.common.training_plans import TorchTrainingPlan\n",
+    "from fedbiomed.common.datamanager import DataManager\n",
+    "from fedbiomed.common.optimizers.optimizer import Optimizer\n",
+    "from fedbiomed.common.optimizers.declearn import ScaffoldClientModule\n",
+    "from fedbiomed.common.dataset import MnistDataset\n",
+    "\n",
+    "\n",
+    "# Here we define the training plan to be used.\n",
+    "# You can use any class name (here 'MyTrainingPlan')\n",
+    "class MyTrainingPlan2(TorchTrainingPlan):\n",
+    "\n",
+    "    def init_dependencies(self):\n",
+    "        return [\"from torchvision import transforms\",\n",
+    "                \"from fedbiomed.common.dataset import MnistDataset\",\n",
+    "                \"from fedbiomed.common.optimizers.optimizer import Optimizer\",\n",
+    "                \"from fedbiomed.common.optimizers.declearn import ScaffoldClientModule\",\n",
+    "                \"from fedbiomed.common.optimizers.declearn import AdamModule\",\n",
+    "                \"from fedbiomed.common.optimizers.declearn import RidgeRegularizer\",\n",
+    "                \"from torch.optim import Adam\"]\n",
+    "        \n",
+    "    class Net(nn.Module):\n",
+    "        def __init__(self, model_args):\n",
+    "            super().__init__()\n",
+    "            self.conv1 = nn.Conv2d(1, 32, 3, 1)\n",
+    "            self.conv2 = nn.Conv2d(32, 64, 3, 1)\n",
+    "            self.dropout1 = nn.Dropout(0.25)\n",
+    "            self.dropout2 = nn.Dropout(0.5)\n",
+    "            self.fc1 = nn.Linear(9216, 128)\n",
+    "            self.fc2 = nn.Linear(128, 10)\n",
+    "\n",
+    "        def forward(self, x):\n",
+    "            x = self.conv1(x)\n",
+    "            x = F.relu(x)\n",
+    "            x = self.conv2(x)\n",
+    "            x = F.relu(x)\n",
+    "            x = F.max_pool2d(x, 2)\n",
+    "            x = self.dropout1(x)\n",
+    "            x = torch.flatten(x, 1)\n",
+    "            x = self.fc1(x)\n",
+    "            x = F.relu(x)\n",
+    "            x = self.dropout2(x)\n",
+    "            x = self.fc2(x)\n",
+    "            output = F.log_softmax(x, dim=1)\n",
+    "            return output\n",
+    "\n",
+    "    def init_model(self, model_args):\n",
+    "        model = self.Net(model_args = model_args)\n",
+    "        return model\n",
+    "        \n",
+    "    def init_optimizer(self, optimizer_args):\n",
+    "       # Defines and return a declearn optimizer\n",
+    "        return Optimizer(lr=optimizer_args['lr'], modules=[ScaffoldClientModule()])\n",
+    "\n",
+    "    def training_data(self):\n",
+    "        transform = transforms.Normalize((0.1307,), (0.3081,))\n",
+    "        loader_arguments = { 'shuffle': True}\n",
+    "        \n",
+    "        dataset = MnistDataset(transform=transform)\n",
+    "        return DataManager(dataset, **loader_arguments)\n",
+    "\n",
+    "    def training_step(self, data, target):\n",
+    "        output = self.model().forward(data)\n",
+    "        loss   = torch.nn.functional.nll_loss(output, target)\n",
+    "        return loss\n",
+    "\n",
+    "    def tag_parameters(self, name):\n",
+    "        if name == 'conv1.weight':\n",
+    "            return {'local', 'persistent'}\n",
+    "        if name == 'conv2.bias':\n",
+    "            return {'persistent'}\n",
+    "        return set()\n",
+    "            "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Model arguments and training arguments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "model_args = {}\n",
+    "\n",
+    "training_args = {\n",
+    "    'loader_args': { 'batch_size': 5, }, \n",
+    "    'optimizer_args': {\n",
+    "        \"lr\" : 1e-3\n",
+    "    },\n",
+    "    'num_updates': 20,\n",
+    "    'dry_run': False\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create and run the experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:39:55,122 fedbiomed INFO - Updating training data. This action will update FederatedDataset, and the nodes that will participate to the experiment."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:39:55,180 fedbiomed INFO - Node selected for training -> Default Node Alias\n",
+       "Node ID is -> NODE_5eaa634a-8589-4251-9779-f4435535cb17"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:39:55,181 fedbiomed INFO - Node selected for training -> Default Node Alias\n",
+       "Node ID is -> NODE_523186bc-f4af-4044-a946-60003cdef368"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:39:55,191 fedbiomed WARNING - Using Declearn optimizers for aggregation and parameters tagged as local may lead to unexpected behaviours."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<fedbiomed.common.optimizers.optimizer.Optimizer at 0x7f2e10c7efe0>"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from fedbiomed.researcher.federated_workflows import Experiment\n",
+    "from fedbiomed.researcher.aggregators.fedavg import FedAverage\n",
+    "from fedbiomed.common.optimizers.optimizer import Optimizer\n",
+    "from fedbiomed.common.optimizers.declearn import ScaffoldServerModule\n",
+    "from fedbiomed.common.optimizers.declearn import YogiModule as FedYogi\n",
+    "\n",
+    "tags =  ['#MNIST', '#dataset']\n",
+    "rounds = 15\n",
+    "\n",
+    "exp = Experiment(tags=tags,\n",
+    "                 model_args=model_args,\n",
+    "                 training_plan_class=MyTrainingPlan2,\n",
+    "                 training_args=training_args,\n",
+    "                 round_limit=rounds,\n",
+    "                 aggregator=FedAverage(),\n",
+    "                 tensorboard=True,\n",
+    "                 save_breakpoints=True,\n",
+    "                 node_selection_strategy=None)\n",
+    "\n",
+    "fed_opt = Optimizer(lr=.8, modules=[ScaffoldServerModule()])\n",
+    "exp.set_agg_optimizer(fed_opt)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:00,381 fedbiomed INFO - Sampled nodes in round 0 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:00,388 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:00,389 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:00,818 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.271706\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:01,168 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.386757\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:03,795 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.292940\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:04,647 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.350819\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:07,333 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.303742\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:07,646 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.330307\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:07,978 fedbiomed INFO - Nodes that successfully reply in round 0 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:08,016 fedbiomed INFO - breakpoint number 0 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0003/breakpoint_0000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:08,055 fedbiomed INFO - Sampled nodes in round 1 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:08,058 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:08,059 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:08,230 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.281565\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:08,827 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.370930\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:11,050 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.281826\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:11,694 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.227797\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:14,558 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.229133\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:14,647 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.365390\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:14,975 fedbiomed INFO - Nodes that successfully reply in round 1 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:15,016 fedbiomed INFO - breakpoint number 1 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0003/breakpoint_0001"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:15,021 fedbiomed INFO - Sampled nodes in round 2 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:15,026 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:15,027 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:15,482 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.313214\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:15,739 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.289869\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:18,440 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.348841\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:18,930 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.294432\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:21,156 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.328807\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:21,285 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.275738\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:21,613 fedbiomed INFO - Nodes that successfully reply in round 2 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:21,658 fedbiomed INFO - breakpoint number 2 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0003/breakpoint_0002"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:21,664 fedbiomed INFO - Sampled nodes in round 3 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:21,672 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:21,674 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:22,398 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.301867\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:22,475 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.247364\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:24,919 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.286952\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:25,130 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.271262\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:27,887 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.259420\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:28,044 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.237752\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:28,351 fedbiomed INFO - Nodes that successfully reply in round 3 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:28,412 fedbiomed INFO - breakpoint number 3 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0003/breakpoint_0003"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:28,418 fedbiomed INFO - Sampled nodes in round 4 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:28,426 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:28,427 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:28,743 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.221801\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:29,362 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.312662\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:31,884 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.290823\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:32,311 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.286154\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:35,510 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.295023\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:35,595 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.318325\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:35,916 fedbiomed INFO - Nodes that successfully reply in round 4 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:36,024 fedbiomed INFO - breakpoint number 4 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0003/breakpoint_0004"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:36,028 fedbiomed INFO - Sampled nodes in round 5 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:36,032 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:36,032 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:36,223 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.233889\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:36,714 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.191432\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:39,294 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.333257\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:39,597 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.236648\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:42,201 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.244261\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:42,278 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.214757\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:42,600 fedbiomed INFO - Nodes that successfully reply in round 5 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:42,690 fedbiomed INFO - breakpoint number 5 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0003/breakpoint_0005"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:42,693 fedbiomed INFO - Sampled nodes in round 6 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:42,702 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:42,708 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:42,993 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.287648\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:43,497 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.282122\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:45,971 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.302920\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:46,461 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.245866\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:49,498 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.297717\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:49,619 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.265600\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:49,929 fedbiomed INFO - Nodes that successfully reply in round 6 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:50,104 fedbiomed INFO - breakpoint number 6 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0003/breakpoint_0006"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:50,108 fedbiomed INFO - Sampled nodes in round 7 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:50,115 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:50,116 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:50,907 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.237111\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:51,030 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.267737\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:53,923 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.305399\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:54,752 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.188151\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:58,056 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.343123\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:58,105 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.181131\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:58,418 fedbiomed INFO - Nodes that successfully reply in round 7 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:58,505 fedbiomed INFO - breakpoint number 7 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0003/breakpoint_0007"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:58,508 fedbiomed INFO - Sampled nodes in round 8 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:58,512 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:58,515 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:59,009 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.149097\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:40:59,248 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.099417\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:01,714 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.242131\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:02,153 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.172521\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:04,926 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.234603\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:05,031 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.152666\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:05,405 fedbiomed INFO - Nodes that successfully reply in round 8 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:05,494 fedbiomed INFO - breakpoint number 8 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0003/breakpoint_0008"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:05,496 fedbiomed INFO - Sampled nodes in round 9 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:05,501 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:05,501 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:06,186 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.250857\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:06,364 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.225173\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:08,558 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.242038\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:09,634 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.341325\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:11,982 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.180161\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:12,100 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.159455\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:12,440 fedbiomed INFO - Nodes that successfully reply in round 9 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:12,533 fedbiomed INFO - breakpoint number 9 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0003/breakpoint_0009"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:12,535 fedbiomed INFO - Sampled nodes in round 10 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:12,538 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:12,539 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:12,727 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.191864\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:13,198 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.111774\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:15,905 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.392036\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:16,015 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.156868\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:19,249 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.234178\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:19,297 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.127061\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:19,692 fedbiomed INFO - Nodes that successfully reply in round 10 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:19,835 fedbiomed INFO - breakpoint number 10 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0003/breakpoint_0010"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:19,838 fedbiomed INFO - Sampled nodes in round 11 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:19,842 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:19,843 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:20,415 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.277319\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:20,551 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.005399\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:23,549 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.150963\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:23,634 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.285806\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:26,923 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.081238\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:26,998 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.137939\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:27,338 fedbiomed INFO - Nodes that successfully reply in round 11 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:27,427 fedbiomed INFO - breakpoint number 11 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0003/breakpoint_0011"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:27,431 fedbiomed INFO - Sampled nodes in round 12 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:27,440 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:27,441 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:27,998 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.264563\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:28,291 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.148181\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:30,768 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.241730\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:31,332 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.326847\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:33,889 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.194232\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:34,007 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.031365\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:34,337 fedbiomed INFO - Nodes that successfully reply in round 12 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:34,447 fedbiomed INFO - breakpoint number 12 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0003/breakpoint_0012"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:34,453 fedbiomed INFO - Sampled nodes in round 13 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:34,456 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:34,457 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:34,732 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.124322\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:35,034 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.050338\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:36,934 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.083464\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:38,097 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.117891\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:40,540 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.308166\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:40,664 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.995807\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:41,000 fedbiomed INFO - Nodes that successfully reply in round 13 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:41,104 fedbiomed INFO - breakpoint number 13 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0003/breakpoint_0013"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:41,107 fedbiomed INFO - Sampled nodes in round 14 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:41,110 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:41,111 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:41,588 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.108913\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:41,988 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.213758\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:44,672 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.249300\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:44,982 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.101269\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:47,822 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.196840\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:48,011 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.756389\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:48,317 fedbiomed INFO - Nodes that successfully reply in round 14 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:41:48,425 fedbiomed INFO - breakpoint number 14 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0003/breakpoint_0014"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "15"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "exp.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Check model parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "List the training rounds :  dict_keys([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14])\n",
+      "\n",
+      "Access the federated params for the last training round :\n",
+      "\t- parameter data:  dict_keys(['conv1.bias', 'conv2.weight', 'conv2.bias', 'fc1.weight', 'fc1.bias', 'fc2.weight', 'fc2.bias'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"\\nList the training rounds : \", exp.aggregated_params().keys())\n",
+    "\n",
+    "print(\"\\nAccess the federated params for the last training round :\")\n",
+    "print(\"\\t- parameter data: \", exp.aggregated_params()[rounds - 1]['params'].keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test 4: with Declearn optimizers and secagg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define an experiment model and parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Declare a torch training plan MyTrainingPlan class to send for training on the node"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.functional as F\n",
+    "from torch.optim import Adam\n",
+    "from torchvision import  transforms\n",
+    "\n",
+    "from fedbiomed.common.training_plans import TorchTrainingPlan\n",
+    "from fedbiomed.common.datamanager import DataManager\n",
+    "from fedbiomed.common.optimizers.optimizer import Optimizer\n",
+    "from fedbiomed.common.optimizers.declearn import ScaffoldClientModule\n",
+    "from fedbiomed.common.dataset import MnistDataset\n",
+    "\n",
+    "\n",
+    "# Here we define the training plan to be used.\n",
+    "# You can use any class name (here 'MyTrainingPlan')\n",
+    "class MyTrainingPlan3(TorchTrainingPlan):\n",
+    "\n",
+    "    def init_dependencies(self):\n",
+    "        return [\"from torchvision import transforms\",\n",
+    "                \"from fedbiomed.common.dataset import MnistDataset\",\n",
+    "                \"from fedbiomed.common.optimizers.optimizer import Optimizer\",\n",
+    "                \"from fedbiomed.common.optimizers.declearn import ScaffoldClientModule\",\n",
+    "                \"from fedbiomed.common.optimizers.declearn import AdamModule\",\n",
+    "                \"from fedbiomed.common.optimizers.declearn import RidgeRegularizer\",\n",
+    "                \"from torch.optim import Adam\"]\n",
+    "        \n",
+    "    class Net(nn.Module):\n",
+    "        def __init__(self, model_args):\n",
+    "            super().__init__()\n",
+    "            self.conv1 = nn.Conv2d(1, 32, 3, 1)\n",
+    "            self.conv2 = nn.Conv2d(32, 64, 3, 1)\n",
+    "            self.dropout1 = nn.Dropout(0.25)\n",
+    "            self.dropout2 = nn.Dropout(0.5)\n",
+    "            self.fc1 = nn.Linear(9216, 128)\n",
+    "            self.fc2 = nn.Linear(128, 10)\n",
+    "\n",
+    "        def forward(self, x):\n",
+    "            x = self.conv1(x)\n",
+    "            x = F.relu(x)\n",
+    "            x = self.conv2(x)\n",
+    "            x = F.relu(x)\n",
+    "            x = F.max_pool2d(x, 2)\n",
+    "            x = self.dropout1(x)\n",
+    "            x = torch.flatten(x, 1)\n",
+    "            x = self.fc1(x)\n",
+    "            x = F.relu(x)\n",
+    "            x = self.dropout2(x)\n",
+    "            x = self.fc2(x)\n",
+    "            output = F.log_softmax(x, dim=1)\n",
+    "            return output\n",
+    "\n",
+    "    def init_model(self, model_args):\n",
+    "        model = self.Net(model_args = model_args)\n",
+    "        return model\n",
+    "\n",
+    "    def init_optimizer(self, optimizer_args):\n",
+    "        # Defines and return a declearn optimizer\n",
+    "        return Optimizer(lr=optimizer_args['lr'], modules=[AdamModule()], regularizers=[RidgeRegularizer()])\n",
+    "\n",
+    "    def training_data(self):\n",
+    "        transform = transforms.Normalize((0.1307,), (0.3081,))\n",
+    "        loader_arguments = { 'shuffle': True}\n",
+    "        \n",
+    "        dataset = MnistDataset(transform=transform)\n",
+    "        return DataManager(dataset, **loader_arguments)\n",
+    "\n",
+    "    def training_step(self, data, target):\n",
+    "        output = self.model().forward(data)\n",
+    "        loss   = torch.nn.functional.nll_loss(output, target)\n",
+    "        return loss\n",
+    "\n",
+    "    def tag_parameters(self, name):\n",
+    "        if name == 'conv1.weight':\n",
+    "            return {'local', 'persistent'}\n",
+    "        if name == 'conv2.bias':\n",
+    "            return {'persistent'}\n",
+    "        return set()\n",
+    "            "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Model arguments and training arguments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "model_args = {}\n",
+    "\n",
+    "training_args = {\n",
+    "    'loader_args': { 'batch_size': 5, }, \n",
+    "    'optimizer_args': {\n",
+    "        \"lr\" : 1e-3\n",
+    "    },\n",
+    "    'num_updates': 20,\n",
+    "    'dry_run': False\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create and run the experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:25,081 fedbiomed INFO - Updating training data. This action will update FederatedDataset, and the nodes that will participate to the experiment."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:25,144 fedbiomed INFO - Node selected for training -> Default Node Alias\n",
+       "Node ID is -> NODE_5eaa634a-8589-4251-9779-f4435535cb17"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:25,145 fedbiomed INFO - Node selected for training -> Default Node Alias\n",
+       "Node ID is -> NODE_523186bc-f4af-4044-a946-60003cdef368"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:25,154 fedbiomed WARNING - Using Declearn optimizers for aggregation and parameters tagged as local may lead to unexpected behaviours."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<fedbiomed.common.optimizers.optimizer.Optimizer at 0x7f2ce7e95a20>"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from fedbiomed.researcher.federated_workflows import Experiment\n",
+    "from fedbiomed.researcher.aggregators.fedavg import FedAverage\n",
+    "from fedbiomed.common.optimizers.optimizer import Optimizer\n",
+    "from fedbiomed.common.optimizers.declearn import ScaffoldServerModule\n",
+    "from fedbiomed.common.optimizers.declearn import YogiModule as FedYogi\n",
+    "\n",
+    "tags =  ['#MNIST', '#dataset']\n",
+    "rounds = 15\n",
+    "\n",
+    "exp = Experiment(tags=tags,\n",
+    "                 model_args=model_args,\n",
+    "                 training_plan_class=MyTrainingPlan3,\n",
+    "                 training_args=training_args,\n",
+    "                 round_limit=rounds,\n",
+    "                 aggregator=FedAverage(),\n",
+    "                 tensorboard=True,\n",
+    "                 secagg=True,\n",
+    "                 save_breakpoints=True,\n",
+    "                 node_selection_strategy=None)\n",
+    "\n",
+    "fed_opt = Optimizer(lr=.8, modules=[FedYogi()])\n",
+    "exp.set_agg_optimizer(fed_opt)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:30,888 fedbiomed INFO - Sampled nodes in round 0 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:30,899 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:30,900 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:31,682 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.241786\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:31,816 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.292182\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:35,055 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.233998\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:35,472 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.355601\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:39,242 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1.872367\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:39,315 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:39,323 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.252957\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:39,364 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:40,140 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:40,185 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:40,610 fedbiomed INFO - Nodes that successfully reply in round 0 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:40,637 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:40,638 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:40,639 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:40,639 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:40,780 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:41,813 fedbiomed INFO - breakpoint number 0 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0004/breakpoint_0000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:41,816 fedbiomed INFO - Sampled nodes in round 1 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:41,820 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:41,820 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:42,556 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m12777.620117\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:42,751 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m11326.688477\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:45,874 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m8152.708008\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:45,922 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m9663.069336\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:50,421 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m4912.392090\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:50,478 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m8851.955078\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:50,490 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:50,502 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:51,345 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:51,353 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:51,852 fedbiomed INFO - Nodes that successfully reply in round 1 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:51,880 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:51,881 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:51,881 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:51,882 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:52,022 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:53,385 fedbiomed INFO - breakpoint number 1 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0004/breakpoint_0001"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:53,387 fedbiomed INFO - Sampled nodes in round 2 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:53,390 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:53,391 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:53,940 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m508.527832\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:53,951 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m552.035767\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:56,962 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m468.920990\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:45:57,314 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m313.388000\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:00,699 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m316.799530\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:00,767 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:00,814 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m184.164978\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:00,857 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:01,625 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:01,688 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:02,163 fedbiomed INFO - Nodes that successfully reply in round 2 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:02,189 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:02,190 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:02,190 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:02,191 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:02,334 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:04,123 fedbiomed INFO - breakpoint number 2 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0004/breakpoint_0002"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:04,125 fedbiomed INFO - Sampled nodes in round 3 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:04,128 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:04,129 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:04,745 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m20942.681641\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:04,935 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m9530.130859\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:08,550 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m5504.498535\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:08,858 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m8088.195312\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:13,049 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m4839.759277\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:13,065 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:13,087 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m3023.795898\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:13,110 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:13,908 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:13,947 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:14,367 fedbiomed INFO - Nodes that successfully reply in round 3 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:14,393 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:14,394 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:14,395 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:14,395 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:14,535 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:16,782 fedbiomed INFO - breakpoint number 3 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0004/breakpoint_0003"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:16,784 fedbiomed INFO - Sampled nodes in round 4 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:16,789 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:16,789 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:17,287 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m59524.550781\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:17,486 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m20015.138672\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:21,340 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m28860.375000\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:21,580 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m19851.578125\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:25,059 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m22530.494141\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:25,130 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:25,158 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m41285.726562\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:25,174 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:25,970 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:26,014 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:26,444 fedbiomed INFO - Nodes that successfully reply in round 4 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:26,470 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:26,471 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:26,471 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:26,472 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:26,651 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:29,357 fedbiomed INFO - breakpoint number 4 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0004/breakpoint_0004"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:29,360 fedbiomed INFO - Sampled nodes in round 5 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:29,363 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:29,364 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:30,079 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m10075.666016\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:30,151 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m22054.148438\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:34,420 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m33435.406250\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:35,012 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m26541.181641\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:38,224 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m34059.335938\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:38,309 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:38,329 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m15416.492188\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:38,347 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:39,194 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:39,195 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:39,677 fedbiomed INFO - Nodes that successfully reply in round 5 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:39,706 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:39,707 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:39,708 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:39,709 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:39,854 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:42,997 fedbiomed INFO - breakpoint number 5 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0004/breakpoint_0005"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:43,000 fedbiomed INFO - Sampled nodes in round 6 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:43,003 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:43,005 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:43,244 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m5671.166504\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:44,010 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m4235.018555\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:47,022 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m5430.576172\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:48,055 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2378.247314\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:51,292 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m686.804993\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:51,358 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:51,367 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m5224.528809\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:51,391 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:52,163 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:52,188 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:52,622 fedbiomed INFO - Nodes that successfully reply in round 6 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:52,654 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:52,655 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:52,656 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:52,657 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:52,802 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:56,436 fedbiomed INFO - breakpoint number 6 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0004/breakpoint_0006"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:56,438 fedbiomed INFO - Sampled nodes in round 7 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:56,441 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:56,441 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:57,123 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m415.100189\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:46:57,170 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m1119.540894\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:01,291 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m423.152161\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:01,427 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m573.698425\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:05,111 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m104.386169\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:05,144 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:05,148 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m610.205750\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:05,168 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:05,995 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:06,013 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:06,451 fedbiomed INFO - Nodes that successfully reply in round 7 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:06,485 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:06,486 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:06,487 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:06,488 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:06,632 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:10,615 fedbiomed INFO - breakpoint number 7 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0004/breakpoint_0007"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:10,617 fedbiomed INFO - Sampled nodes in round 8 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:10,621 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:10,622 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:11,439 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m6.662345\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:11,470 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m162.489304\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:15,262 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m12.760236\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:15,718 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m91.338875\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:19,334 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m20.409954\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:19,388 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:19,399 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m45.479820\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:19,430 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:20,216 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:20,245 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:20,741 fedbiomed INFO - Nodes that successfully reply in round 8 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:20,769 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:20,770 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:20,770 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:20,771 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:20,913 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:25,440 fedbiomed INFO - breakpoint number 8 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0004/breakpoint_0008"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:25,443 fedbiomed INFO - Sampled nodes in round 9 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:25,447 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:25,448 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:25,902 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m25.250683\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:26,300 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m46.186298\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:30,105 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m21.814922\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:30,232 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m12.761660\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:33,533 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m12.303709\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:33,572 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:33,574 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m37.808449\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:33,604 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:34,441 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:34,445 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:34,960 fedbiomed INFO - Nodes that successfully reply in round 9 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:34,997 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:34,998 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:34,998 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:35,000 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:35,142 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:40,010 fedbiomed INFO - breakpoint number 9 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0004/breakpoint_0009"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:40,012 fedbiomed INFO - Sampled nodes in round 10 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:40,016 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:40,016 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:40,284 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m9.732363\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:40,715 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m8.229604\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:43,455 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m6.100736\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:44,333 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m8.788065\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:47,156 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m9.505475\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:47,222 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:47,355 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m7.815547\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:47,373 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:48,053 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:48,204 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:48,637 fedbiomed INFO - Nodes that successfully reply in round 10 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:48,672 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:48,673 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:48,674 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:48,674 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:48,821 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:54,192 fedbiomed INFO - breakpoint number 10 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0004/breakpoint_0010"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:54,194 fedbiomed INFO - Sampled nodes in round 11 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:54,197 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:54,198 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:54,487 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m5.095644\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:55,095 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m6.516891\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:57,821 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m6.454534\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:47:58,523 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m2.960518\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:02,002 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m7.611038\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:02,071 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:02,077 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m6.991339\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:02,106 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:02,962 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:02,968 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:03,461 fedbiomed INFO - Nodes that successfully reply in round 11 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:03,497 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:03,498 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:03,499 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:03,499 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:03,641 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:09,534 fedbiomed INFO - breakpoint number 11 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0004/breakpoint_0011"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:09,537 fedbiomed INFO - Sampled nodes in round 12 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:09,545 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:09,550 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:09,991 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m3.160778\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:10,078 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m5.868433\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:14,417 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m3.911711\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:14,568 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m5.396675\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:18,180 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m4.690047\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:18,237 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:18,245 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m5.945895\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:18,265 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:19,041 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:19,110 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:19,579 fedbiomed INFO - Nodes that successfully reply in round 12 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:19,614 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:19,616 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:19,617 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:19,617 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:19,760 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:26,111 fedbiomed INFO - breakpoint number 12 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0004/breakpoint_0012"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:26,115 fedbiomed INFO - Sampled nodes in round 13 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:26,118 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:26,119 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:26,348 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m5.451568\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:26,935 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m6.148293\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:30,044 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m5.273780\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:30,719 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m5.251956\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:34,177 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m3.705738\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:34,255 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:34,263 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m4.008670\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:34,288 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:35,105 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:35,144 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:35,561 fedbiomed INFO - Nodes that successfully reply in round 13 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:35,589 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:35,590 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:35,591 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:35,592 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:35,757 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:42,414 fedbiomed INFO - breakpoint number 13 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0004/breakpoint_0013"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:42,416 fedbiomed INFO - Sampled nodes in round 14 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:42,418 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:42,419 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:42,668 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m4.375505\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:43,478 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m3.193473\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:46,566 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m3.860252\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:47,915 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m3.907615\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:50,643 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m3.576222\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:50,713 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:50,755 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss: \u001b[1m3.486454\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:50,778 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encrypting model parameters.This process can take some time depending on model size.\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:51,539 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_523186bc-f4af-4044-a946-60003cdef368\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:51,604 fedbiomed INFO - \u001b[1mINFO\u001b[0m\n",
+       "\t\t\t\t\t\u001b[1m NODE\u001b[0m NODE_5eaa634a-8589-4251-9779-f4435535cb17\n",
+       "\t\t\t\t\t\u001b[1m MESSAGE:\u001b[0m Encryption was completed!\u001b[0m\n",
+       "-----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:52,039 fedbiomed INFO - Nodes that successfully reply in round 14 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:52,069 fedbiomed INFO - Validating secure aggregation results..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:52,070 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:52,071 fedbiomed INFO - Validation is completed."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:52,072 fedbiomed INFO - Aggregating encrypted parameters. This process may take some time dependingon model size."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:52,221 fedbiomed INFO - Aggregating 2 parameters from 2 nodes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 17:48:59,411 fedbiomed INFO - breakpoint number 14 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0004/breakpoint_0014"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "15"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "exp.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Check model parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "List the training rounds :  dict_keys([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14])\n",
+      "\n",
+      "Access the federated params for the last training round :\n",
+      "\t- parameter data:  dict_keys(['conv1.bias', 'conv2.weight', 'conv2.bias', 'fc1.weight', 'fc1.bias', 'fc2.weight', 'fc2.bias'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"\\nList the training rounds : \", exp.aggregated_params().keys())\n",
+    "\n",
+    "print(\"\\nAccess the federated params for the last training round :\")\n",
+    "print(\"\\t- parameter data: \", exp.aggregated_params()[rounds - 1]['params'].keys())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/sklearn-tag-parameters.ipynb
+++ b/notebooks/sklearn-tag-parameters.ipynb
@@ -1,0 +1,2521 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "217752eb",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# Node specific parameters with Sklearn training plan\n",
+    "\n",
+    "The goal of this notebook is to test tag_parameters functionality with sklearn training plan.\n",
+    "\n",
+    "This example uses MNIST dataset. Please check `README.md` file in `notebooks` directory for the instructions to load MNIST dataset and configure nodes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb09b8af",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# Test 1: simple experiment with breakpoints"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60707430-4530-482b-aa91-b56b43b538b6",
+   "metadata": {},
+   "source": [
+    "## Define an experiment model and parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "fb84ea0d",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from fedbiomed.common.training_plans import FedPerceptron\n",
+    "from fedbiomed.common.datamanager import DataManager\n",
+    "from fedbiomed.common.dataset import MnistDataset\n",
+    "\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import FunctionTransformer\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "class SkLearnClassifierTrainingPlan(FedPerceptron):\n",
+    "    def init_dependencies(self):\n",
+    "        \"\"\"Define additional dependencies.\"\"\"\n",
+    "        return [\"from sklearn.pipeline import Pipeline\",\n",
+    "                \"from sklearn.preprocessing import FunctionTransformer\",\n",
+    "                \"from fedbiomed.common.dataset import MnistDataset\",\n",
+    "                \"import numpy as np\"]\n",
+    "                \n",
+    "    def training_data(self):\n",
+    "        \"\"\"Prepare data for training.\n",
+    "        \n",
+    "        This function loads a MNIST dataset from the node's filesystem, applies some\n",
+    "        preprocessing and converts the full dataset to a numpy array. \n",
+    "        Finally, it returns a DataManager created with these numpy arrays.\n",
+    "        \"\"\"\n",
+    "\n",
+    "        pipeline = Pipeline([\n",
+    "                (\"norm\", FunctionTransformer(\n",
+    "                    lambda im: (np.asarray(im, dtype=np.float64) / 255.0 - 0.1307) / 0.3081,\n",
+    "                    validate=False\n",
+    "                )),\n",
+    "                (\"flatten\", FunctionTransformer(\n",
+    "                    lambda x: np.ascontiguousarray(x.reshape(-1), dtype=np.float64),\n",
+    "                    validate=False\n",
+    "                )),\n",
+    "            ])\n",
+    "\n",
+    "        dataset = MnistDataset(transform=pipeline.transform)\n",
+    "        \n",
+    "        return DataManager(dataset=dataset, shuffle=True)\n",
+    "\n",
+    "    def tag_parameters(self, name):\n",
+    "        if name == 'intercept_':\n",
+    "            return {'local', 'persistent'}\n",
+    "        return set()\n",
+    "\n",
+    "    \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5893072c-34cd-441b-a674-9fa4658817ef",
+   "metadata": {},
+   "source": [
+    "### Model arguments and training arguments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "08d7bed8",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "model_args = {'n_features': 28*28,\n",
+    "              'n_classes' : 10,\n",
+    "              'eta0': 1e-6,\n",
+    "              'learning_rate':'constant',\n",
+    "              'alpha':0.1 \n",
+    "              }\n",
+    "\n",
+    "training_args = {\n",
+    "    'num_updates': 20, \n",
+    "    'loader_args': {\n",
+    "        'batch_size': 5,\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f8bc423",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "### Create and run the experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "8c54acbb",
+   "metadata": {
+    "pycharm": {
+     "is_executing": true,
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:26,505 fedbiomed INFO - Updating training data. This action will update FederatedDataset, and the nodes that will participate to the experiment."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:26,563 fedbiomed INFO - Node selected for training -> Default Node Alias\n",
+       "Node ID is -> NODE_5eaa634a-8589-4251-9779-f4435535cb17"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:26,564 fedbiomed INFO - Node selected for training -> Default Node Alias\n",
+       "Node ID is -> NODE_523186bc-f4af-4044-a946-60003cdef368"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:26,567 fedbiomed WARNING - Option share_persistent_buffers is not supported in SKLearnTrainingPlan, it will be ignored."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from fedbiomed.researcher.federated_workflows import Experiment\n",
+    "from fedbiomed.researcher.aggregators.fedavg import FedAverage\n",
+    "\n",
+    "tags =  ['#MNIST', '#dataset']\n",
+    "rounds = 15\n",
+    "\n",
+    "# select nodes participating in this experiment\n",
+    "exp = Experiment(tags=tags,\n",
+    "                 model_args=model_args,\n",
+    "                 training_plan_class=SkLearnClassifierTrainingPlan,\n",
+    "                 training_args=training_args,\n",
+    "                 round_limit=rounds,\n",
+    "                 save_breakpoints = True,\n",
+    "                 aggregator=FedAverage(),\n",
+    "                 node_selection_strategy=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "df22732e",
+   "metadata": {
+    "pycharm": {
+     "is_executing": true,
+     "name": "#%%\n"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:27,794 fedbiomed INFO - Sampled nodes in round 0 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:27,799 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:27,801 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:27,875 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000000\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:27,892 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000000\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:27,998 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000007\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:27,999 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000002\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:28,114 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000014\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:28,115 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 1 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000003\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:28,380 fedbiomed INFO - Nodes that successfully reply in round 0 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:28,383 fedbiomed INFO - breakpoint number 0 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0007/breakpoint_0000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:28,384 fedbiomed INFO - Sampled nodes in round 1 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:28,387 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:28,387 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:28,476 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000009\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:28,507 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000005\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:28,587 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000002\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:28,620 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000009\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:28,702 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000021\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:28,739 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000014\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,010 fedbiomed INFO - Nodes that successfully reply in round 1 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,014 fedbiomed INFO - breakpoint number 1 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0007/breakpoint_0001"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,015 fedbiomed INFO - Sampled nodes in round 2 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,016 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,016 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,111 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000011\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,116 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000005\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,224 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000001\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,225 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000006\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,348 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000007\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,351 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 3 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000003\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,612 fedbiomed INFO - Nodes that successfully reply in round 2 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,615 fedbiomed INFO - breakpoint number 2 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0007/breakpoint_0002"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,616 fedbiomed INFO - Sampled nodes in round 3 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,617 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,617 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,705 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000002\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,722 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000002\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,827 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000005\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,832 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000009\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,948 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000001\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:29,950 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 4 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000002\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:30,231 fedbiomed INFO - Nodes that successfully reply in round 3 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:30,234 fedbiomed INFO - breakpoint number 3 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0007/breakpoint_0003"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:30,235 fedbiomed INFO - Sampled nodes in round 4 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:30,237 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:30,237 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:30,340 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000001\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:30,345 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000018\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:30,451 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000009\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:30,457 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000006\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:30,565 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000013\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:30,570 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 5 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000013\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:30,847 fedbiomed INFO - Nodes that successfully reply in round 4 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:30,851 fedbiomed INFO - breakpoint number 4 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0007/breakpoint_0004"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:30,852 fedbiomed INFO - Sampled nodes in round 5 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:30,853 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:30,854 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:30,944 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000005\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:30,965 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000000\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:31,052 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000005\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:31,072 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000002\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:31,166 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000007\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:31,189 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 6 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000005\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:31,458 fedbiomed INFO - Nodes that successfully reply in round 5 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:31,463 fedbiomed INFO - breakpoint number 5 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0007/breakpoint_0005"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:31,464 fedbiomed INFO - Sampled nodes in round 6 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:31,465 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:31,466 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:31,562 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000000\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:31,569 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000013\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:31,669 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000027\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:31,676 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000004\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:31,785 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000001\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:31,794 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 7 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000010\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,064 fedbiomed INFO - Nodes that successfully reply in round 6 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,067 fedbiomed INFO - breakpoint number 6 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0007/breakpoint_0006"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,067 fedbiomed INFO - Sampled nodes in round 7 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,069 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,070 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,167 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000005\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,175 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000000\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,283 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000002\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,290 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000006\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,400 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000005\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,406 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 8 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000001\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,673 fedbiomed INFO - Nodes that successfully reply in round 7 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,676 fedbiomed INFO - breakpoint number 7 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0007/breakpoint_0007"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,677 fedbiomed INFO - Sampled nodes in round 8 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,678 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,679 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,770 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000008\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,783 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000012\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,873 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000005\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,893 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000000\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:32,986 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000000\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:33,015 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 9 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000004\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:33,293 fedbiomed INFO - Nodes that successfully reply in round 8 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:33,297 fedbiomed INFO - breakpoint number 8 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0007/breakpoint_0008"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:33,298 fedbiomed INFO - Sampled nodes in round 9 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:33,300 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:33,300 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:33,406 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000008\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:33,407 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000004\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:33,516 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000002\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:33,526 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000000\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:33,633 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000004\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:33,642 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 10 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000002\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:33,913 fedbiomed INFO - Nodes that successfully reply in round 9 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:33,916 fedbiomed INFO - breakpoint number 9 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0007/breakpoint_0009"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:33,917 fedbiomed INFO - Sampled nodes in round 10 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:33,918 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:33,919 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:34,011 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000001\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:34,028 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000002\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:34,121 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000002\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:34,162 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000002\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:34,237 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000000\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:34,279 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 11 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000000\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:34,552 fedbiomed INFO - Nodes that successfully reply in round 10 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:34,559 fedbiomed INFO - breakpoint number 10 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0007/breakpoint_0010"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:34,561 fedbiomed INFO - Sampled nodes in round 11 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:34,563 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:34,564 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:34,656 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000016\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:34,672 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000005\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:34,769 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000013\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:34,781 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000010\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:34,884 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000004\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:34,895 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 12 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000004\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:35,170 fedbiomed INFO - Nodes that successfully reply in round 11 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:35,175 fedbiomed INFO - breakpoint number 11 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0007/breakpoint_0011"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:35,176 fedbiomed INFO - Sampled nodes in round 12 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:35,178 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:35,179 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:35,288 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000009\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:35,293 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000003\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:35,400 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000002\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:35,402 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000004\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:35,513 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000000\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:35,515 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 13 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000001\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:35,780 fedbiomed INFO - Nodes that successfully reply in round 12 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:35,784 fedbiomed INFO - breakpoint number 12 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0007/breakpoint_0012"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:35,785 fedbiomed INFO - Sampled nodes in round 13 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:35,786 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:35,786 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:35,872 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000005\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:35,891 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000015\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:35,988 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000001\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:36,004 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000003\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:36,111 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000002\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:36,124 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 14 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000000\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:36,394 fedbiomed INFO - Nodes that successfully reply in round 13 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:36,399 fedbiomed INFO - breakpoint number 13 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0007/breakpoint_0013"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:36,399 fedbiomed INFO - Sampled nodes in round 14 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:36,401 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:36,401 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:36,494 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000000\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:36,510 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000005\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:36,615 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000001\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:36,619 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000003\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:36,730 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000001\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:36,736 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 15 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000007\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:37,024 fedbiomed INFO - Nodes that successfully reply in round 14 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:06:37,029 fedbiomed INFO - breakpoint number 14 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0007/breakpoint_0014"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "15"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "exp.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3fbd8f2-d0d7-480d-a518-aa0f0bf2d12e",
+   "metadata": {},
+   "source": [
+    "#### Check model parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "069e8ff0-d819-48d0-b661-277a887fa459",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "List the training rounds :  dict_keys([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14])\n",
+      "\n",
+      "Access the federated params for the last training round :\n",
+      "\t- parameter data:  dict_keys(['coef_'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"\\nList the training rounds : \", exp.aggregated_params().keys())\n",
+    "\n",
+    "print(\"\\nAccess the federated params for the last training round :\")\n",
+    "print(\"\\t- parameter data: \", exp.aggregated_params()[rounds - 1]['params'].keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fb49e0b-6074-40ae-aa0e-66acf2543a47",
+   "metadata": {},
+   "source": [
+    "#### Breakpoints"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "81e11f87-b1cf-40c9-8591-321d65a4d8dd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:07:00,670 fedbiomed WARNING - Option share_persistent_buffers is not supported in SKLearnTrainingPlan, it will be ignored."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:07:00,673 fedbiomed INFO - Experimentation reload from ../../fbm-researcher/var/experiments/Experiment_0007/breakpoint_0000 successful!"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from fedbiomed.researcher.federated_workflows import Experiment\n",
+    "new_exp = Experiment.load_breakpoint('../../fbm-researcher/var/experiments/Experiment_0007/breakpoint_0000')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "16c3bbcc-0b6e-4bf4-8b49-ba8c32dc0190",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:07:03,330 fedbiomed INFO - Sampled nodes in round 1 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:07:03,335 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:07:03,336 fedbiomed INFO - \u001b[1mSending request\u001b[0m \n",
+       "\t\t\t\t\t\u001b[1m To\u001b[0m: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t\u001b[1m Request: \u001b[0m: TRAIN\n",
+       " -----------------------------------------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:07:03,513 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000008\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:07:03,526 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 1/20 (5%) | Samples: 5/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000009\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:07:03,628 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000005\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:07:03,643 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 10/20 (50%) | Samples: 50/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000010\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:07:03,743 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_5eaa634a-8589-4251-9779-f4435535cb17 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000001\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:07:03,766 fedbiomed INFO - \u001b[1mTRAINING\u001b[0m \n",
+       "\t\t\t\t\t NODE_ID: NODE_523186bc-f4af-4044-a946-60003cdef368 \n",
+       "\t\t\t\t\t Node Name: Default Node Alias \n",
+       "\t\t\t\t\t Round 2 | Iteration: 20/20 (100%) | Samples: 100/100\n",
+       " \t\t\t\t\t Loss perceptron: \u001b[1m0.000011\u001b[0m \n",
+       "\t\t\t\t\t ---------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:07:04,026 fedbiomed INFO - Nodes that successfully reply in round 1 ['NODE_5eaa634a-8589-4251-9779-f4435535cb17', 'NODE_523186bc-f4af-4044-a946-60003cdef368']"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2026-04-15 18:07:04,029 fedbiomed INFO - breakpoint number 1 saved at /home/lchambon/Documents/FedBioMed/dev_tests/tests_local_parameters/fbm-components/fbm-researcher/var/experiments/Experiment_0007/breakpoint_0001"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "new_exp.run_once(increase=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8fbe415a-b53a-473a-bc81-362f89eb4ee1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/end2end/e2e_mnist_pytorch.py
+++ b/tests/end2end/e2e_mnist_pytorch.py
@@ -1,9 +1,12 @@
+import json
+import os
 import time
 
 import pytest
 from experiments.training_plans.mnist_pytorch_training_plan import (
     CustomTrainingPlan,
     MnistModelScaffoldDeclearn,
+    MnistModelTaggedParameters,
     MyTrainingPlan,
 )
 from helpers import (
@@ -17,9 +20,11 @@ from helpers import (
     start_nodes,
 )
 
+from fedbiomed.common.constants import DB_PREFIX, VAR_FOLDER_NAME
 from fedbiomed.common.metrics import MetricTypes
 from fedbiomed.common.optimizers import Optimizer
 from fedbiomed.common.optimizers.declearn import ScaffoldServerModule
+from fedbiomed.common.serializer import Serializer
 from fedbiomed.researcher.aggregators.fedavg import FedAverage
 from fedbiomed.researcher.aggregators.scaffold import Scaffold
 from fedbiomed.researcher.federated_workflows import Experiment
@@ -75,7 +80,7 @@ def setup(port, post_session):
     print("Waiting 10 seconds for nodes to start")
     time.sleep(10)
 
-    yield
+    yield node_1, node_2, researcher
 
     try:
         kill_subprocesses(node_processes)
@@ -226,4 +231,88 @@ def test_04_mnist_pytorch_experiment_declearn_scaffold():
     exp.set_test_on_global_updates(True)
     exp.set_test_metric(MetricTypes.ACCURACY)
     exp.run()
+    clear_experiment_data(exp)
+
+
+def test_05_mnist_pytorch_experiment_with_tagged_parameters(setup):
+    """Tests running training mnist with tagged parameters"""
+    node_1, node_2, researcher = setup
+
+    model_args = {}
+    tags = ["#MNIST", "#dataset"]
+    rounds = 1
+    training_args = {
+        "loader_args": {
+            "batch_size": 48,
+        },
+        "optimizer_args": {"lr": 1e-3},
+        "num_updates": 100,
+        "dry_run": False,
+    }
+
+    exp = Experiment(
+        tags=tags,
+        model_args=model_args,
+        training_plan_class=MnistModelTaggedParameters,
+        training_args=training_args,
+        round_limit=rounds,
+        aggregator=FedAverage(),
+        node_selection_strategy=None,
+    )
+
+    exp.run()
+    reply = exp.training_replies()
+
+    # Check keys in aggregated parameters in the last round
+    agg_params = exp.aggregated_params()[rounds - 1]["params"].keys()
+    for local_p in exp.training_plan()._local_params:
+        assert local_p not in agg_params
+
+    # Check parameters saved on the node side
+    node_1_id = node_1.get("default", "id")
+    state_id_node_1 = reply[rounds - 1][node_1_id]["state_id"]
+    experiment_id = reply[rounds - 1][node_1_id]["experiment_id"]
+
+    db_path = os.path.join(node_1.root, VAR_FOLDER_NAME, f"{DB_PREFIX}{node_1_id}.json")
+    try:
+        with open(db_path, "r") as f:
+            db_content = json.load(f)
+    except FileNotFoundError:
+        pytest.fail(f"Node DB file not found at expected path: {db_path}")
+    except json.JSONDecodeError as e:
+        pytest.fail(f"Node DB file is not valid JSON: {e}")
+
+    # Retrieve node state
+    node_1_state = next(
+        (
+            state
+            for state in db_content["Node_states"].values()
+            if state["state_id"] == state_id_node_1
+            and state["experiment_id"] == experiment_id
+        ),
+        None,
+    )
+    assert node_1_state is not None, (
+        f"No matching Node_state found for "
+        f"state_id={state_id_node_1}, "
+        f"experiment_id={experiment_id}"
+    )
+
+    try:
+        model_weights_path = node_1_state["persistent_model_weights"]["state_path"]
+    except KeyError as e:
+        pytest.fail(f"Missing expected key in node DB: {e}")
+
+    assert os.path.exists(model_weights_path), "Model weights file does not exist"
+
+    try:
+        persistent_model_weights = Serializer.load(model_weights_path)
+    except Exception as e:
+        pytest.fail(f"Error loading persistent model weights: {e}")
+
+    # Check persistent parameters saved on node side
+    assert isinstance(persistent_model_weights, dict)
+    assert "conv1.weight" in persistent_model_weights
+    assert "conv2.bias" in persistent_model_weights
+
     clear_experiment_data(exp)

--- a/tests/end2end/e2e_sklearn.py
+++ b/tests/end2end/e2e_sklearn.py
@@ -9,6 +9,7 @@ End to End test module for testing  Sklearn training plans using:
 
 """
 
+import json
 import os
 import time
 
@@ -23,6 +24,7 @@ from experiments.training_plans.sklearn import (
     SGDRegressorTrainingPlanDeclearn,
     SGDRegressorTrainingPlanDeclearnScaffold,
     SkLearnClassifierTrainingPlanDeclearn,
+    SkLearnClassifierTrainingPlanTaggedParameters,
     SklearnCSVTrainingPlan,
     SkLearnMedNistTrainingPlan,
 )
@@ -38,6 +40,7 @@ from helpers import (
     start_nodes,
 )
 
+from fedbiomed.common.constants import DB_PREFIX, VAR_FOLDER_NAME
 from fedbiomed.common.metrics import MetricTypes
 from fedbiomed.common.optimizers.declearn import (
     ScaffoldServerModule,
@@ -46,6 +49,7 @@ from fedbiomed.common.optimizers.declearn import (
     YogiModule as FedYogi,
 )
 from fedbiomed.common.optimizers.optimizer import Optimizer
+from fedbiomed.common.serializer import Serializer
 from fedbiomed.common.utils import SHARE_DIR
 from fedbiomed.researcher.aggregators.fedavg import FedAverage
 from fedbiomed.researcher.federated_workflows import Experiment
@@ -516,4 +520,94 @@ def test_11_sklearn_csv_customdataset():
     )
 
     exp.run()
+    clear_experiment_data(exp)
+
+
+def test_12_sklearn_mnist_perceptron_with_tagged_parameters(setup):
+    """Tests sklearn classifier with tagged parameters"""
+    node_1, node_2, node_3, researcher = setup
+
+    model_args = {
+        "n_features": 28 * 28,
+        "n_classes": 10,
+        "eta0": 1e-6,
+        "alpha": 0.1,
+        "learning_rate": "constant",
+    }
+
+    training_args = {
+        "num_updates": 20,
+        "loader_args": {
+            "batch_size": 5,
+        },
+        "random_seed": 1234,
+    }
+
+    # select nodes participating in this experiment
+    rounds = 4
+    exp = Experiment(
+        tags=["#MNIST", "#dataset"],
+        model_args=model_args,
+        training_plan_class=SkLearnClassifierTrainingPlanTaggedParameters,
+        training_args=training_args,
+        round_limit=rounds,
+        aggregator=FedAverage(),
+        node_selection_strategy=None,
+        save_breakpoints=True,
+    )
+
+    exp.run()
+    reply = exp.training_replies()
+
+    # Check keys in aggregated parameters in the last round
+    agg_params = exp.aggregated_params()[rounds - 1]["params"].keys()
+    for local_p in exp.training_plan()._local_params:
+        assert local_p not in agg_params
+
+    # Check parameters saved on the node side
+    node_1_id = node_1.get("default", "id")
+    state_id_node_1 = reply[rounds - 1][node_1_id]["state_id"]
+    experiment_id = reply[rounds - 1][node_1_id]["experiment_id"]
+
+    db_path = os.path.join(node_1.root, VAR_FOLDER_NAME, f"{DB_PREFIX}{node_1_id}.json")
+    try:
+        with open(db_path, "r") as f:
+            db_content = json.load(f)
+    except FileNotFoundError:
+        pytest.fail(f"Node DB file not found at expected path: {db_path}")
+    except json.JSONDecodeError as e:
+        pytest.fail(f"Node DB file is not valid JSON: {e}")
+
+    # Retrieve node state
+    node_1_state = next(
+        (
+            state
+            for state in db_content["Node_states"].values()
+            if state["state_id"] == state_id_node_1
+            and state["experiment_id"] == experiment_id
+        ),
+        None,
+    )
+    assert node_1_state is not None, (
+        f"No matching Node_state found for "
+        f"state_id={state_id_node_1}, "
+        f"experiment_id={experiment_id}"
+    )
+
+    try:
+        model_weights_path = node_1_state["persistent_model_weights"]["state_path"]
+    except KeyError as e:
+        pytest.fail(f"Missing expected key in node DB: {e}")
+
+    assert os.path.exists(model_weights_path), "Model weights file does not exist"
+
+    try:
+        persistent_model_weights = Serializer.load(model_weights_path)
+    except Exception as e:
+        pytest.fail(f"Error loading persistent model weights: {e}")
+
+    # Check persistent parameters saved on node side
+    assert isinstance(persistent_model_weights, dict)
+    assert "intercept_" in persistent_model_weights
+
     clear_experiment_data(exp)

--- a/tests/end2end/experiments/training_plans/mnist_pytorch_training_plan.py
+++ b/tests/end2end/experiments/training_plans/mnist_pytorch_training_plan.py
@@ -265,3 +265,68 @@ class MnistModelScaffoldDeclearn(TorchTrainingPlan):
         output = self.model().forward(data)
         loss = torch.nn.functional.nll_loss(output, target)
         return loss
+
+
+class MnistModelTaggedParameters(TorchTrainingPlan):
+    # Defines and return model
+    def init_model(self, model_args):
+        return self.Net(model_args=model_args)
+
+    # Defines and return optimizer
+    def init_optimizer(self, optimizer_args):
+        return torch.optim.Adam(self.model().parameters(), lr=optimizer_args["lr"])
+
+    # Declares and return dependencies
+    def init_dependencies(self):
+        deps = [
+            "from torchvision import transforms",
+            "from fedbiomed.common.dataset import MnistDataset",
+        ]
+        return deps
+
+    class Net(nn.Module):
+        def __init__(self, model_args):
+            super().__init__()
+            self.conv1 = nn.Conv2d(1, 32, 3, 1)
+            self.conv2 = nn.Conv2d(32, 64, 3, 1)
+            self.dropout1 = nn.Dropout(0.25)
+            self.dropout2 = nn.Dropout(0.5)
+            self.fc1 = nn.Linear(9216, 128)
+            self.fc2 = nn.Linear(128, 10)
+
+        def forward(self, x):
+            x = self.conv1(x)
+            x = F.relu(x)
+            x = self.conv2(x)
+            x = F.relu(x)
+            x = F.max_pool2d(x, 2)
+            x = self.dropout1(x)
+            x = torch.flatten(x, 1)
+            x = self.fc1(x)
+            x = F.relu(x)
+            x = self.dropout2(x)
+            x = self.fc2(x)
+
+            output = F.log_softmax(x, dim=1)
+            return output
+
+    def training_data(self):
+        # Mnist Dataset from fedbiomed.common.dataset is used.
+        transform = transforms.Normalize((0.1307,), (0.3081,))
+        dataset1 = MnistDataset(transform=transform)
+        train_kwargs = {"shuffle": True}
+        return DataManager(dataset=dataset1, **train_kwargs)
+
+    def training_step(self, data, target):
+        output = self.model().forward(data)
+        loss = torch.nn.functional.nll_loss(output, target)
+        return loss
+
+    def tag_parameters(self, name):
+        if name == "conv1.weight":
+            return {"local", "persistent"}
+        if name == "conv1.bias":
+            return {"local"}
+        if name == "conv2.bias":
+            return {"persistent"}
+        return set()

--- a/tests/end2end/experiments/training_plans/sklearn.py
+++ b/tests/end2end/experiments/training_plans/sklearn.py
@@ -388,3 +388,51 @@ class SklearnCSVTrainingPlan(FedSGDClassifier):
     def training_data(self):
         dataset = self.CSVClassificationDataset()
         return DataManager(dataset=dataset, shuffle=True)
+
+
+class SkLearnClassifierTrainingPlanTaggedParameters(FedPerceptron):
+    def init_dependencies(self):
+        """Define additional dependencies."""
+        return [
+            "from sklearn.pipeline import Pipeline",
+            "from sklearn.preprocessing import FunctionTransformer",
+            "from fedbiomed.common.dataset import MnistDataset",
+            "import numpy as np",
+        ]
+
+    def training_data(self):
+        """Prepare data for training.
+
+        This function loads a MNIST dataset from the node's filesystem, applies some
+        preprocessing and converts the full dataset to a numpy array.
+        Finally, it returns a DataManager created with these numpy arrays.
+        """
+
+        pipeline = Pipeline(
+            [
+                (
+                    "norm",
+                    FunctionTransformer(
+                        lambda im: (np.asarray(im, dtype=np.float64) / 255.0 - 0.1307)
+                        / 0.3081,
+                        validate=False,
+                    ),
+                ),
+                (
+                    "flatten",
+                    FunctionTransformer(
+                        lambda x: np.ascontiguousarray(x.reshape(-1), dtype=np.float64),
+                        validate=False,
+                    ),
+                ),
+            ]
+        )
+
+        dataset = MnistDataset(transform=pipeline.transform)
+
+        return DataManager(dataset=dataset, shuffle=True)
+
+    def tag_parameters(self, name):
+        if name == "intercept_":
+            return {"local", "persistent"}
+        return set()

--- a/tests/test_base_training_plan.py
+++ b/tests/test_base_training_plan.py
@@ -15,6 +15,7 @@ from fedbiomed.common.training_args import TrainingArgs
 
 # from fedbiomed.common.dataloader import NPDataLoader
 from fedbiomed.common.training_plans._base_training_plan import BaseTrainingPlan  # noqa
+from fedbiomed.node.history_monitor import HistoryMonitor
 
 
 class SimpleTrainingPlan(BaseTrainingPlan):
@@ -369,11 +370,11 @@ class TestBaseTrainingPlan(unittest.TestCase):
             # data.__len__.return_value = 2
             # test_data = MagicMock(spec=np.ndarray, dataset = MagicMock(return_value=test_data_loader))
             # test_data.__len__.return_value = test_batch_size
-            data = NPDataLoader(
+            data = NPDataLoader(  # noqa: F821
                 dataset=train_data_loader, target=train_data_loader_target
             )
 
-            test_data = NPDataLoader(
+            test_data = NPDataLoader(  # noqa: F821
                 dataset=test_data_loader,
                 target=test_data_loader_target,
                 batch_size=test_batch_size,
@@ -454,6 +455,121 @@ class TestBaseTrainingPlan(unittest.TestCase):
                 nb_samples_test_dataset % test_batch_size > 0
             )
             self.assertEqual(model.predict.call_count, nb_test_batch)
+
+    def test_base_training_plan_11_local_params_property(self):
+        """Test local_params property"""
+
+        self.assertIsNone(self.tp.local_params)
+
+        self.tp._local_params = ["param1", "param2"]
+        self.assertEqual(self.tp.local_params, ["param1", "param2"])
+
+    def test_base_training_plan_12_get_dp_controller(self):
+        """Test default DP controller getter"""
+        self.assertIsNone(self.tp.get_dp_controller())
+
+    def test_base_training_plan_13_validate_parameter_tags(self):
+        """Test validation of parameter tags"""
+
+        # valid case
+        tags = {"local"}
+        validated = self.tp._validate_parameter_tags("weight", tags)
+        self.assertEqual(validated, tags)
+
+        # invalid type
+        with self.assertRaises(FedbiomedTrainingPlanError):
+            self.tp._validate_parameter_tags("weight", ["local"])
+
+        # invalid tag
+        with self.assertRaises(FedbiomedTrainingPlanError):
+            self.tp._validate_parameter_tags("weight", {"invalid"})
+
+    def test_base_training_plan_14_get_parameter_tags(self):
+        """Test retrieving parameter tags"""
+
+        tags = self.tp.get_parameter_tags("weight")
+        self.assertEqual(tags, set())
+
+    def test_base_training_plan_15_filter_model_params_by_tags(self):
+        """Test filtering model parameters based on tags"""
+
+        params = {"w1": 1, "w2": 2, "w3": 3}
+
+        def fake_tag_parameters(name):
+            if name == "w1":
+                return {"local"}
+            if name == "w2":
+                return {"persistent"}
+            return set()
+
+        self.tp.tag_parameters = fake_tag_parameters
+
+        # filter required tag
+        filtered = self.tp.filter_model_params_by_tags(params, required_tags={"local"})
+        self.assertEqual(filtered, {"w1": 1})
+        # invalid required tag
+        with self.assertRaises(FedbiomedTrainingPlanError):
+            self.tp.filter_model_params_by_tags(params, required_tags=["local"])
+
+        # filter forbidden tag
+        filtered = self.tp.filter_model_params_by_tags(params, forbidden_tags={"local"})
+        self.assertNotIn("w1", filtered)
+        # invalid forbidden tag
+        with self.assertRaises(FedbiomedTrainingPlanError):
+            self.tp.filter_model_params_by_tags(params, forbidden_tags="local")
+
+    def test_base_training_plan_16_get_model_params_local(self):
+        """Test get_model_params passes local_params to model"""
+
+        model = MagicMock()
+        model.get_weights.return_value = {"w": 1}
+
+        self.tp._model = model
+
+        self.tp.get_model_params(local_params=["w"])
+
+        model.get_weights.assert_called_once_with(
+            only_trainable=False, exclude_buffers=True, local_params=["w"]
+        )
+
+    def test_base_training_plan_17_set_model_params_local(self):
+        """Test set_model_params passes local_params to model"""
+
+        model = MagicMock()
+        self.tp._model = model
+
+        params = {"w": 1}
+
+        self.tp.set_model_params(params, local_params=["w"])
+
+        model.set_weights.assert_called_once_with(params, local_params=["w"])
+
+    def test_base_training_plan_18_after_training_params(self):
+        """Test after_training_params uses local_params"""
+
+        model = MagicMock()
+        model.get_weights.return_value = {"w": 1}
+
+        self.tp._model = model
+        self.tp._local_params = ["w"]
+        self.tp._training_args = {"share_persistent_buffers": False}
+
+        self.tp.after_training_params()
+
+        model.get_weights.assert_called_once_with(
+            only_trainable=False, exclude_buffers=True, local_params=["w"]
+        )
+
+    def test_base_training_plan_19_import_model(self):
+        """Test import_model passes local_params"""
+
+        model = MagicMock()
+        self.tp._model = model
+        self.tp._local_params = ["w"]
+
+        self.tp.import_model("model.pt")
+
+        model.reload.assert_called_once_with("model.pt", ["w"])
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_base_training_plan.py
+++ b/tests/test_base_training_plan.py
@@ -9,11 +9,11 @@ import torch
 # Import again the full module: we need it to test saving code without dependencies. Do not delete the line below.
 import fedbiomed.common.training_plans._base_training_plan  # noqa
 from fedbiomed.common.constants import ProcessTypes
+from fedbiomed.common.dataloader import SkLearnDataLoader
+from fedbiomed.common.dataset import Dataset
 from fedbiomed.common.exceptions import FedbiomedError, FedbiomedTrainingPlanError
 from fedbiomed.common.models._torch import TorchModel
 from fedbiomed.common.training_args import TrainingArgs
-
-# from fedbiomed.common.dataloader import NPDataLoader
 from fedbiomed.common.training_plans._base_training_plan import BaseTrainingPlan  # noqa
 from fedbiomed.node.history_monitor import HistoryMonitor
 
@@ -340,83 +340,39 @@ class TestBaseTrainingPlan(unittest.TestCase):
         )
 
     # test for bug #893
-    @unittest.skip("Deprecated class")
-    def test_base_training_plan_10_node_out_of_memory_bug_npdataloader(self):
-        # bug description: validation testing uses batch size equal to all the validation dataset, which leads to some
-        # OutOfMemory errors.
-        # It tests the introduction of new feature `test_batch_size`, in order to compute validation
-        # metric for every batches (and avoid loading the whole dataset, thus OutOfMemory errors)
-        nb_samples_test_dataset = 123
-        test_batch_sizes = (
-            1,
-            2,
-            10,
-            nb_samples_test_dataset,
-            nb_samples_test_dataset + 10,
-            nb_samples_test_dataset - 1,
-        )
+    def test_base_training_plan_10_node_out_of_memory_bug(self):
+        # bug description: validation testing uses batch size equal to all the validation dataset,
+        # which leads to OutOfMemory errors. Tests that testing_routine iterates over
+        # test_batch_size-sized batches rather than loading the whole dataset at once.
+        # Covers both sklearn (SkLearnDataLoader) and pytorch (torch.utils.data.DataLoader) paths.
 
-        for test_batch_size in test_batch_sizes:
-            test_data_loader = np.random.randn(nb_samples_test_dataset, 100)
-            test_data_loader_target = np.random.randint(
-                0, 2, size=nb_samples_test_dataset
-            )
-            train_data_loader = np.random.randn(64, 100)
-            train_data_loader_target = np.random.randint(0, 2, size=64)
-            nb_test_batch = nb_samples_test_dataset // test_batch_size + int(
-                nb_samples_test_dataset % test_batch_size > 0
-            )
-            # data = MagicMock(spec=np.ndarray, dataset = MagicMock(retrun_value = train_data_loader))
-            # data.__len__.return_value = 2
-            # test_data = MagicMock(spec=np.ndarray, dataset = MagicMock(return_value=test_data_loader))
-            # test_data.__len__.return_value = test_batch_size
-            data = NPDataLoader(  # noqa: F821
-                dataset=train_data_loader, target=train_data_loader_target
-            )
+        class FakeSkLearnDataset(Dataset):
+            def __init__(self, nb_samples: int, n_features: int = 10):
+                self._data = [np.random.randn(n_features) for _ in range(nb_samples)]
+                self._target = [
+                    np.array(np.random.randint(0, 2)) for _ in range(nb_samples)
+                ]
 
-            test_data = NPDataLoader(  # noqa: F821
-                dataset=test_data_loader,
-                target=test_data_loader_target,
-                batch_size=test_batch_size,
-            )
+            def complete_initialization(self, *args, **kwargs) -> None:
+                pass
 
-            def predict(x: np.ndarray):
-                return x.T[0]
+            def __getitem__(self, idx: int):
+                return self._data[idx], self._target[idx]
 
-            model = MagicMock(predict=MagicMock(side_effect=predict))
+            def __len__(self) -> int:
+                return len(self._data)
 
-            self.tp._model = model
-            self.tp._training_args = TrainingArgs(only_required=False)
-            self.tp.set_data_loaders(data, test_data)
-            self.tp.testing_routine(
-                metric=None,
-                metric_args={},
-                history_monitor=None,
-                before_train=True,
-            )
-
-            # here we are checking how many time we are calling model.`predict` method, which is equal to
-            # how many batch sizes are processed
-            self.assertEqual(model.predict.call_count, nb_test_batch)
-
-    # 2nd test for bug #893
-    def test_base_training_plan_10_node_out_of_memory_bug_pytorch(self):
-        # bug description: validation testing uses batch size equal to all the validation dataset, which leads to some
-        # OutOfMemory errors.
-        #
-        class FakeDataset(torch.utils.data.Dataset):
-            def __init__(self, nb_samples_dataset: int = 1234):
-                self.train_dataset = torch.randn(nb_samples_dataset, 100)
-                self.train_label = torch.randint(0, 5, size=(nb_samples_dataset,))
-                self.nb_samples = nb_samples_dataset
+        class FakeTorchDataset(torch.utils.data.Dataset):
+            def __init__(self, nb_samples: int = 1234):
+                self.data = torch.randn(nb_samples, 100)
+                self.label = torch.randint(0, 5, size=(nb_samples,))
+                self.nb_samples = nb_samples
 
             def __len__(self):
                 return self.nb_samples
 
             def __getitem__(self, idx):
-                data = self.train_dataset[idx]
-                label = self.train_label[idx]
-                return data, label
+                return self.data[idx], self.label[idx]
 
         nb_samples_test_dataset = 123
         test_batch_sizes = (
@@ -427,34 +383,48 @@ class TestBaseTrainingPlan(unittest.TestCase):
             nb_samples_test_dataset + 10,
             nb_samples_test_dataset - 1,
         )
-        nb_samples_train_dataset = 1234
 
-        for test_batch_size in test_batch_sizes:
-            train_dataloader = torch.utils.data.DataLoader(
-                FakeDataset(nb_samples_train_dataset),
-            )
-            test_dataloader = torch.utils.data.DataLoader(
-                FakeDataset(nb_samples_test_dataset), batch_size=test_batch_size
-            )
+        loader_cases = [
+            # (train_loader, test_loader_factory, predict_fn, model_spec)
+            (
+                SkLearnDataLoader(dataset=FakeSkLearnDataset(64)),
+                lambda bs: SkLearnDataLoader(
+                    dataset=FakeSkLearnDataset(nb_samples_test_dataset), batch_size=bs
+                ),
+                lambda x: np.zeros(x.shape[0], dtype=int),
+                None,
+            ),
+            (
+                torch.utils.data.DataLoader(FakeTorchDataset(1234)),
+                lambda bs: torch.utils.data.DataLoader(
+                    FakeTorchDataset(nb_samples_test_dataset), batch_size=bs
+                ),
+                lambda x: x.T[0].numpy(),
+                TorchModel,
+            ),
+        ]
 
-            def predict(x: torch.Tensor):
-                return x.T[0].numpy()
-
-            model = MagicMock(predict=MagicMock(side_effect=predict), spec=TorchModel)
-            self.tp._model = model
-            self.tp._training_args = TrainingArgs(only_required=False)
-            self.tp.set_data_loaders(train_dataloader, test_dataloader)
-            self.tp.testing_routine(
-                metric=None,
-                metric_args={},
-                history_monitor=None,
-                before_train=True,
-            )
-
-            nb_test_batch = nb_samples_test_dataset // test_batch_size + int(
-                nb_samples_test_dataset % test_batch_size > 0
-            )
-            self.assertEqual(model.predict.call_count, nb_test_batch)
+        for train_loader, test_loader_factory, predict_fn, model_spec in loader_cases:
+            for test_batch_size in test_batch_sizes:
+                model = MagicMock(
+                    predict=MagicMock(side_effect=predict_fn),
+                    **({"spec": model_spec} if model_spec else {}),
+                )
+                self.tp._model = model
+                self.tp._training_args = TrainingArgs(only_required=False)
+                self.tp.set_data_loaders(
+                    train_loader, test_loader_factory(test_batch_size)
+                )
+                self.tp.testing_routine(
+                    metric=None,
+                    metric_args={},
+                    history_monitor=None,
+                    before_train=True,
+                )
+                nb_test_batch = nb_samples_test_dataset // test_batch_size + int(
+                    nb_samples_test_dataset % test_batch_size > 0
+                )
+                self.assertEqual(model.predict.call_count, nb_test_batch)
 
     def test_base_training_plan_11_local_params_property(self):
         """Test local_params property"""

--- a/tests/test_dp_controller.py
+++ b/tests/test_dp_controller.py
@@ -1,16 +1,15 @@
 import unittest
+from unittest.mock import MagicMock, patch
 
 import torch
-
 from torch.nn import Module
 from torch.optim import Adam
 from torch.utils.data import DataLoader, Dataset
 
-from unittest.mock import patch, MagicMock
+from fedbiomed.common.exceptions import FedbiomedDPControllerError
 from fedbiomed.common.models import TorchModel
 from fedbiomed.common.optimizers.generic_optimizers import NativeTorchOptimizer
 from fedbiomed.common.privacy import DPController
-from fedbiomed.common.exceptions import FedbiomedDPControllerError
 
 
 class TestDPController(unittest.TestCase):
@@ -187,22 +186,39 @@ class TestDPController(unittest.TestCase):
         )
 
     def test_dep_controller_07_post_process_dp(self):
-        """Tests before training method with different scenarios"""
+        """Tests postprocess dp renaming behaviour"""
 
-        params = {"a_module.": torch.zeros([2, 4]), "b_module.": torch.zeros([2, 4])}
-
-        # Post processes with DPL
-        p = self.dpl._postprocess_dp(params)
-        self.assertTrue(
-            "module" not in list(p.keys())[0],
-            "`module tag is not properly removed from private end-model`",
-        )
+        params = {
+            "_module.weight": torch.zeros([2, 4]),
+            "_module.bias": torch.zeros([2, 4]),
+        }
 
         # Post processes with DPC
-        p = self.dpc._postprocess_dp(params)
+        # With renaming=True
+        p = self.dpc._postprocess_dp(params, renaming=True)
         self.assertTrue(
-            "module" not in list(p.keys())[0],
-            "`module tag is not properly removed from private end-model`",
+            "_module." not in list(p.keys())[0],
+            "Opacus prefix not removed when renaming=True",
+        )
+        # With renaming=False
+        p = self.dpc._postprocess_dp(params, renaming=False)
+        self.assertTrue(
+            "_module." in list(p.keys())[0],
+            "Opacus prefix removed when renaming=False",
+        )
+
+        # Post processes with DPL
+        # With renaming=True
+        p = self.dpl._postprocess_dp(params, renaming=True)
+        self.assertTrue(
+            "_module." not in list(p.keys())[0],
+            "Opacus prefix not removed when renaming=True",
+        )
+        # With renaming=False
+        p = self.dpl._postprocess_dp(params, renaming=False)
+        self.assertTrue(
+            "_module." in list(p.keys())[0],
+            "Opacus prefix removed when renaming=False",
         )
 
     @patch("fedbiomed.common.privacy.DPController._postprocess_dp")
@@ -211,15 +227,73 @@ class TestDPController(unittest.TestCase):
 
         postprocess.return_value = "POSTPROCESS"
 
-        params = {"a_module.": torch.zeros([2, 4]), "b_module.": torch.zeros([2, 4])}
+        params = {
+            "_module.weight": torch.zeros([2, 4]),
+            "_module.bias": torch.zeros([2, 4]),
+        }
 
         # Post processes with DPL
+        # Default renaming=True
         p = self.dpl.after_training(params)
         self.assertEqual(p, "POSTPROCESS")
+        postprocess.assert_called_with(params, True)
+        postprocess.reset_mock()
+        # renaming=False
+        p = self.dpl.after_training(params, renaming=False)
+        self.assertEqual(p, "POSTPROCESS")
+        postprocess.assert_called_with(params, False)
+        postprocess.reset_mock()
 
         # Post processes with DPC
+        # Default renaming=True
         p = self.dpc.after_training(params)
         self.assertEqual(p, "POSTPROCESS")
+        postprocess.assert_called_with(params, True)
+        postprocess.reset_mock()
+        # renaming=False
+        p = self.dpc.after_training(params, renaming=False)
+        self.assertEqual(p, "POSTPROCESS")
+        postprocess.assert_called_with(params, False)
+
+    def test_dep_controller_09_rename_params(self):
+        """Test rename_params strips Opacus prefix"""
+
+        params = {
+            "_module.weight": torch.zeros(2, 2),
+            "_module.bias": torch.zeros(2),
+            "normal_param": torch.zeros(1),
+        }
+
+        renamed, mapping = self.dpl.rename_params(params)
+
+        self.assertIn("weight", renamed)
+        self.assertIn("bias", renamed)
+        self.assertIn("normal_param", renamed)
+
+        self.assertNotIn("_module.weight", renamed)
+
+        self.assertEqual(mapping["weight"], "_module.weight")
+        self.assertEqual(mapping["bias"], "_module.bias")
+
+    def test_dep_controller_10_revert_rename_params(self):
+        """Test revert_rename_params restores original names"""
+
+        params = {
+            "weight": torch.zeros(2, 2),
+            "bias": torch.zeros(2),
+        }
+        mapping = {
+            "weight": "_module.weight",
+            "bias": "_module.bias",
+        }
+
+        reverted = self.dpl.revert_rename_params(params, mapping)
+
+        self.assertIn("_module.weight", reverted)
+        self.assertIn("_module.bias", reverted)
+
+        self.assertNotIn("weight", reverted)
+        self.assertNotIn("bias", reverted)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,6 +1,6 @@
 import unittest
 from itertools import product
-from unittest.mock import MagicMock, create_autospec, patch
+from unittest.mock import MagicMock, PropertyMock, create_autospec, patch
 
 from declearn.model.api import Vector
 from declearn.optimizer.modules import AuxVar
@@ -351,6 +351,21 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
         self.assertEqual(exp.round_current(), 7)
         # ------------------------------------------------------------------------
 
+        # Test run_once with local parameters ------------------------------------
+        self.mock_job.reset_mock()
+        _strategy.reset_mock()
+        _aggregator.reset_mock()
+        exp.training_plan().reset_mock()
+        self.mock_tp._local_params = ["layer1.weight"]
+        type(self.mock_tp).local_params = PropertyMock(
+            return_value=self.mock_tp._local_params
+        )
+
+        exp.run_once(increase=True)
+        _, kwargs = exp.training_plan().set_model_params.call_args
+        self.assertEqual(kwargs["local_params"], ["layer1.weight"])
+        # ------------------------------------------------------------------------
+
     def test_experiment_05_run(self):
         """Tests run method of the experiment"""
         exp = Experiment(round_limit=2)
@@ -669,7 +684,8 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
         exp.set_test_on_global_updates(False)
         self.assertFalse(exp.test_on_global_updates())
 
-    def test_experiment_12_set_agg_optimizer(self):
+    @patch("fedbiomed.researcher.experiment.logger.warning")
+    def test_experiment_12_set_agg_optimizer(self, mock_warning):
         """Tests setting aggregator optimizer"""
 
         exp = Experiment()
@@ -690,6 +706,14 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
         # Check getter
         exp._agg_optimizer = _agg_optim
         self.assertEqual(exp.agg_optimizer(), _agg_optim)
+
+        # Check warning if optimizer is set with a local parameters in training plan
+        mock_tp = MagicMock()
+        mock_tp._local_params = ["layer.weight"]
+        exp._training_plan = mock_tp
+        exp.set_agg_optimizer(_agg_optim)
+
+        mock_warning.assert_called_once()
 
     def test_experiment_13_set_round_limit(self):
         """Tests setting round limit"""
@@ -886,6 +910,118 @@ class TestExperiment(unittest.TestCase, MockRequestModule):
         state_agent.reset_mock()
         exp._update_nodes_states_agent({"hello": "world"})
         state_agent.update_node_states.assert_called_once_with({"hello": "world"})
+
+    def test_experiment_24_aggregate_encrypted_model_params_passes_local_params(self):
+        """Test _aggregate_encrypted_model_params_and_optim_auxvar forwards local_params.
+
+        Verifies that both flatten() (on get_model_wrapper_class()) and unflatten()
+        receive the local_params from the training plan.
+        """
+        exp = Experiment()
+
+        # Mock secagg
+        mock_secagg = MagicMock(spec=_SecureAggregation)
+        mock_secagg.aggregate.return_value = [0.0, 1.0]
+        exp._secagg = mock_secagg
+
+        # training_args share_persistent_buffers
+        exp._training_args = MagicMock()
+        exp._training_args.__getitem__ = MagicMock(
+            side_effect=lambda k: True if k == "share_persistent_buffers" else None
+        )
+
+        # Training plan with non-empty local_params
+        local = ["fc.bias"]
+        mock_tp = MagicMock()
+        mock_tp._local_params = local
+        type(mock_tp).local_params = PropertyMock(return_value=mock_tp._local_params)
+
+        # Model wrapper: flatten returns a size-2 list, unflatten returns a dict
+        mock_wrapper = MagicMock()
+        mock_wrapper.flatten.return_value = [0.0, 1.0]
+        mock_wrapper.unflatten.return_value = {"fc1.weight": 0.0, "fc2.weight": 1.0}
+        mock_tp.get_model_wrapper_class.return_value = mock_wrapper
+
+        exp.training_plan = MagicMock(return_value=mock_tp)
+
+        aggregated_params, aggregated_auxvar = (
+            exp._aggregate_encrypted_model_params_and_optim_auxvar(
+                model_params={"node-1": [0, 1]},
+                optim_auxvar={},
+                encryption_factors=None,
+                total_sample_size=10,
+            )
+        )
+
+        # flatten must have been called with local_params=local
+        flatten_kwargs = mock_wrapper.flatten.call_args
+        self.assertEqual(
+            flatten_kwargs.kwargs.get("local_params"),
+            local,
+            "flatten() was not called with the correct local_params",
+        )
+
+        # unflatten must have been called with local_params=local
+        unflatten_kwargs = mock_wrapper.unflatten.call_args
+        self.assertEqual(
+            unflatten_kwargs.kwargs.get("local_params"),
+            local,
+            "unflatten() was not called with the correct local_params",
+        )
+        self.assertIsNone(aggregated_auxvar)
+
+    def test_experiment_25_run_agg_optimizer_passes_local_params(self):
+        """Test that _run_agg_optimizer filters model params through local_params.
+
+        Two sub-cases:
+        A. No agg_optimizer set: returns aggregated_params unchanged.
+        B. agg_optimizer set with local_params: get_model_params called with
+           local_params on both the trainable-only and full-params calls.
+        """
+        exp = Experiment()
+
+        aggregated_params = {"fc.weight": MagicMock(), "fc.bias": MagicMock()}
+
+        # A. No optimizer
+        exp._agg_optimizer = None
+        mock_tp_no_optim = MagicMock()
+        result = exp._run_agg_optimizer(mock_tp_no_optim, aggregated_params)
+        self.assertEqual(result, aggregated_params)
+        mock_tp_no_optim.get_model_params.assert_not_called()
+
+        # B. Optimizer set: local_params must propagate
+        local = ["fc.bias"]
+        mock_tp = MagicMock()
+        mock_tp._local_params = local
+        type(mock_tp).local_params = PropertyMock(return_value=mock_tp._local_params)
+
+        # get_model_params returns params compatible with Vector.build
+        param_tensor = MagicMock()
+        mock_tp.get_model_params.return_value = {"fc.weight": param_tensor}
+
+        _agg_optim = MagicMock(spec=fedbiomed.common.optimizers.Optimizer)
+        mock_update = MagicMock()
+        mock_update.coefs = {}
+        _agg_optim.step.return_value = mock_update
+
+        exp._agg_optimizer = _agg_optim
+
+        with patch.object(Vector, "build", return_value=MagicMock()):
+            exp._run_agg_optimizer(mock_tp, aggregated_params)
+
+        # Both get_model_params calls must include local_params=local
+        calls = mock_tp.get_model_params.call_args_list
+        self.assertGreaterEqual(
+            len(calls),
+            2,
+            "Expected at least two get_model_params calls",
+        )
+        for call in calls:
+            self.assertEqual(
+                call.kwargs.get("local_params"),
+                local,
+                f"get_model_params was called without local_params=local: {call}",
+            )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_fedbiosklearn.py
+++ b/tests/test_fedbiosklearn.py
@@ -209,6 +209,38 @@ class TestSklearnTrainingPlanBasicInheritance(unittest.TestCase):
             training_plan.import_model("filename")
             self.assertIs(training_plan._model.model, model)
 
+    def test_sklearntrainingplanbasicinheritance_05_post_init_local_params(self):
+        """Ensure post_init correctly computes _local_params from tagged parameters."""
+
+        training_plan = SKLearnTrainingPlan()
+
+        # mock model
+        mock_model = MagicMock()
+        mock_model.get_weights.return_value = {
+            "coef_": np.array([0.0]),
+            "intercept_": np.array([0.0]),
+        }
+
+        # patch get_model_params to return fake params
+        training_plan.get_model_params = MagicMock(
+            return_value={"coef_": np.array([0.0]), "intercept_": np.array([0.0])}
+        )
+
+        # simulate tagging behaviour
+        def fake_filter(params, required_tags=None, forbidden_tags=None):
+            return {"coef_": params["coef_"]}  # only coef_ tagged local
+
+        training_plan.filter_model_params_by_tags = MagicMock(side_effect=fake_filter)
+
+        training_plan._model = mock_model
+
+        training_plan.post_init(
+            {"n_classes": 2, "n_features": 2},
+            FakeTrainingArgs(),
+        )
+
+        self.assertEqual(training_plan._local_params, ["coef_"])
+
 
 class TestSklearnTrainingPlanPartialFit(unittest.TestCase):
     def setUp(self):
@@ -601,6 +633,15 @@ class TestSklearnTrainingPlansCommonFunctionalities(unittest.TestCase):
             self.assertEqual(
                 training_plan._model.model.n_iter_, 1
             )  # n_iter_ == 1 always after calling _train_over_batch
+
+    def test_sklearntrainingplancommonfunctionalities_06_local_params_default_empty(
+        self,
+    ):
+        """Ensure sklearn training plans have no local parameters by default."""
+
+        for training_plan in self.training_plans:
+            self.assertIsInstance(training_plan._local_params, list)
+            self.assertEqual(training_plan._local_params, [])
 
 
 class TestSklearnTrainingPlansRegression(unittest.TestCase):

--- a/tests/test_federated_workflow.py
+++ b/tests/test_federated_workflow.py
@@ -463,8 +463,12 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
     @patch(
         "fedbiomed.researcher.federated_workflows._federated_workflow.NodeStateAgent.load_state_breakpoint"
     )
+    @patch(
+        "fedbiomed.researcher.federated_workflows._federated_workflow.NodeStateAgent.load_fds_breakpoint"
+    )
     def test_federated_workflow_05_load_breakpoint(
         self,
+        mock_load_fds,
         mock_node_state_load,
         mock_bkpt_file,
         mock_json_load,
@@ -531,6 +535,7 @@ class TestFederatedWorkflow(unittest.TestCase, MockRequestModule):
         self.assertDictEqual(saved_state["node_state"], {"node_state": "bkpt"})
         self.assertEqual(exp.secagg.scheme, SecureAggregationSchemes.LOM)
         self.assertIsInstance(exp_tempo_id, str)
+        mock_load_fds.assert_called_once_with(breakpoint_json["training_data"])
 
         # 2. Test with preprocessing
         breakpoint_json["preprocessing"] = {

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -116,6 +116,7 @@ class TestJob(unittest.TestCase):
         mock_tp_class.__name__ = "mock_tp_class"
 
         mock_tp = mock_tp_class()
+        mock_tp.local_params = None
         mock_tp.get_model_params.return_value = MagicMock(spec=dict)
         mock_tp.source.return_value = MagicMock(spec=str)
 
@@ -248,6 +249,7 @@ class TestJob(unittest.TestCase):
         mock_tp_class.__name__ = "mock_tp_class"
 
         mock_tp = mock_tp_class()
+        mock_tp.local_params = None
         mock_tp.get_model_params.return_value = MagicMock(spec=dict)
         mock_tp.source.return_value = MagicMock(spec=str)
 
@@ -420,6 +422,7 @@ class TestJob(unittest.TestCase):
         mock_tp_class.__name__ = "mock_tp_class"
 
         mock_tp = mock_tp_class()
+        mock_tp.local_params = None
         mock_tp.get_model_params.return_value = MagicMock(spec=dict)
         mock_tp.source.return_value = MagicMock(spec=str)
 
@@ -472,6 +475,7 @@ class TestJob(unittest.TestCase):
         mock_tp_class.__name__ = "mock_tp_class"
 
         mock_tp = mock_tp_class()
+        mock_tp.local_params = None
         mock_tp.get_model_params.return_value = MagicMock(spec=dict)
         mock_tp.source.return_value = MagicMock(spec=str)
 
@@ -585,6 +589,7 @@ class TestJob(unittest.TestCase):
         mock_tp = create_autospec(spec=BaseTrainingPlan, instance=True)
         mock_tp.get_model_params.return_value = MagicMock(spec=dict)
         mock_tp.source.return_value = MagicMock(spec=str)
+        mock_tp.local_params = None
         # Set up stub node state ids.
         fake_node_state_ids = {"node-1": "node-1_nsid", "node-2": "node-2_nsid"}
         # Set up a mock dataset.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -44,7 +44,7 @@ class TestSkLearnModelBuilder(unittest.TestCase):
         for sk_model in self.implemented_models:
             model = SkLearnModel(sk_model)
             with self.assertRaises(FedbiomedModelError):
-                val = model.this_method_does_not_exist()
+                _ = model.this_method_does_not_exist()
 
     def test_sklearnbuilder_4_test_sklearn_deepcopy(self):
         for sk_model in self.implemented_models:
@@ -62,7 +62,7 @@ class TestSkLearnModelBuilder(unittest.TestCase):
             # check that all attributes have different references
 
             for attribute, copied_attribute in zip(
-                model._instance.__dict__, copied_model._instance.__dict__
+                model._instance.__dict__, copied_model._instance.__dict__, strict=True
             ):
                 self.assertNotEqual(
                     id(getattr(model._instance, attribute)),
@@ -134,7 +134,7 @@ class TestSkLearnModel(unittest.TestCase):
 
         for invalid_model in invalid_models:
             with self.assertRaises(FedbiomedModelError):
-                model = SkLearnModel(invalid_model)
+                _model = SkLearnModel(invalid_model)
 
     def test_sklearnmodel_02_method_export(self):
         """Test that 'SklearnModel.export' works - in one specific case."""
@@ -171,6 +171,23 @@ class TestSkLearnModel(unittest.TestCase):
         ):
             self.sgdclass_model.reload("filename")
             self.assertDictEqual(self.sgdclass_model.get_weights(), coefs)
+
+    def test_sklearnmodel_03b_method_reload_with_local_params(self):
+        """Test that 'SklearnModel.reload' works with local_params."""
+        self.sgdclass_model.set_init_params({"n_classes": 3, "n_features": 5})
+        _original_intercept = self.sgdclass_model.model.intercept_.copy()
+        new_coefs = {
+            "coef_": np.array([[0.99]]),
+            "intercept_": np.array([0.99]),
+        }
+        self.sgdclass_model.model.coef_ = new_coefs["coef_"]
+        self.sgdclass_model.model.intercept_ = new_coefs["intercept_"]
+        with (
+            patch("joblib.load", return_value=self.sgdclass_model.model),
+            patch("builtins.open", mock_open()),
+        ):
+            # Reload accepting local_params kwarg without error.
+            self.sgdclass_model.reload("filename", local_params=["intercept_"])
 
     def test_sklearnmodel_04_set_init_params(self):
         # self.assertEqual(training_plan._model.n_iter_, 1)
@@ -379,6 +396,31 @@ class TestSkLearnModel(unittest.TestCase):
                 # should raise exception complaining about non reachable model layer
                 model.get_weights()
 
+    def test_sklearnmodel_09b_get_weights_unknown_local_params(self):
+        """Test that get_weights raises FedbiomedModelError for unknown local_params entries."""
+        for skmodel in self.models:
+            model = SkLearnModel(skmodel)
+            model.set_init_params(model_args={"n_classes": 2, "n_features": 3})
+            with self.assertRaises(FedbiomedModelError):
+                model.get_weights(local_params=["nonexistent_param"])
+
+    def test_sklearnmodel_09c_get_weights_with_local_params(self):
+        """Test that get_weights correctly excludes local_params from the output."""
+        for skmodel in self.models:
+            model = SkLearnModel(skmodel)
+            model.set_init_params(model_args={"n_classes": 2, "n_features": 3})
+            # With no local_params, both coef_ and intercept_ should be present.
+            full_weights = model.get_weights()
+            self.assertIn("coef_", full_weights)
+            self.assertIn("intercept_", full_weights)
+            # Excluding one param should remove it from the result.
+            weights_excl_coef = model.get_weights(local_params=["coef_"])
+            self.assertNotIn("coef_", weights_excl_coef)
+            self.assertIn("intercept_", weights_excl_coef)
+            weights_excl_intercept = model.get_weights(local_params=["intercept_"])
+            self.assertIn("coef_", weights_excl_intercept)
+            self.assertNotIn("intercept_", weights_excl_intercept)
+
     def test_sklearn_model_10_flatten_and_unflatten(self):
         """Tests flatten and unflatten methods of Sklearn methods"""
 
@@ -408,6 +450,23 @@ class TestSkLearnModel(unittest.TestCase):
             with self.assertRaises(FedbiomedModelError):
                 model.unflatten(["not-float-list"])
 
+    def test_sklearn_model_10b_flatten_and_unflatten_with_local_params(self):
+        """Test that flatten/unflatten respect local_params exclusion for SkLearnModel."""
+        inputs = np.array([[1, 2], [1, 1], [0, 1]])
+        target = np.array([0, 2, 1])
+        for skmodel in self.models:
+            model = SkLearnModel(skmodel)
+            model.set_init_params(model_args={"n_classes": 3, "n_features": 2})
+            model.model.partial_fit(inputs, target)
+            # Flatten excluding coef_.
+            flat_excl = model.flatten(local_params=["coef_"])
+            flat_full = model.flatten()
+            self.assertLess(len(flat_excl), len(flat_full))
+            # Unflatten should return only non-excluded params.
+            unflat = model.unflatten(flat_excl, local_params=["coef_"])
+            self.assertIn("intercept_", unflat)
+            self.assertNotIn("coef_", unflat)
+
     def test_sklearnmodel_11_set_weights(self):
         """Test that 'SkLearnModel.set_weights' works properly."""
         for skmodel in self.models:
@@ -425,6 +484,20 @@ class TestSkLearnModel(unittest.TestCase):
             self.assertTrue(
                 all(np.all(weights[key] == current[key]) for key in weights)
             )
+
+    def test_sklearnmodel_11b_set_weights_with_local_params(self):
+        """Test that 'SkLearnModel.set_weights' with local_params does not raise."""
+        for skmodel in self.models:
+            model = SkLearnModel(skmodel)
+            model.set_init_params(model_args={"n_classes": 3, "n_features": 2})
+            weights = {
+                key: np.random.normal(size=wgt.shape).astype(wgt.dtype)
+                for key, wgt in model.get_weights().items()
+            }
+            # Passing local_params should not raise and should still set the provided weights.
+            model.set_weights(weights, local_params=["coef_"])
+            current = model.get_weights()
+            self.assertEqual(current.keys(), weights.keys())
 
 
 class TestSklearnClassification(unittest.TestCase):
@@ -604,7 +677,7 @@ class TestTorchModel(unittest.TestCase):
         self.torch_optim.step()
 
         grads = self.model.get_weights()
-        for layer_name, values in grads.items():
+        for _layer_name, values in grads.items():
             self.assertTrue(torch.all(values))
 
     def test_torchmodel_02_get_weights(self):
@@ -619,6 +692,45 @@ class TestTorchModel(unittest.TestCase):
                 )
             )
 
+    def test_torchmodel_02b_get_weights_local_params_excluded(self):
+        """Test that local_params are excluded from get_weights output."""
+        all_weights = self.model.get_weights()
+        param_names = list(all_weights.keys())
+        self.assertGreaterEqual(len(param_names), 1)
+        # Exclude the first parameter via local_params.
+        excluded = param_names[:1]
+        weights = self.model.get_weights(local_params=excluded)
+        for name in excluded:
+            self.assertNotIn(name, weights)
+        for name in param_names[1:]:
+            self.assertIn(name, weights)
+
+    def test_torchmodel_02c_get_weights_unknown_local_params_raises(self):
+        """Test that unknown local_params entries raise FedbiomedModelError."""
+        with self.assertRaises(FedbiomedModelError):
+            self.model.get_weights(local_params=["nonexistent_layer"])
+
+    def test_torchmodel_02d_get_weights_exclude_buffers_false(self):
+        """Test that exclude_buffers=False includes buffers from state_dict."""
+
+        # Build a model that has a registered buffer.
+        class ModelWithBuffer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 1)
+                self.register_buffer("running_mean", torch.zeros(1))
+
+            def forward(self, x):
+                return self.linear(x)
+
+        buffered_model = TorchModel(ModelWithBuffer())
+        # exclude_buffers=True (default): buffer should not appear.
+        weights_no_buffers = buffered_model.get_weights(exclude_buffers=True)
+        self.assertNotIn("running_mean", weights_no_buffers)
+        # exclude_buffers=False: buffer should appear.
+        weights_with_buffers = buffered_model.get_weights(exclude_buffers=False)
+        self.assertIn("running_mean", weights_with_buffers)
+
     def test_torchmodel_03_set_weights(self):
         """Test that 'TorchModel.set_weights' works properly."""
         # Create random weights that are suitable for the model.
@@ -632,6 +744,32 @@ class TestTorchModel(unittest.TestCase):
         self.assertEqual(current.keys(), weights.keys())
         self.assertTrue(all(torch.all(weights[key] == current[key]) for key in weights))
 
+    def test_torchmodel_03b_set_weights_warn_missing_params(self):
+        """Test warning when missing trainable parameters."""
+        weights = self.model.get_weights()
+        # remove one parameter to simulate missing weight
+        missing_param = list(weights.keys())[0]
+        partial_weights = dict(weights)
+        partial_weights.pop(missing_param)
+
+        with patch("fedbiomed.common.models._torch.logger.warning") as mock_warn:
+            self.model.set_weights(partial_weights)
+
+        mock_warn.assert_called()
+
+    def test_torchmodel_03b_set_weights_ignore_local_params_warning(self):
+        """Test that missing local parameters do not trigger warnings."""
+        weights = self.model.get_weights()
+        # remove one parameter to simulate missing weight
+        missing_param = list(weights.keys())[0]
+        partial_weights = dict(weights)
+        partial_weights.pop(missing_param)
+
+        with patch("fedbiomed.common.models._torch.logger.warning") as mock_warn:
+            self.model.set_weights(partial_weights, local_params=[missing_param])
+
+        mock_warn.assert_not_called()
+
     def test_torchmodel_04_apply_updates_1(self):
         init_weights = copy.deepcopy(self.model.get_weights())
 
@@ -642,7 +780,7 @@ class TestTorchModel(unittest.TestCase):
 
         # checks
         for (layer, w), (_, updated_w) in zip(
-            init_weights.items(), updated_weights.items()
+            init_weights.items(), updated_weights.items(), strict=True
         ):
             self.assertFalse(torch.all(torch.isclose(w, updated_w)))
             self.assertTrue(
@@ -683,7 +821,7 @@ class TestTorchModel(unittest.TestCase):
         corrections = {
             layer_name: val
             for (layer_name, _), val in zip(
-                self.model.model.named_parameters(), correction_values
+                self.model.model.named_parameters(), correction_values, strict=True
             )
         }
 
@@ -692,8 +830,8 @@ class TestTorchModel(unittest.TestCase):
         # action
         self.model.add_corrections_to_gradients(corrections)
         # checks
-        for (layer_name, param), val in zip(
-            self.model.model.named_parameters(), correction_values
+        for (_layer_name, param), val in zip(
+            self.model.model.named_parameters(), correction_values, strict=True
         ):
             self.assertTrue(torch.all(torch.isclose(param.grad, val)))
 
@@ -764,6 +902,22 @@ class TestTorchModel(unittest.TestCase):
         with self.assertRaises(FedbiomedModelError):
             self.model.unflatten(["not-float-list"])
 
+    def test_torch_model_9b_flatten_and_unflatten_with_local_params(self):
+        """Test that flatten/unflatten respect local_params exclusion."""
+        all_weights = self.model.get_weights()
+        param_names = list(all_weights.keys())
+        # Exclude the bias (last param) via local_params.
+        excluded = [param_names[-1]]
+        flat_excl = self.model.flatten(local_params=excluded)
+        flat_full = self.model.flatten()
+        # Excluded flatten should be shorter than the full one.
+        self.assertLess(len(flat_excl), len(flat_full))
+        # Unflatten with the same exclusion should return all params except excluded.
+        unflat = self.model.unflatten(flat_excl, local_params=excluded)
+        for name in param_names[:-1]:
+            self.assertIn(name, unflat)
+        self.assertNotIn(excluded[0], unflat)
+
     def test_torchmodel_09_export(self):
         """Test that 'TorchModel.export' works properly."""
         with patch("torch.save") as save_patch:
@@ -797,6 +951,22 @@ class TestTorchModel(unittest.TestCase):
                 ]
             )
         )
+
+    def test_torchmodel_10b_reload_with_local_params(self):
+        """Test that 'TorchModel.reload' respects local_params (excluded weights kept)."""
+        d1 = self.model.model.state_dict()
+        # Record original value of the first parameter.
+        first_key = list(d1.keys())[0]
+        original_value = self.model.model.state_dict()[first_key].clone()
+        # Provide new weights that differ from original.
+        new_weights = {key: torch.randn_like(val) for key, val in d1.items()}
+        new_weights.pop(first_key)
+        with patch("torch.load", return_value=new_weights):
+            # Reload but treat the first key as local (should not be overwritten).
+            self.model.reload("filename", local_params=[first_key])
+        reloaded = self.model.model.state_dict()
+        # The local parameter should not have been changed.
+        self.assertTrue(torch.all(torch.eq(reloaded[first_key], original_value)))
 
     def test_torchmodel_11_reload_fails(self):
         """Test that 'TorchModel.reload' fails with a non-torch dump object."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -397,12 +397,13 @@ class TestSkLearnModel(unittest.TestCase):
                 model.get_weights()
 
     def test_sklearnmodel_09b_get_weights_unknown_local_params(self):
-        """Test that get_weights raises FedbiomedModelError for unknown local_params entries."""
+        """Test that get_weights logs a warning for unknown local_params entries."""
         for skmodel in self.models:
             model = SkLearnModel(skmodel)
             model.set_init_params(model_args={"n_classes": 2, "n_features": 3})
-            with self.assertRaises(FedbiomedModelError):
+            with patch("fedbiomed.common.models._sklearn.logger.warning") as mock_warn:
                 model.get_weights(local_params=["nonexistent_param"])
+            mock_warn.assert_called()
 
     def test_sklearnmodel_09c_get_weights_with_local_params(self):
         """Test that get_weights correctly excludes local_params from the output."""
@@ -705,10 +706,11 @@ class TestTorchModel(unittest.TestCase):
         for name in param_names[1:]:
             self.assertIn(name, weights)
 
-    def test_torchmodel_02c_get_weights_unknown_local_params_raises(self):
-        """Test that unknown local_params entries raise FedbiomedModelError."""
-        with self.assertRaises(FedbiomedModelError):
+    def test_torchmodel_02c_get_weights_unknown_local_params(self):
+        """Test that unknown local_params entries logs a warning."""
+        with patch("fedbiomed.common.models._sklearn.logger.warning") as mock_warn:
             self.model.get_weights(local_params=["nonexistent_layer"])
+        mock_warn.assert_called()
 
     def test_torchmodel_02d_get_weights_exclude_buffers_false(self):
         """Test that exclude_buffers=False includes buffers from state_dict."""

--- a/tests/test_node_state_agent.py
+++ b/tests/test_node_state_agent.py
@@ -141,6 +141,24 @@ class TestNodeStateAgent(unittest.TestCase):
             last_nodes_states_after_saving, last_nodes_states_before_saving
         )
 
+    def test_node_state_agent_9_load_fds_breakpoint(self):
+        fds_bkpt = {
+            "NODE_node_id": {
+                "name": "some-name",
+                "data_type": "some-type",
+                "tags": [
+                    "some-tags",
+                ],
+                "description": "some-description",
+                "dataset_id": "some-id",
+            }
+        }
+
+        nsa = NodeStateAgent(federated_dataset=FederatedDataset(None))
+        nsa.load_fds_breakpoint(fds_bkpt)
+
+        self.assertDictEqual(fds_bkpt, nsa._fds._data)
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/tests/test_node_state_manager.py
+++ b/tests/test_node_state_manager.py
@@ -3,10 +3,12 @@ import os
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
+
+from testsupport.fake_uuid import FakeUuid
+
 from fedbiomed.common.constants import NODE_STATE_PREFIX, __node_state_version__
 from fedbiomed.common.exceptions import FedbiomedNodeStateManagerError
-from fedbiomed.node.node_state_manager import NodeStateManager, NodeStateFileName
-from testsupport.fake_uuid import FakeUuid
+from fedbiomed.node.node_state_manager import NodeStateFileName, NodeStateManager
 
 
 class TestNodeStateManager(unittest.TestCase):
@@ -67,7 +69,7 @@ class TestNodeStateManager(unittest.TestCase):
         db_patcher.start()
 
         with self.assertRaises(FedbiomedNodeStateManagerError):
-            nsm = NodeStateManager(self.temp_dir.name, "test-node-id", "path/to/db")
+            _nsm = NodeStateManager(self.temp_dir.name, "test-node-id", "path/to/db")
 
         query_patcher.stop()
         table_patcher.stop()
@@ -258,6 +260,14 @@ class TestNodeStateFileName(unittest.TestCase):
                     f"error in NodeStateFileName, entry {entry_value} doesn't respect formatting convention"
                     f" details : {te}",
                 )
+
+    def test_node_state_file_name_2_model_weights_entry(self):
+        """Test that MODEL_WEIGHTS entry exists and formats correctly."""
+        entry = NodeStateFileName.MODEL_WEIGHTS.value
+
+        formatted = entry % ("round_id", "node_state_id")
+
+        self.assertEqual(formatted, "persistent_model_weights_round_id_node_state_id")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -4,8 +4,8 @@
 """Unit tests for the declearn-interfacing Optimizer class."""
 
 import json
-from typing import Dict, List
 import unittest
+from typing import Dict, List
 from unittest import mock
 
 import declearn
@@ -45,7 +45,7 @@ class TestOptimizer(unittest.TestCase):
             modules=modules,
             regularizers=regularizers,
         )
-        d_opt = getattr(optim, "_optimizer")
+        d_opt = optim._optimizer
         self.assertIsInstance(d_opt, DeclearnOptimizer)
         self.assertEqual(d_opt.lrate, 1e-3)
         self.assertEqual(d_opt.w_decay, 1e-4)
@@ -138,10 +138,10 @@ class TestOptimizer(unittest.TestCase):
         mockaux = mock.create_autospec(AuxVar, instance=True)
         mod_aux = mock.create_autospec(OptiModule, instance=True)
         mod_aux.collect_aux_var.return_value = mockaux
-        setattr(mod_aux, "aux_name", "mock-module-1")
+        mod_aux.aux_name = "mock-module-1"
         mod_nox = mock.create_autospec(OptiModule, instance=True)
         mod_nox.collect_aux_var.return_value = None
-        setattr(mod_nox, "aux_name", "mock-module-2")
+        mod_nox.aux_name = "mock-module-2"
         optim = Optimizer(lr=0.001, modules=[mod_aux, mod_nox])
         # Call 'get_aux' and assert that the results match expectations.
         aux = optim.get_aux()
@@ -166,7 +166,7 @@ class TestOptimizer(unittest.TestCase):
         """Test `Optimizer.set_aux` using a mock Module."""
         # Set up an Optimizer, a mock module and mock aux-var inputs.
         module = mock.create_autospec(OptiModule, instance=True)
-        setattr(module, "aux_name", "mock-module")
+        module.aux_name = "mock-module"
         optim = Optimizer(lr=0.001, modules=[module])
         state = mock.MagicMock()
         # Call 'set_aux' and assert that the information was passed.
@@ -301,6 +301,99 @@ class TestOptimizer(unittest.TestCase):
         """Test that `Optimizer.load_state` exceptions are wrapped."""
         with self.assertRaises(FedbiomedOptimizerError):
             Optimizer.load_state({})
+
+    def test_optimizer_19_filter_aux(self):
+        """Test that filter_aux removes local parameters from aux vectors."""
+        optim = Optimizer(lr=0.001)
+        aux_var = ScaffoldAuxVar(
+            delta=Vector.build(
+                {
+                    "weight": torch.ones(2, 2),
+                    "bias": torch.ones(2),
+                }
+            ),
+            clients={"node-1"},
+        )
+        aux = {"scaffold": aux_var}
+        filtered = optim.filter_aux(aux, local_params=["bias"])
+        self.assertIn("scaffold", filtered)
+        self.assertNotIn("bias", filtered["scaffold"].delta.coefs)
+        self.assertIn("weight", filtered["scaffold"].delta.coefs)
+
+    def test_optimizer_20_filter_aux_invalid_aux(self):
+        """Test filter_aux fails if aux_vars is not a dict."""
+        optim = Optimizer(lr=0.001)
+        with self.assertRaises(FedbiomedOptimizerError):
+            optim.filter_aux(aux_vars="not-a-dict", local_params=["bias"])
+
+    def test_optimizer_21_filter_aux_invalid_vector_structure(self):
+        """Test filter_aux fails when vector.coefs is not a dict."""
+        optim = Optimizer(lr=0.001)
+        bad_vector = mock.MagicMock()
+        bad_vector.coefs = "not-a-dict"
+        auxvar = mock.MagicMock()
+        auxvar.delta = bad_vector
+        aux = {"module": auxvar}
+        with self.assertRaises(FedbiomedOptimizerError):
+            optim.filter_aux(aux, local_params=["bias"])
+
+    def test_optimizer_22_restore_aux(self):
+        """Test that restore_aux recreates missing local parameters."""
+        optim = Optimizer(lr=0.001)
+        aux_var = ScaffoldAuxVar(
+            delta=Vector.build({"weight": torch.ones(2, 2)}), clients={"node-1"}
+        )
+        aux = {"scaffold": aux_var}
+        reference_params = {"weight": torch.ones(2, 2), "bias": torch.ones(2)}
+        restored = optim.restore_aux(
+            aux_vars=aux, reference_params=reference_params, local_params=["bias"]
+        )
+        self.assertIn("bias", restored["scaffold"].delta.coefs)
+        self.assertTrue(
+            torch.equal(
+                restored["scaffold"].delta.coefs["bias"],
+                torch.zeros_like(reference_params["bias"]),
+            )
+        )
+
+    def test_optimizer_23_restore_aux_invalid_aux(self):
+        """Test restore_aux fails if aux_vars is not a dict."""
+        optim = Optimizer(lr=0.001)
+        with self.assertRaises(FedbiomedOptimizerError):
+            optim.restore_aux("not-a-dict", {}, [])
+
+    def test_optimizer_24_restore_aux_vector_build_fails(self):
+        """Test restore_aux wraps Vector.build failure."""
+        optim = Optimizer(lr=0.001)
+        aux = {}
+        with mock.patch("declearn.model.api.Vector.build", side_effect=RuntimeError):
+            with self.assertRaises(FedbiomedOptimizerError):
+                optim.restore_aux(aux, {"w": torch.ones(1)}, ["w"])
+
+    def test_optimizer_25_restore_aux_invalid_vector_structure(self):
+        """Test restore_aux fails when vector.coefs is invalid."""
+        optim = Optimizer(lr=0.001)
+        bad_vector = mock.MagicMock()
+        bad_vector.coefs = "not-a-dict"
+        auxvar = mock.MagicMock()
+        auxvar.delta = bad_vector
+        aux = {"module": auxvar}
+        with self.assertRaises(FedbiomedOptimizerError):
+            optim.restore_aux(aux, {"w": torch.ones(1)}, ["w"])
+
+    def test_optimizer_25_restore_aux_missing_reference(self):
+        """Test restore_aux fails if reference tensor is missing."""
+        optim = Optimizer(lr=0.001)
+        aux_var = ScaffoldAuxVar(
+            delta=Vector.build({"weight": torch.ones(2, 2)}), clients={"node-1"}
+        )
+        aux = {"scaffold": aux_var}
+        with self.assertRaises(FedbiomedOptimizerError):
+            optim.restore_aux(
+                aux,
+                reference_params={"weight": torch.ones(2, 2)},
+                local_params=["bias"],
+            )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_round.py
+++ b/tests/test_round.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 import unittest
 from typing import Any, Dict, Optional, Tuple
-from unittest.mock import MagicMock, PropertyMock, create_autospec, patch
+from unittest.mock import MagicMock, PropertyMock, call, create_autospec, patch
 
 import numpy as np
 import pandas as pd
@@ -48,6 +48,7 @@ from fedbiomed.common.optimizers.declearn import (
 )
 from fedbiomed.common.optimizers.generic_optimizers import DeclearnOptimizer
 from fedbiomed.common.training_plans import BaseTrainingPlan
+from fedbiomed.node.node_state_manager import NodeStateFileName
 from fedbiomed.node.round import Round
 from fedbiomed.node.secagg._secagg_round import _SecaggSchemeRound
 from fedbiomed.node.training_plan_security_manager import TrainingPlanSecurityManager
@@ -94,6 +95,12 @@ class TestRound(unittest.TestCase):
         self.ic_from_spec_mock = self.ic_from_spec_patch.start()
         self.ic_from_file_mock = self.ic_from_file_patch.start()
         self.state_manager_mock = self.state_manager_patch.start()
+        node_state = {
+            "optimizer_state": None,
+            "testing_dataset": None,
+            "persistent_model_weights": None,
+        }
+        self.state_manager_mock.return_value.get.return_value = node_state
 
         type(self.state_manager_mock.return_value).state_id = PropertyMock(
             return_value="test-state-id"
@@ -879,10 +886,24 @@ class TestRound(unittest.TestCase):
         # Attach fake auxiliary variables (as though pre-downloaded).
         mock_aux_var = {"module": create_autospec(AuxVar, instance=True)}
         self.r1.aux_vars = mock_aux_var
+        # Mock functions used for local parameters
+        self.r1.training_plan.get_model_params.return_value = {"w": 1, "w_local": 2}
+        self.r1.training_plan.filter_model_params_by_tags.return_value = {"w_local": 2}
+        mock_aux_var_after_restore = {"module": create_autospec(AuxVar, instance=True)}
+        mock_optim.restore_aux.return_value = mock_aux_var_after_restore
         # Call the tested method and verify its outputs and effects.
         msg = self.r1.process_optim_aux_var()
         self.assertEqual(msg, None)
-        mock_optim.set_aux.assert_called_once_with(mock_aux_var)
+        self.r1.training_plan.get_model_params.assert_called_once_with(
+            only_trainable=False, exclude_buffers=False, local_params=None
+        )
+        self.r1.training_plan.filter_model_params_by_tags.assert_called_once_with(
+            {"w": 1, "w_local": 2}, required_tags={"local"}
+        )
+        mock_optim.restore_aux.assert_called_once_with(
+            mock_aux_var, {"w": 1, "w_local": 2}, ["w_local"]
+        )
+        mock_optim.set_aux.assert_called_once_with(mock_aux_var_after_restore)
 
     def test_round_13_process_optim_aux_var_without_aux_var(self):
         """Test that 'process_optim_aux_var' exits properly without aux vars."""
@@ -938,7 +959,7 @@ class TestRound(unittest.TestCase):
         # Call the tested method, verifying that it returns an error.
         msg = self.r1.process_optim_aux_var()
         self.assertTrue(fake_error in msg)
-        mock_optim.set_aux.assert_called_once_with(mock_aux_var)
+        mock_optim.set_aux.assert_called_once()
 
     def test_round_17_collect_optim_aux_var(self):
         """Test that 'collect_optim_aux_var' works properly with an Optimizer."""
@@ -949,10 +970,24 @@ class TestRound(unittest.TestCase):
         mock_b_opt.optimizer = mock_optim
         self.r1.training_plan = create_autospec(BaseTrainingPlan, instance=True)
         self.r1.training_plan.optimizer.return_value = mock_b_opt
-        # Call the tested method and verify its outputs.
+        # Mock the removal of auxiliary variables
+        full_aux_var = {"module": create_autospec(AuxVar, instance=True)}
+        mock_optim.get_aux.return_value = full_aux_var
+        self.r1.training_plan.get_model_params.return_value = {"w": 1, "w_local": 2}
+        self.r1.training_plan.filter_model_params_by_tags.return_value = {"w_local": 2}
+        mock_aux_var_after_filter = {"module": create_autospec(AuxVar, instance=True)}
+        mock_optim.filter_aux.return_value = mock_aux_var_after_filter
+        # Call the tested method and verify its outputs and effects.
         aux_var = self.r1.collect_optim_aux_var()
-        self.assertEqual(aux_var, mock_optim.get_aux.return_value)
+        self.assertEqual(aux_var, mock_aux_var_after_filter)
         mock_optim.get_aux.assert_called_once()
+        self.r1.training_plan.get_model_params.assert_called_once_with(
+            only_trainable=False, exclude_buffers=False, local_params=None
+        )
+        self.r1.training_plan.filter_model_params_by_tags.assert_called_once_with(
+            {"w": 1, "w_local": 2}, required_tags={"local"}
+        )
+        mock_optim.filter_aux.assert_called_once_with(full_aux_var, ["w_local"])
 
     def test_round_18_collect_optim_aux_var_without_optimizer(self):
         """Test that 'collect_optim_aux_var' works properly without an Optimizer."""
@@ -975,7 +1010,7 @@ class TestRound(unittest.TestCase):
 
     @patch("fedbiomed.common.utils.import_class_object_from_file")
     @patch("fedbiomed.node.round.SecaggRound")
-    def test_round_26_run_model_training_secagg_with_optim_aux_var(
+    def test_round_26_run_model_training_secagg_with_optim_aux_var_no_local_params(
         self,
         secagg_round,
         ic_from_file,
@@ -989,6 +1024,8 @@ class TestRound(unittest.TestCase):
         base_optimizer.save_state.return_value = None
         training_plan.optimizer.return_value = base_optimizer
         training_plan.optimizer_args.return_value = {}
+        training_plan.get_dp_controller.return_value = None
+        training_plan.filter_model_params_by_tags.return_value = {}
         # Set deterministic output model parameters and auxiliary variables.
         training_plan.after_training_params.return_value = [0.1, 0.2, 0.3]
 
@@ -1004,6 +1041,7 @@ class TestRound(unittest.TestCase):
                 return {"cryptable": self.cryptable}, {"cleartext": self.cleartext}
 
         fbm_optimizer.get_aux.return_value = {"module": StubAuxVar()}
+        fbm_optimizer.filter_aux.return_value = {"module": StubAuxVar()}
         # Patch things to approve the training plan and use it in the round.
         ic_from_file.return_value = (MagicMock(), training_plan)
 
@@ -1068,7 +1106,8 @@ class TestRound(unittest.TestCase):
     ):
         self.r1.experiment_id = 1234
         state_id = "state_id_1234"
-        path_state = "/path/to/state"
+        path_state_optimizer = "/path/to/state/optimizer"
+        path_state_weights = "/path/to/state/weights"
 
         training_plan_mock = MagicMock(
             spec=BaseTrainingPlan, type=MagicMock(), _model=MagicMock(spec=Model)
@@ -1078,25 +1117,35 @@ class TestRound(unittest.TestCase):
         node_state = {
             "optimizer_state": {
                 "optimizer_type": "optimizer_type",
-                "state_path": path_state,
+                "state_path": path_state_optimizer,
             },
             "testing_dataset": None,
+            "persistent_model_weights": {"state_path": path_state_weights},
         }
         self.state_manager_mock.return_value.get.return_value = node_state
         get_optim_patch.return_value = MagicMock(
             spec=DeclearnOptimizer,
             __class__="optimizer_type",
         )
+        serializer_patch.load.side_effect = [{"config": {}, "states": {}}, {"w": 123}]
         self.r1._load_round_state(state_id)
 
         # checks
         # FIXME: in future version, we should check each call to Serializer.load
-        serializer_patch.load.assert_called_once_with(path_state)
+        serializer_patch.load.assert_has_calls(
+            [
+                call(path_state_optimizer),
+                call(path_state_weights),
+            ]
+        )
 
         # check Optimizer.load_state call
         get_optim_patch.return_value.load_state.assert_called_once_with(
-            serializer_patch.load.return_value, load_from_state=True
+            {"config": {}, "states": {}}, load_from_state=True
         )
+
+        # check persistent model weights
+        assert self.r1._persistent_model_weights == {"w": 123}
 
     @patch("fedbiomed.node.round.logger")
     @patch("fedbiomed.node.round.Serializer")
@@ -1119,6 +1168,7 @@ class TestRound(unittest.TestCase):
                 "state_path": path_state,
             },
             "testing_dataset": None,
+            "persistent_model_weights": None,
         }
         self.state_manager_mock.return_value.get.return_value = node_state
         get_optim_patch.return_value = MagicMock(
@@ -1160,12 +1210,32 @@ class TestRound(unittest.TestCase):
         }
         self.r1.testing_arguments = {"test_ratio": test_ratio}
 
-        optim_path = "path/to/folder/containing/state/files"
-        self.state_manager_mock.return_value.generate_folder_and_create_file_name.return_value = optim_path
+        optim_path = "path/to/folder/containing/optim/state/files"
+        weights_path = "path/to/folder/containing/weight/state/files"
+        self.state_manager_mock.return_value.generate_folder_and_create_file_name.side_effect = [
+            optim_path,
+            weights_path,
+        ]
         get_optim_patch.return_value = MagicMock(
             spec=DeclearnOptimizer,
             __class__="optimizer_type",
         )
+
+        training_plan_mock = MagicMock(
+            spec=BaseTrainingPlan, type=MagicMock(), _model=MagicMock(spec=Model)
+        )
+        training_plan_mock.get_model_params.return_value = {
+            "_module.w_renamed": 1,
+            "w_persistent": 2,
+        }
+        training_plan_mock.filter_model_params_by_tags.return_value = {"w_renamed": 1}
+        mock_dp = MagicMock()
+        mock_dp.rename_params.return_value = (
+            {"w_renamed": 1, "w_persistent": 2},
+            {"w_renamed": "_module.w_renamed"},
+        )
+        training_plan_mock.get_dp_controller.return_value = mock_dp
+        self.r1.training_plan = training_plan_mock
 
         # adding a function that add additional dictionary entries through reference
         self.state_manager_mock.return_value.add.side_effect = lambda x, y: y.update(
@@ -1184,15 +1254,37 @@ class TestRound(unittest.TestCase):
                 "testing_index": testing_idx,
                 "test_ratio": test_ratio,
             },
+            "persistent_model_weights": {"state_path": weights_path},
         }
 
         expected_state = copy.deepcopy(added_state)
         expected_state.update({"version_node_id": "1", "state_id": "state_id_1234"})
         get_optim_patch.return_value.save_state.assert_called_once()
-        serializer_patch.dump.assert_called_once_with(
-            get_optim_patch.return_value.save_state.return_value, path=optim_path
+        serializer_patch.dump.assert_has_calls(
+            [
+                call(
+                    get_optim_patch.return_value.save_state.return_value,
+                    path=optim_path,
+                ),
+                call({"w_renamed": 1}, path=weights_path),
+            ]
         )
-
+        self.state_manager_mock.return_value.generate_folder_and_create_file_name.assert_has_calls(
+            [
+                call("1234", 34, NodeStateFileName.OPTIMIZER),
+                call("1234", 34, NodeStateFileName.MODEL_WEIGHTS),
+            ]
+        )
+        training_plan_mock.get_model_params.assert_called_once_with(
+            only_trainable=False, exclude_buffers=False, local_params=None
+        )
+        training_plan_mock.get_dp_controller.assert_called_once()
+        mock_dp.rename_params.assert_called_once_with(
+            {"_module.w_renamed": 1, "w_persistent": 2}
+        )
+        training_plan_mock.filter_model_params_by_tags.assert_called_once_with(
+            params={"w_renamed": 1, "w_persistent": 2}, required_tags={"persistent"}
+        )
         self.state_manager_mock.return_value.add.assert_called_once_with(
             "1234", expected_state
         )
@@ -1216,6 +1308,13 @@ class TestRound(unittest.TestCase):
         get_optim_patch.return_value = MagicMock(
             save_state=MagicMock(return_value=None)
         )
+        training_plan_mock = MagicMock(
+            spec=BaseTrainingPlan, type=MagicMock(), _model=MagicMock(spec=Model)
+        )
+        training_plan_mock.get_model_params.return_value = {"w": 1}
+        training_plan_mock.filter_model_params_by_tags.return_value = {}
+        training_plan_mock.get_dp_controller.return_value = None
+        self.r1.training_plan = training_plan_mock
 
         self.state_manager_mock.return_value.add.side_effect = lambda x, y: y.update(
             {"version_node_id": "1", "state_id": "state_id_1234"}
@@ -1230,6 +1329,7 @@ class TestRound(unittest.TestCase):
                 "testing_index": testing_idx,
                 "test_ratio": test_ratio,
             },
+            "persistent_model_weights": None,
         }
 
         self.assertDictEqual(res, expected_state)
@@ -1252,6 +1352,9 @@ class TestRound(unittest.TestCase):
             "testing_index": testing_idx,
             "training_index": training_idx,
         }
+        training_plan_mock.get_model_params.return_value = {"w": 1}
+        training_plan_mock.filter_model_params_by_tags.return_value = {}
+        training_plan_mock.get_dp_controller.return_value = None
 
         uuid_patch.return_value = FakeUuid()
         experiment_id = _id = FakeUuid.VALUE
@@ -1298,6 +1401,9 @@ class TestRound(unittest.TestCase):
         training_plan_mock = MagicMock(
             spec=BaseTrainingPlan, type=MagicMock(), _model=MagicMock(spec=Model)
         )
+        training_plan_mock.get_model_params.return_value = {"w": 1}
+        training_plan_mock.filter_model_params_by_tags.return_value = {}
+        training_plan_mock.get_dp_controller.return_value = None
 
         # data_manager = MagicMock(spec=DataManager)
         # data_manager.dataset = [[1, 2, 3],
@@ -1400,6 +1506,51 @@ class TestRound(unittest.TestCase):
         self.state_manager_mock.return_value.initialize.assert_called_once_with(
             previous_state_id=previous_state_id, testing=False
         )
+
+    def test_round_34_reconstruct_full_params(self):
+        self.r1.training_plan = MagicMock()
+
+        initial = {
+            "a": 1,
+            "b": 2,
+            "c": 3,
+            "d": 4,
+        }
+
+        received = {
+            "a": 10,
+            "b": 20,
+            "c": 30,
+            "d": 40,
+        }
+
+        persistent = {"a": 100}
+
+        # Mock tag filtering behavior
+        def filter_params(params, required_tags=None, forbidden_tags=None):
+            if required_tags == {"local", "persistent"}:
+                return {"a": params["a"]}
+            if required_tags == {"local"} and forbidden_tags == {"persistent"}:
+                return {"b": params["b"]}
+            return {}
+
+        self.r1.training_plan.filter_model_params_by_tags.side_effect = filter_params
+
+        # Test 1: with already persistent parameters saved
+        result = self.r1._reconstruct_full_params(initial, received, persistent)
+
+        assert result["a"] == 100  # persistent overrides with stored parameters
+        assert result["b"] == 2  # local-only reset to initial
+        assert result["c"] == 30  # unchanged from researcher
+        assert result["d"] == 40  # unchanged from researcher
+
+        # Test 2: with no persistent parameters saved
+        result = self.r1._reconstruct_full_params(initial, received, None)
+
+        assert result["a"] == 1  # persistent overrides with initial values
+        assert result["b"] == 2  # local-only reset to initial
+        assert result["c"] == 30  # unchanged from researcher
+        assert result["d"] == 40  # unchanged from researcher
 
 
 ########################################

--- a/tests/test_round.py
+++ b/tests/test_round.py
@@ -1520,7 +1520,11 @@ class TestRound(unittest.TestCase):
         )
 
     def test_round_34_reconstruct_full_params(self):
-        self.r1.training_plan = MagicMock()
+        # Scenario:
+        # - a is tagged as "local" and "persistent" (not shared and aggregated with researcher, and saved locally)
+        # - b is tagged as "local" only (not shared and aggregated with researcher, and not saved locally)
+        # - c is tagged as "persistent" only (shared and aggregated with researcher, but not saved locally)
+        # - d is untagged (global)
 
         initial = {
             "a": 1,
@@ -1530,38 +1534,28 @@ class TestRound(unittest.TestCase):
         }
 
         received = {
-            "a": 10,
-            "b": 20,
             "c": 30,
             "d": 40,
         }
 
-        persistent = {"a": 100}
-
-        # Mock tag filtering behavior
-        def filter_params(params, required_tags=None, forbidden_tags=None):
-            if required_tags == {"local", "persistent"}:
-                return {"a": params["a"]}
-            if required_tags == {"local"} and forbidden_tags == {"persistent"}:
-                return {"b": params["b"]}
-            return {}
-
-        self.r1.training_plan.filter_model_params_by_tags.side_effect = filter_params
+        persistent = {"a": 100, "c": 300}
 
         # Test 1: with already persistent parameters saved
         result = self.r1._reconstruct_full_params(initial, received, persistent)
 
-        assert result["a"] == 100  # persistent overrides with stored parameters
+        assert (
+            result["a"] == 100
+        )  # local and persistent overrides with stored parameters
         assert result["b"] == 2  # local-only reset to initial
-        assert result["c"] == 30  # unchanged from researcher
+        assert result["c"] == 30  # persistent only, unchanged from researcher
         assert result["d"] == 40  # unchanged from researcher
 
         # Test 2: with no persistent parameters saved
         result = self.r1._reconstruct_full_params(initial, received, None)
 
-        assert result["a"] == 1  # persistent overrides with initial values
+        assert result["a"] == 1  # local and persistent overrides with initial values
         assert result["b"] == 2  # local-only reset to initial
-        assert result["c"] == 30  # unchanged from researcher
+        assert result["c"] == 30  # persistent only, unchanged from researcher
         assert result["d"] == 40  # unchanged from researcher
 
 

--- a/tests/test_round.py
+++ b/tests/test_round.py
@@ -943,23 +943,35 @@ class TestRound(unittest.TestCase):
         self.assertIsInstance(msg, str)
 
     def test_round_16_process_optim_aux_var_with_optimizer_error(self):
-        """Test that 'process_optim_aux_var' documents 'Optimizer.set_aux' error."""
-        # Set up a Round with fake pre-downloaded aux vars.
-        mock_aux_var = {"module": create_autospec(AuxVar, instance=True)}
-        self.r1.aux_vars = mock_aux_var
-        # Set up a mock BaseOptimizer with an attached failing Optimizer.
-        mock_optim = create_autospec(Optimizer, instance=True)
-        fake_error = "fake FedbiomedOptimizerError on 'set_aux' call"
-        mock_optim.set_aux.side_effect = FedbiomedOptimizerError(fake_error)
+        """Test that 'process_optim_aux_var' returns an error when 'restore_aux' or 'set_aux' raise."""
         mock_b_opt = create_autospec(BaseOptimizer, instance=True)
-        mock_b_opt.optimizer = mock_optim
-        # Attach the former to the Round's mock TrainingPlan.
         self.r1.training_plan = create_autospec(BaseTrainingPlan, instance=True)
         self.r1.training_plan.optimizer.return_value = mock_b_opt
-        # Call the tested method, verifying that it returns an error.
+        self.r1.training_plan.get_model_params.return_value = {"w": 1}
+        self.r1.training_plan.filter_model_params_by_tags.return_value = {}
+
+        # Sub-case 1: restore_aux raises.
+        mock_aux_var = {"module": create_autospec(AuxVar, instance=True)}
+        self.r1.aux_vars = mock_aux_var
+        mock_optim = create_autospec(Optimizer, instance=True)
+        restore_error = "fake FedbiomedOptimizerError on 'restore_aux' call"
+        mock_optim.restore_aux.side_effect = FedbiomedOptimizerError(restore_error)
+        mock_b_opt.optimizer = mock_optim
         msg = self.r1.process_optim_aux_var()
-        self.assertTrue(fake_error in msg)
-        mock_optim.set_aux.assert_called_once()
+        self.assertIsInstance(msg, str)
+        self.assertIn(restore_error, msg)
+        mock_optim.restore_aux.assert_called_once()
+        mock_optim.set_aux.assert_not_called()
+
+        # Sub-case 2: set_aux raises.
+        mock_optim2 = create_autospec(Optimizer, instance=True)
+        set_aux_error = "fake FedbiomedOptimizerError on 'set_aux' call"
+        mock_optim2.set_aux.side_effect = FedbiomedOptimizerError(set_aux_error)
+        mock_b_opt.optimizer = mock_optim2
+        msg = self.r1.process_optim_aux_var()
+        self.assertIsInstance(msg, str)
+        self.assertIn(set_aux_error, msg)
+        mock_optim2.set_aux.assert_called_once()
 
     def test_round_17_collect_optim_aux_var(self):
         """Test that 'collect_optim_aux_var' works properly with an Optimizer."""

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -372,6 +372,30 @@ class TestScaffold(unittest.TestCase):
                     training_plan=training_plan, training_replies=training_replies
                 )
 
+        # test case where local_params is non-None: should be forwarded to get_model_params
+        lr = {"layer-1": 0.1, "layer-2": 0.2}
+        n_model_layer = len(lr)
+        training_replies = {
+            node_id: {"node_id": node_id, "optimizer_args": {"lr": lr}}
+            for node_id in self.node_ids
+        }
+        training_plan2 = MagicMock()
+        training_plan2.local_params = ["layer-3.weight"]
+        get_model_params_mock2 = MagicMock()
+        get_model_params_mock2.__len__ = MagicMock(return_value=n_model_layer)
+        training_plan2.get_model_params.return_value = get_model_params_mock2
+        fds2 = FederatedDataset({node_id: {} for node_id in self.node_ids})
+        scaffold2 = Scaffold(fds=fds2)
+        node_lr = scaffold2.set_nodes_learning_rate_after_training(
+            training_plan=training_plan2, training_replies=training_replies
+        )
+        training_plan2.get_model_params.assert_called_with(
+            only_trainable=False,
+            exclude_buffers=True,
+            local_params=["layer-3.weight"],
+        )
+        self.assertDictEqual(node_lr, {node_id: lr for node_id in self.node_ids})
+
 
 class TestIntegrationScaffold(unittest.TestCase):
     # For testing training_plan setter of Experiment

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -51,7 +51,7 @@ class TestScaffold(unittest.TestCase):
         self.replies = [self.replies]
         self.weights = [
             {node_id: random.random()}
-            for (node_id, _) in zip(self.node_ids, self.models)
+            for (node_id, _) in zip(self.node_ids, self.models, strict=True)
         ]
 
         # setting all coefficients of `zero_model` to 0
@@ -206,6 +206,7 @@ class TestScaffold(unittest.TestCase):
         for v_s, v_f in zip(
             aggregated_model_params_scaffold.values(),
             aggregated_model_params_fedavg.values(),
+            strict=True,
         ):
             self.assertTrue(torch.isclose(v_s, v_f * 0.2).all())
 
@@ -248,8 +249,10 @@ class TestScaffold(unittest.TestCase):
         agg_args = agg.create_aggregator_args(self.model.state_dict(), self.node_ids)
 
         for node_id in self.node_ids:
-            for (k, v), (k0, v0) in zip(
-                agg.nodes_deltas[node_id].items(), self.zero_model.state_dict().items()
+            for (_k, v), (_k0, v0) in zip(
+                agg.nodes_deltas[node_id].items(),
+                self.zero_model.state_dict().items(),
+                strict=True,
             ):
                 self.assertTrue(torch.isclose(v, v0).all())
 
@@ -292,7 +295,7 @@ class TestScaffold(unittest.TestCase):
             save_patch.call_count, 2, "'Serializer.dump' should be called 2 times"
         )
 
-        for node_id in self.node_ids:
+        for _node_id in self.node_ids:
             self.assertIsInstance(state["parameters"], str)
 
         self.assertEqual(state["class"], Scaffold.__name__)
@@ -331,17 +334,23 @@ class TestScaffold(unittest.TestCase):
             for node_id in self.node_ids
         }
         training_plan = MagicMock()
+        training_plan.local_params = None
         get_model_params_mock = MagicMock()
         get_model_params_mock.__len__ = MagicMock(return_value=n_model_layer)
         training_plan.get_model_params.return_value = get_model_params_mock
         fds = FederatedDataset({node_id: {} for node_id in self.node_ids})
         scaffold = Scaffold(fds=fds)
-        for n_round in range(n_rounds):
+        for _n_round in range(n_rounds):
             node_lr = scaffold.set_nodes_learning_rate_after_training(
                 training_plan=training_plan, training_replies=training_replies
             )
             test_node_lr = {node_id: lr for node_id in self.node_ids}
             self.assertDictEqual(node_lr, test_node_lr)
+        training_plan.get_model_params.assert_called_with(
+            only_trainable=False,
+            exclude_buffers=True,
+            local_params=None,
+        )
 
         # same test with a mix of present and absent nodes in training_replies
         fds = FederatedDataset({node_id: {} for node_id in self.node_ids + ["node_99"]})
@@ -349,7 +358,7 @@ class TestScaffold(unittest.TestCase):
         optim_w.get_learning_rate = MagicMock(return_value=lr)
         training_plan.optimizer = MagicMock(return_value=optim_w)
         scaffold = Scaffold(fds=fds)
-        for n_round in range(n_rounds):
+        for _n_round in range(n_rounds):
             node_lr = scaffold.set_nodes_learning_rate_after_training(
                 training_plan=training_plan, training_replies=training_replies
             )
@@ -357,7 +366,7 @@ class TestScaffold(unittest.TestCase):
         # test case where len(lr) != n_model_layer
         lr.update({"layer-4": 0.333})
         training_plan.get_learning_rate = MagicMock(return_value=lr)
-        for n_round in range(n_rounds):
+        for _n_round in range(n_rounds):
             with self.assertRaises(FedbiomedAggregatorError):
                 scaffold.set_nodes_learning_rate_after_training(
                     training_plan=training_plan, training_replies=training_replies
@@ -400,7 +409,10 @@ class TestIntegrationScaffold(unittest.TestCase):
             # for test Exprmient 26 (test_experiment_26_run_once_with_scaffold_and_training_args)
             # this has be done to avoid mocking a private attribute (`_dp_controller`), which is inappropriate
             self._dp_controller = MagicMock()
-            do_nothing = lambda x: x
+
+            def do_nothing(x):
+                return x
+
             self._dp_controller.side_effect = do_nothing
 
         def init_model(self, args):
@@ -439,7 +451,7 @@ class TestIntegrationScaffold(unittest.TestCase):
 
         self.weights = [
             {node_id: random.random()}
-            for (node_id, _) in zip(self.node_ids, self.models)
+            for (node_id, _) in zip(self.node_ids, self.models, strict=True)
         ]
 
     # after the tests
@@ -483,7 +495,7 @@ class TestIntegrationScaffold(unittest.TestCase):
             scaffold = Scaffold(server_lr=1)
 
             scaffold.set_fds(self.fds)
-            agg_params = scaffold.aggregate(
+            scaffold.aggregate(
                 local_models,
                 self.weights,
                 global_model=global_params,
@@ -528,7 +540,7 @@ class TestIntegrationScaffold(unittest.TestCase):
         scaffold = Scaffold(server_lr=server_lr)
 
         scaffold.set_fds(self.fds)
-        agg_params = scaffold.aggregate(
+        scaffold.aggregate(
             local_models,
             self.weights,
             global_model=global_params,
@@ -572,7 +584,7 @@ class TestIntegrationScaffold(unittest.TestCase):
             for i, node_id in enumerate(self.node_ids)
         }
 
-        agg_params_2 = loaded_scaffold.aggregate(
+        loaded_scaffold.aggregate(
             local_models,
             self.weights,
             global_model=global_params,
@@ -601,9 +613,10 @@ class TestIntegrationScaffold(unittest.TestCase):
             )
         # delta_i = (c_i - c)
         for node_id in self.node_ids:
-            for (k_ns, v_ns), (k_d, v_d) in zip(
+            for (k_ns, v_ns), (_k_d, v_d) in zip(
                 loaded_scaffold.nodes_states[node_id].items(),
                 loaded_scaffold.nodes_deltas[node_id].items(),
+                strict=True,
             ):
                 self.assertTrue(
                     torch.isclose(v_d, v_ns - loaded_scaffold.global_state[k_ns]).all()

--- a/tests/test_torchnn.py
+++ b/tests/test_torchnn.py
@@ -6,7 +6,7 @@ import re
 import tempfile
 import types
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import torch
 import torch.nn as nn
@@ -169,9 +169,17 @@ class TestTorchnn(unittest.TestCase):
     @patch(
         "fedbiomed.common.training_plans.TorchTrainingPlan._configure_model_and_optimizer"
     )
-    def test_torch_training_plan_02_post_init(self, conf_optimizer_model, conf_deps):
+    @patch(
+        "fedbiomed.common.training_plans.TorchTrainingPlan.filter_model_params_by_tags"
+    )
+    @patch("fedbiomed.common.training_plans.TorchTrainingPlan.get_model_params")
+    def test_torch_training_plan_02_post_init(
+        self, get_params, filter_params, conf_optimizer_model, conf_deps
+    ):
         conf_optimizer_model.return_value = None
         conf_deps.return_value = None
+        get_params.return_value = {}
+        filter_params.return_value = {}
 
         tp = TorchTrainingPlan()
         tp._model = Module()
@@ -398,6 +406,86 @@ class TestTorchnn(unittest.TestCase):
             self.assertTrue(torch.all(torch.isclose(value, sd2[key])))
 
         os.remove(paramfile)
+
+    def test_torch_training_plan_10_get_dp_controller(self):
+        """Test get_dp_controller getter returns the _dp_controller attribute."""
+        tp = TorchTrainingPlan()
+
+        # Before post_init, dp_controller should be None
+        self.assertIsNone(tp.get_dp_controller())
+
+        # After assigning a mock dp_controller, getter should return it
+        mock_dp = MagicMock()
+        tp._dp_controller = mock_dp
+        self.assertIs(tp.get_dp_controller(), mock_dp)
+
+    @patch(
+        "fedbiomed.common.training_plans.TorchTrainingPlan._configure_model_and_optimizer"
+    )
+    @patch("fedbiomed.common.training_plans.TorchTrainingPlan._configure_dependencies")
+    def test_torch_training_plan_11_post_init_local_params(
+        self, conf_deps, conf_model_optimizer
+    ):
+        """Test that post_init correctly initialises _local_params via filter_model_params_by_tags.
+
+        Three sub-cases are verified:
+        1. No params tagged 'local'  → _local_params is an empty list.
+        2. Some params tagged 'local' → _local_params contains exactly those param names.
+        3. filter_model_params_by_tags returns all params tagged 'local' regardless of
+           other tags on the same parameter.
+        """
+        conf_deps.return_value = None
+        conf_model_optimizer.return_value = None
+
+        # Sub-case 1: no local params
+        tp = TorchTrainingPlan()
+        tp._model = MagicMock()
+
+        with (
+            patch.object(
+                tp,
+                "get_model_params",
+                return_value={"layer.weight": MagicMock(), "layer.bias": MagicMock()},
+            ),
+            patch.object(
+                tp,
+                "filter_model_params_by_tags",
+                return_value={},  # no params tagged 'local'
+            ) as mock_filter,
+        ):
+            tp.post_init({}, TestTorchnn.FakeTrainingArgs())
+
+        mock_filter.assert_called_once_with(
+            {
+                "layer.weight": mock_filter.call_args[0][0]["layer.weight"],
+                "layer.bias": mock_filter.call_args[0][0]["layer.bias"],
+            },
+            required_tags={"local"},
+        )
+        self.assertEqual(tp._local_params, [])
+
+        # Sub-case 2: some params tagged 'local'
+        tp2 = TorchTrainingPlan()
+        tp2._model = MagicMock()
+
+        with (
+            patch.object(
+                tp2,
+                "get_model_params",
+                return_value={
+                    "layer.weight": MagicMock(),
+                    "local_layer.weight": MagicMock(),
+                },
+            ),
+            patch.object(
+                tp2,
+                "filter_model_params_by_tags",
+                return_value={"local_layer.weight": MagicMock()},
+            ),
+        ):
+            tp2.post_init({}, TestTorchnn.FakeTrainingArgs())
+
+        self.assertEqual(tp2._local_params, ["local_layer.weight"])
 
     @patch("torch.nn.Module.__call__")
     def test_torch_nn_03_testing_routine(self, patch_model_call):
@@ -796,9 +884,10 @@ class TestTorchnn(unittest.TestCase):
         tp_scaffold.training_routine(None, None)
 
         # test that model trained with scaffold is equivalent to model trained with fedavg
-        for (name, layer_fedavg), (name, layer_scaffold) in zip(
+        for (_name, layer_fedavg), (_name, layer_scaffold) in zip(
             tp_fedavg._model.model.state_dict().items(),
             tp_scaffold._model.model.state_dict().items(),
+            strict=True,
         ):
             self.assertTrue(torch.isclose(layer_fedavg, layer_scaffold).all())
 
@@ -866,8 +955,8 @@ class TestTorchnn(unittest.TestCase):
                 tp.post_init({}, TrainingArgs(training_args, only_required=False))
             tp._model.init_training()
             for _ in range(2):
-                corrected_l, l = tp._train_over_batch(model[1], model[2])
-            self.assertEqual(corrected_l, l)  # no fedprox updates
+                corrected_l, loss = tp._train_over_batch(model[1], model[2])
+            self.assertEqual(corrected_l, loss)  # no fedprox updates
 
             training_args = {"fedprox_mu": 1.0, "epochs": 1}
             with (
@@ -881,10 +970,10 @@ class TestTorchnn(unittest.TestCase):
                 tp.post_init({}, TrainingArgs(training_args, only_required=False))
             tp._model.init_training()
             for _ in range(2):
-                corrected_l, l = tp._train_over_batch(model[1], model[2])
+                corrected_l, loss = tp._train_over_batch(model[1], model[2])
 
             self.assertGreaterEqual(
-                corrected_l, l
+                corrected_l, loss
             )  # if fedprox_mu is positive, regularization term will be positive
             # and thus, corrected loss will always be greater than the actual loss (correct_loss = loss + fedprox_mu * reg / 2)
 
@@ -1142,6 +1231,446 @@ class TestTorchNNTrainingRoutineDataloaderTypes(unittest.TestCase):
         )
         patch_tensor_backward.assert_called_once()
         # tp._optimizer.step.assert_called()
+
+
+class TestAfterTrainingParams(unittest.TestCase):
+    """Exhaustive tests for TorchTrainingPlan.after_training_params()"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.patcher = patch.multiple(TorchTrainingPlan, __abstractmethods__=set())
+        self.patcher.start()
+        self.tp = TorchTrainingPlan()
+        self.tp._model = MagicMock(spec=TorchModel)
+        self.tp._dp_controller = MagicMock()
+        self.tp._local_params = None
+        self.tp._share_persistent_buffers = True
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_after_training_params_01_basic(self):
+        """Test returning dict without flattening, local params, DP and postprocess method"""
+        params_dict = {
+            "layer1.weight": torch.tensor([1.0]),
+            "layer1.bias": torch.tensor([0.1]),
+        }
+        self.tp._dp_controller.rename_params.return_value = (params_dict, {})
+        self.tp._dp_controller.after_training.return_value = params_dict
+
+        with patch.object(
+            self.tp, "get_model_params", return_value=params_dict
+        ) as mock_get:
+            result = self.tp.after_training_params(flatten=False)
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("layer1.weight", result)
+        self.assertIn("layer1.bias", result)
+        self.assertEqual(result["layer1.weight"], params_dict["layer1.weight"])
+        self.assertEqual(result["layer1.bias"], params_dict["layer1.bias"])
+        self.tp._dp_controller.after_training.assert_called_once_with(
+            params_dict, renaming=False
+        )
+        self.tp._model.set_weights.assert_called_once_with(
+            params_dict, local_params=None
+        )
+        mock_get.assert_has_calls(
+            [
+                call(exclude_buffers=False, local_params=None),
+                call(exclude_buffers=False, local_params=None),
+            ]
+        )
+        self.tp._dp_controller.rename_params.assert_has_calls(
+            [
+                call(params_dict),
+                call(params_dict),
+            ]
+        )
+
+    def test_after_training_params_02_postprocess(self):
+        """Test returning dict with postprocess method"""
+        params_dict_before_postprocess = {
+            "layer1.weight": torch.tensor([1.0]),
+            "layer1.bias": torch.tensor([0.1]),
+        }
+        params_dict_after_postprocess = {
+            "layer1.weight": torch.tensor([1.1]),
+            "layer1.bias": torch.tensor([0.11]),
+        }
+        self.tp._dp_controller.rename_params.side_effect = [
+            (params_dict_before_postprocess, {}),
+            (params_dict_after_postprocess, {}),
+        ]
+        self.tp._dp_controller.revert_rename_params.return_value = (
+            params_dict_after_postprocess
+        )
+        self.tp._dp_controller.after_training.return_value = (
+            params_dict_after_postprocess
+        )
+
+        # Add postprocess method
+        postprocess_mock = MagicMock(return_value=params_dict_after_postprocess)
+        self.tp.postprocess = postprocess_mock
+
+        with patch.object(
+            self.tp,
+            "get_model_params",
+            side_effect=[params_dict_before_postprocess, params_dict_after_postprocess],
+        ) as mock_get:
+            result = self.tp.after_training_params(flatten=False)
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("layer1.weight", result)
+        self.assertIn("layer1.bias", result)
+        self.assertEqual(
+            result["layer1.weight"], params_dict_after_postprocess["layer1.weight"]
+        )
+        self.assertEqual(
+            result["layer1.bias"], params_dict_after_postprocess["layer1.bias"]
+        )
+        self.tp.postprocess.assert_called_once_with(params_dict_before_postprocess)
+        self.tp._dp_controller.revert_rename_params.assert_called_once_with(
+            params_dict_after_postprocess, {}
+        )
+        self.tp._dp_controller.after_training.assert_called_once_with(
+            params_dict_after_postprocess, renaming=False
+        )
+        self.tp._model.set_weights.assert_called_once_with(
+            params_dict_after_postprocess, local_params=None
+        )
+        mock_get.assert_has_calls(
+            [
+                call(exclude_buffers=False, local_params=None),
+                call(exclude_buffers=False, local_params=None),
+            ]
+        )
+        self.tp._dp_controller.rename_params.assert_has_calls(
+            [
+                call(params_dict_before_postprocess),
+                call(params_dict_after_postprocess),
+            ]
+        )
+
+    def test_after_training_params_03_postprocess_raises(self):
+        """Test exception handling when postprocess raises"""
+        params_dict_before_postprocess = {
+            "layer1.weight": torch.tensor([1.0]),
+            "layer1.bias": torch.tensor([0.1]),
+        }
+        self.tp._dp_controller.rename_params.return_value = (
+            params_dict_before_postprocess,
+            {},
+        )
+
+        # Add postprocess method
+        postprocess_mock = MagicMock(side_effect=ValueError("postprocess error"))
+        self.tp.postprocess = postprocess_mock
+
+        with patch.object(
+            self.tp, "get_model_params", return_value=params_dict_before_postprocess
+        ):
+            with self.assertRaises(FedbiomedTrainingPlanError) as context:
+                self.tp.after_training_params(flatten=False)
+
+        self.assertIn("Error while running post-process", str(context.exception))
+
+    def test_after_training_params_04_DP(self):
+        """Test returning dict with DP method"""
+        initial_params_dict = {
+            "_module.layer1.weight": torch.tensor([1.0]),
+            "_module.layer1.bias": torch.tensor([0.1]),
+        }
+        renamed_params_dict_before_DP = {
+            "layer1.weight": torch.tensor([1.0]),
+            "layer1.bias": torch.tensor([0.1]),
+        }
+        rename_mapping = {
+            "layer1.weight": "_module.layer1.weight",
+            "layer1.bias": "_module.layer1.bias",
+        }
+        params_dict_after_DP = {
+            "_module.layer1.weight": torch.tensor([1.001]),
+            "_module.layer1.bias": torch.tensor([0.1002]),
+        }
+        renamed_params_dict_after_DP = {
+            "layer1.weight": torch.tensor([1.001]),
+            "layer1.bias": torch.tensor([0.1002]),
+        }
+        self.tp._dp_controller.rename_params.side_effect = [
+            (renamed_params_dict_before_DP, rename_mapping),
+            (renamed_params_dict_after_DP, rename_mapping),
+        ]
+        self.tp._dp_controller.after_training.return_value = params_dict_after_DP
+
+        with patch.object(
+            self.tp,
+            "get_model_params",
+            side_effect=[initial_params_dict, params_dict_after_DP],
+        ) as mock_get:
+            result = self.tp.after_training_params(flatten=False)
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("layer1.weight", result)
+        self.assertIn("layer1.bias", result)
+        self.assertEqual(
+            result["layer1.weight"], renamed_params_dict_after_DP["layer1.weight"]
+        )
+        self.assertEqual(
+            result["layer1.bias"], renamed_params_dict_after_DP["layer1.bias"]
+        )
+        self.tp._dp_controller.after_training.assert_called_once_with(
+            initial_params_dict, renaming=False
+        )
+        self.tp._model.set_weights.assert_called_once_with(
+            params_dict_after_DP, local_params=None
+        )
+        self.tp._dp_controller.rename_params.assert_has_calls(
+            [
+                call(initial_params_dict),
+                call(params_dict_after_DP),
+            ]
+        )
+        mock_get.assert_has_calls(
+            [
+                call(exclude_buffers=False, local_params=None),
+                call(exclude_buffers=False, local_params=None),
+            ]
+        )
+
+    def test_after_training_params_05_local_params(self):
+        """Test returning dict with local params"""
+        self.tp._local_params = ["layer1.weight"]
+        initial_params_dict = {
+            "layer1.weight": torch.tensor([1.0]),
+            "layer1.bias": torch.tensor([0.1]),
+        }
+        params_dict_without_local_params = {"layer1.bias": torch.tensor([0.1])}
+        self.tp._dp_controller.rename_params.side_effect = [
+            (initial_params_dict, {}),
+            (params_dict_without_local_params, {}),
+        ]
+        self.tp._dp_controller.after_training.return_value = initial_params_dict
+
+        with patch.object(
+            self.tp,
+            "get_model_params",
+            side_effect=[initial_params_dict, params_dict_without_local_params],
+        ) as mock_get:
+            result = self.tp.after_training_params(flatten=False)
+
+        self.assertIsInstance(result, dict)
+        self.assertNotIn("layer1.weight", result)
+        self.assertIn("layer1.bias", result)
+        self.assertEqual(
+            result["layer1.bias"], params_dict_without_local_params["layer1.bias"]
+        )
+        self.tp._dp_controller.after_training.assert_called_once_with(
+            initial_params_dict, renaming=False
+        )
+        self.tp._model.set_weights.assert_called_once_with(
+            initial_params_dict, local_params=None
+        )
+        self.tp._dp_controller.rename_params.assert_has_calls(
+            [
+                call(initial_params_dict),
+                call(params_dict_without_local_params),
+            ]
+        )
+        mock_get.assert_has_calls(
+            [
+                call(exclude_buffers=False, local_params=None),
+                call(exclude_buffers=False, local_params=["layer1.weight"]),
+            ]
+        )
+
+    def test_after_training_params_06_flatten(self):
+        """Test returning params with flatten"""
+        initial_params_dict = {
+            "layer1.weight": torch.tensor([1.0]),
+            "layer1.bias": torch.tensor([0.1]),
+        }
+        params_flatten = [1.0, 0.1]
+        self.tp._dp_controller.rename_params.return_value = (initial_params_dict, {})
+        self.tp._dp_controller.after_training.return_value = initial_params_dict
+        self.tp._model.flatten.return_value = params_flatten
+
+        with patch.object(
+            self.tp, "get_model_params", return_value=initial_params_dict
+        ) as mock_get:
+            result = self.tp.after_training_params(flatten=True)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(result, params_flatten)
+        mock_get.assert_called_once_with(exclude_buffers=False, local_params=None)
+        self.tp._dp_controller.rename_params.assert_called_once_with(
+            initial_params_dict
+        )
+        self.tp._dp_controller.after_training.assert_called_once_with(
+            initial_params_dict, renaming=False
+        )
+        self.tp._model.set_weights.assert_called_once_with(
+            initial_params_dict, local_params=None
+        )
+        self.tp._model.flatten.assert_called_once_with(
+            exclude_buffers=False, local_params=None
+        )
+
+    def test_after_training_params_07_integration_no_flatten(self):
+        """Test returning dict with: local params, postprocess, DP"""
+        self.tp._local_params = ["layer1.weight"]
+        initial_params_dict = {
+            "_module.layer1.weight": torch.tensor([1.0]),
+            "_module.layer1.bias": torch.tensor([0.1]),
+        }
+        renamed_params_dict_before_postprocess = {
+            "layer1.weight": torch.tensor([1.0]),
+            "layer1.bias": torch.tensor([0.1]),
+        }
+        rename_mapping = {
+            "layer1.weight": "_module.layer1.weight",
+            "layer1.bias": "_module.layer1.bias",
+        }
+        renamed_params_dict_after_postprocess = {
+            "layer1.weight": torch.tensor([10.0]),
+            "layer1.bias": torch.tensor([1.0]),
+        }
+        initial_params_dict_after_postprocess = {
+            "_module.layer1.weight": torch.tensor([10.0]),
+            "_module.layer1.bias": torch.tensor([1.0]),
+        }
+        params_dict_after_DP = {
+            "_module.layer1.weight": torch.tensor([10.001]),
+            "_module.layer1.bias": torch.tensor([1.0002]),
+        }
+        params_dict_after_DP_without_local = {
+            "_module.layer1.bias": torch.tensor([1.0002])
+        }
+        renamed_params_dict_after_DP_without_local = {
+            "layer1.bias": torch.tensor([1.0002])
+        }
+        final_rename_mapping = {"layer1.bias": "_module.layer1.bias"}
+
+        self.tp._dp_controller.rename_params.side_effect = [
+            (renamed_params_dict_before_postprocess, rename_mapping),
+            (renamed_params_dict_after_DP_without_local, final_rename_mapping),
+        ]
+        self.tp._dp_controller.after_training.return_value = params_dict_after_DP
+        self.tp._dp_controller.revert_rename_params.return_value = (
+            initial_params_dict_after_postprocess
+        )
+
+        # Add postprocess method
+        postprocess_mock = MagicMock(return_value=renamed_params_dict_after_postprocess)
+        self.tp.postprocess = postprocess_mock
+
+        with patch.object(
+            self.tp,
+            "get_model_params",
+            side_effect=[initial_params_dict, params_dict_after_DP_without_local],
+        ) as mock_get:
+            result = self.tp.after_training_params(flatten=False)
+
+        self.assertIsInstance(result, dict)
+        self.assertNotIn("layer1.weight", result)
+        self.assertIn("layer1.bias", result)
+        self.assertEqual(
+            result["layer1.bias"],
+            renamed_params_dict_after_DP_without_local["layer1.bias"],
+        )
+        self.tp.postprocess.assert_called_once_with(
+            renamed_params_dict_before_postprocess
+        )
+        self.tp._dp_controller.revert_rename_params.assert_called_once_with(
+            renamed_params_dict_after_postprocess, rename_mapping
+        )
+        self.tp._dp_controller.after_training.assert_called_once_with(
+            initial_params_dict_after_postprocess, renaming=False
+        )
+        self.tp._model.set_weights.assert_called_once_with(
+            params_dict_after_DP, local_params=None
+        )
+        self.tp._dp_controller.rename_params.assert_has_calls(
+            [
+                call(initial_params_dict),
+                call(params_dict_after_DP_without_local),
+            ]
+        )
+        mock_get.assert_has_calls(
+            [
+                call(exclude_buffers=False, local_params=None),
+                call(exclude_buffers=False, local_params=["_module.layer1.weight"]),
+            ]
+        )
+
+    def test_after_training_params_08_integration_flatten(self):
+        """Test returning dict with: local params, postprocess, DP, flatten"""
+        self.tp._local_params = ["layer1.weight"]
+        initial_params_dict = {
+            "_module.layer1.weight": torch.tensor([1.0]),
+            "_module.layer1.bias": torch.tensor([0.1]),
+        }
+        renamed_params_dict_before_postprocess = {
+            "layer1.weight": torch.tensor([1.0]),
+            "layer1.bias": torch.tensor([0.1]),
+        }
+        rename_mapping = {
+            "layer1.weight": "_module.layer1.weight",
+            "layer1.bias": "_module.layer1.bias",
+        }
+        renamed_params_dict_after_postprocess = {
+            "layer1.weight": torch.tensor([10.0]),
+            "layer1.bias": torch.tensor([1.0]),
+        }
+        initial_params_dict_after_postprocess = {
+            "_module.layer1.weight": torch.tensor([10.0]),
+            "_module.layer1.bias": torch.tensor([1.0]),
+        }
+        params_dict_after_DP = {
+            "_module.layer1.weight": torch.tensor([10.001]),
+            "_module.layer1.bias": torch.tensor([1.0002]),
+        }
+        flattened_params_after_DP_without_local = [1.0002]
+
+        self.tp._dp_controller.rename_params.return_value = (
+            renamed_params_dict_before_postprocess,
+            rename_mapping,
+        )
+        self.tp._dp_controller.after_training.return_value = params_dict_after_DP
+        self.tp._dp_controller.revert_rename_params.return_value = (
+            initial_params_dict_after_postprocess
+        )
+        self.tp._model.flatten.return_value = flattened_params_after_DP_without_local
+
+        # Add postprocess method
+        postprocess_mock = MagicMock(return_value=renamed_params_dict_after_postprocess)
+        self.tp.postprocess = postprocess_mock
+
+        with patch.object(
+            self.tp, "get_model_params", return_value=initial_params_dict
+        ) as mock_get:
+            result = self.tp.after_training_params(flatten=True)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(result, flattened_params_after_DP_without_local)
+        self.tp.postprocess.assert_called_once_with(
+            renamed_params_dict_before_postprocess
+        )
+        self.tp._dp_controller.revert_rename_params.assert_called_once_with(
+            renamed_params_dict_after_postprocess, rename_mapping
+        )
+        self.tp._dp_controller.after_training.assert_called_once_with(
+            initial_params_dict_after_postprocess, renaming=False
+        )
+        self.tp._model.set_weights.assert_called_once_with(
+            params_dict_after_DP, local_params=None
+        )
+        self.tp._dp_controller.rename_params.assert_called_once_with(
+            initial_params_dict
+        )
+        mock_get.assert_called_once_with(exclude_buffers=False, local_params=None)
+        self.tp._model.flatten.assert_called_once_with(
+            exclude_buffers=False, local_params=["_module.layer1.weight"]
+        )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_training_plan_workflow.py
+++ b/tests/test_training_plan_workflow.py
@@ -152,7 +152,9 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
         self.mock_tp.get_model_params.return_value = {"model": "params"}
         exp.set_training_plan_class(FakeTorchTrainingPlan)
 
-        self.mock_tp.set_model_params.assert_called_once_with({"model": "params"})
+        self.mock_tp.set_model_params.assert_called_once_with(
+            {"model": "params"}, local_params=self.mock_tp.local_params
+        )
 
         # check that weights are not preserved if we explicitly ask not to
         self.mock_tp.set_model_params.reset_mock()
@@ -193,7 +195,9 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
         exp.set_model_args({"model": "other-args"})
 
         self.assertDictEqual(exp.model_args(), {"model": "other-args"})
-        self.mock_tp.set_model_params.assert_called_once_with({"model": "new-params"})
+        self.mock_tp.set_model_params.assert_called_once_with(
+            {"model": "new-params"}, local_params=self.mock_tp.local_params
+        )
 
         # Invalid model args type
         with self.assertRaises(FedbiomedExperimentError):
@@ -263,6 +267,12 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
             "breakpoint_0000",
             f"model_params_{mock_uuid.return_value}.mpk",
         )
+        local_params = self.mock_tp.local_params
+        self.mock_tp.get_model_wrapper_class.return_value.get_weights.assert_called_once_with(
+            only_trainable=False,
+            exclude_buffers=False,
+            local_params=local_params,
+        )
         mock_serializer_dump.assert_called_once_with(
             self.mock_tp.get_model_wrapper_class.return_value.get_weights.return_value,
             params_path,
@@ -327,8 +337,9 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
             TrainingArgs({"num_updates": 42}, only_required=False).dict(),
         )
         # Test if set_weights is called with the right arguments
+        local_params = self.mock_tp.local_params
         exp.training_plan().get_model_wrapper_class.return_value.set_weights.assert_called_once_with(
-            mock_serializer_load.return_value
+            mock_serializer_load.return_value, local_params=local_params
         )
         self.assertIsInstance(exp_tempo_id, str)
 
@@ -403,6 +414,8 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
 
         exp = TrainingPlanWorkflow()
         training_plan = MagicMock(spec=BaseTrainingPlan)
+        training_plan.local_params = ["fc1.bias"]
+        training_plan.get_model_params.return_value = {"fc1.weight": 0.123}
         exp._training_plan = training_plan
 
         def dummy_yield():
@@ -411,7 +424,15 @@ class TestTrainingPlanWorkflow(unittest.TestCase, MockRequestModule):
         # Check correct case
         with exp._keep_weights(True):
             dummy_yield()
-        training_plan.set_model_params.assert_called_once()
+
+        training_plan.get_model_params.assert_called_once_with(
+            exclude_buffers=False,
+            local_params=["fc1.bias"],
+        )
+        training_plan.set_model_params.assert_called_once_with(
+            {"fc1.weight": 0.123},
+            local_params=["fc1.bias"],
+        )
 
         # Check set_model_params raises an exception
 


### PR DESCRIPTION
**PR description**

This draft PR introduces a first attempt to address issue #1618 regarding node-specific parameters, implementing the design discussions from issues #1620, #1627 and #1628.

**Summary of changes**

Researcher can now tag parameters in a training plan as persistent and/or private:

- private: parameters that are never shared with the researcher (i.e., never aggregated).
- persistent: parameters that are saved locally on the node after each round.

In simple scenarios, this implementation works correctly for both Scikit-learn and PyTorch examples.
After fixing a small bug in breakpoint loading, breakpoints also appear to work correctly.

**Open questions & discussion points**

About Differential Privacy:

- Currently, OPACUS modifies model parameter names by adding a `"_module"` prefix, which breaks the current implementation because parameters cannot be loaded by the original names specified in `tag_parameters`.
- Should DP be applied to private parameters that are never shared to researcher? My intuition is no, but it’s unclear how this affects implementation. What are the consequences if the set of parameters subject to DP is smaller than expected
- While modifying the `after_training_params` function in `TorchTrainingPlan`, it seems that both SecAgg and DP cannot be applied simultaneously:

```
def after_training_params(self, flatten: bool = False) -> Dict[str, torch.Tensor]:
    ...

    # Run (optional) DP controller adjustments as well.
    params = self._dp_controller.after_training(params)
    if flatten:
        params = self._model.flatten(
            exclude_buffers=not self._share_persistent_buffers,
            private_params=self._private_params,
        )
    return params
 ```
 At least, DP seems to be ignored if SecAgg is applied in the `if flatten` statement.

About Declearn:

- How does the private parameter concept impact Declearn and more complex optimizers?
- Currently, using Scaffold triggers warnings, which require investigation.

About Secure Aggregation:

- The different use cases tested with secure aggregation (PyTorch and Scikit-learn) seem to work fine.
- However, the `secure_aggregation` function in `Aggregator` does not appear to be used anywhere. Should it still be updated to reflect the new parameter access logic, or can it be deprecated?

**Missing**

- [x] Implement unit tests.
- [x] Update documentation.
- [x] Create e2e test