### PR TITLE
ensure clean up after failure of endurance tests and reschedule

### DIFF
--- a/.github/workflows/endurance-tests.yml
+++ b/.github/workflows/endurance-tests.yml
@@ -4,7 +4,7 @@ run-name: endurance-tests
 
 on:
   schedule:
-    - cron: "0 1 * * *"  # Run every day at 1 am on default branch: develop
+    - cron: "0 1 * * 6"  # Run every Saturday at 1 am on default branch: develop
   workflow_dispatch:
   push:
     branches:
@@ -12,6 +12,7 @@ on:
 
 jobs:
   endurance-test:
+    timeout-minutes: 360  # matches the GitHub-hosted runner default; prevents infinite hangs on self-hosted runners
     defaults:
       run:
         shell:  bash -l {0}
@@ -38,8 +39,20 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # set -m enables job control so tox runs in its own process group;
+      # TEST_PGID is captured immediately (before wait) for the cleanup step to use.
       - name: Run end-to-end endurance tests
         id: e2e-tests-with-pytest
         run: |
-          FEDBIOMED_E2E_DATA_PATH=$HOME/Data/fedbiomed tox -r -m endurance
+          set -m
+          FEDBIOMED_E2E_DATA_PATH=$HOME/Data/fedbiomed tox -r -m endurance &
+          TEST_PID=$!
+          echo "TEST_PGID=$(ps -o pgid= -p $TEST_PID | tr -d ' ')" >> $GITHUB_ENV
+          wait $TEST_PID
         shell: bash -l {0}
+
+      # Kill by process group: scoped to this job, safe on shared self-hosted runners.
+      - name: Cleanup lingering processes
+        if: always()
+        run: |
+          [ -n "$TEST_PGID" ] && kill -- "-$TEST_PGID" 2>/dev/null || true


### PR DESCRIPTION
Adds cleaning up, timing out and reschedule endurance tests on weekends for develop. Push to master triggers it as before.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`