### PR TITLE
Feature/1734 fix fa dtype bug

### DIFF
--- a/fedbiomed/common/analytics/accumulators/_operations.py
+++ b/fedbiomed/common/analytics/accumulators/_operations.py
@@ -65,11 +65,11 @@ class MeanAccumulator(BaseStatAccumulator):
         self._validate_shape(val)
 
         # Sum (replace non-finite with 0, initialize as float32)
-        zeroed = np.nan_to_num(val, nan=0.0, posinf=0.0, neginf=0.0).astype(np.float32)
+        zeroed = np.nan_to_num(val.astype(float), nan=0.0, posinf=0.0, neginf=0.0).astype(np.float32)
         self.sum_val = zeroed if self.sum_val is None else self.sum_val + zeroed
 
         # Count (finite values only)
-        increment = np.isfinite(val).astype(np.int32)
+        increment = np.isfinite(val.astype(float)).astype(np.int32)
         self.counts = increment if self.counts is None else self.counts + increment
 
     def finalize(self) -> Dict[str, Any]:

--- a/tests/test_analytics/test_accumulators_operations.py
+++ b/tests/test_analytics/test_accumulators_operations.py
@@ -310,6 +310,23 @@ def test_mean_accumulator_update_with_inf():
     np.testing.assert_array_equal(acc.counts, np.array([1, 0, 0], dtype=np.int32))
 
 
+def test_mean_accumulator_update_with_object_dtype():
+    """Test update when passed array has the incorrect dtype (object)."""
+    acc = MeanAccumulator()
+    acc.update(np.array([2.0, np.nan, -np.inf], dtype=object))
+
+    # inf replaced with 0 in sum
+    np.testing.assert_array_almost_equal(
+        acc.sum_val, np.array([2.0, 0.0, 0.0], dtype=np.float32)
+    )
+    # inf not counted
+    np.testing.assert_array_equal(acc.counts, np.array([1, 0, 0], dtype=np.int32))
+
+    # Test edge case where a string is passed in object array - should raise error
+    acc = MeanAccumulator()
+    with pytest.raises(ValueError, match="could not convert string to float"):
+        acc.update(np.array([2.0, np.nan, -np.inf, 'a string'], dtype=object))
+
 def test_mean_accumulator_multiple_updates():
     """Test multiple updates accumulate correctly."""
     acc = MeanAccumulator()


### PR DESCRIPTION
**PR description**
Fixes #1734.

The implementation relies on attempting to convert all columns to floating point type, which assumes that all columns were numeric. This should be a reasonable assumption since we're asking for `mean`. It raises a nicely interpretable `Value Error: could not convert string to float` in case the user requested the computing the mean on a column with strings. 

Note that this PR only fixes the issue for `mean`, but the problem may still persist in case of `count`, although the fix is harder there because we cannot make the assumption that the columns should be converted to float. 

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`