### PR TITLE
Fix docker image size issue coming from high user ID number

### DIFF
--- a/envs/vpn/docker/gui/build_files/entrypoint_functions.bash
+++ b/envs/vpn/docker/gui/build_files/entrypoint_functions.bash
@@ -76,7 +76,7 @@ CONTAINER_GROUP=$CONTAINER_GROUP or CONTAINER_GID=$CONTAINER_GID : \
     if [ -z "$(getent passwd $CONTAINER_UID)" -a -z "$(getent passwd $CONTAINER_USER)" ]
     then
         # delete stderr to avoid warning messages because homedir already exists
-        useradd -m -d /home/$CONTAINER_BUILD_USER \
+        useradd -l -m -d /home/$CONTAINER_BUILD_USER \
             -u $CONTAINER_UID -g $CONTAINER_GID -s /bin/bash $CONTAINER_USER 2>/dev/null
         if [ "$?" -ne 0 ]
         then

--- a/envs/vpn/docker/node/build_files/entrypoint_functions.bash
+++ b/envs/vpn/docker/node/build_files/entrypoint_functions.bash
@@ -76,7 +76,7 @@ CONTAINER_GROUP=$CONTAINER_GROUP or CONTAINER_GID=$CONTAINER_GID : \
     if [ -z "$(getent passwd $CONTAINER_UID)" -a -z "$(getent passwd $CONTAINER_USER)" ]
     then
         # delete stderr to avoid warning messages because homedir already exists
-        useradd -m -d /home/$CONTAINER_BUILD_USER \
+        useradd -l -m -d /home/$CONTAINER_BUILD_USER \
             -u $CONTAINER_UID -g $CONTAINER_GID -s /bin/bash $CONTAINER_USER 2>/dev/null
         if [ "$?" -ne 0 ]
         then

--- a/envs/vpn/docker/researcher/build_files/entrypoint_functions.bash
+++ b/envs/vpn/docker/researcher/build_files/entrypoint_functions.bash
@@ -76,7 +76,7 @@ CONTAINER_GROUP=$CONTAINER_GROUP or CONTAINER_GID=$CONTAINER_GID : \
     if [ -z "$(getent passwd $CONTAINER_UID)" -a -z "$(getent passwd $CONTAINER_USER)" ]
     then
         # delete stderr to avoid warning messages because homedir already exists
-        useradd -m -d /home/$CONTAINER_BUILD_USER \
+        useradd -l -m -d /home/$CONTAINER_BUILD_USER \
             -u $CONTAINER_UID -g $CONTAINER_GID -s /bin/bash $CONTAINER_USER 2>/dev/null
         if [ "$?" -ne 0 ]
         then

--- a/envs/vpn/docker/vpnserver/build_files/entrypoint_functions.bash
+++ b/envs/vpn/docker/vpnserver/build_files/entrypoint_functions.bash
@@ -76,7 +76,7 @@ CONTAINER_GROUP=$CONTAINER_GROUP or CONTAINER_GID=$CONTAINER_GID : \
     if [ -z "$(getent passwd $CONTAINER_UID)" -a -z "$(getent passwd $CONTAINER_USER)" ]
     then
         # delete stderr to avoid warning messages because homedir already exists
-        useradd -m -d /home/$CONTAINER_BUILD_USER \
+        useradd -l -m -d /home/$CONTAINER_BUILD_USER \
             -u $CONTAINER_UID -g $CONTAINER_GID -s /bin/bash $CONTAINER_USER 2>/dev/null
         if [ "$?" -ne 0 ]
         then


### PR DESCRIPTION
**PR description**

Completes #1708 by solving huge docker image size issue when coming from high user ID number.

Checked rebuilding images with the patch on Linux, works fine.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`