### PR TITLE
Add support for multi-modal data or target in CustomDataset

### DIFF
--- a/docs/user-guide/datasets/custom-dataset.md
+++ b/docs/user-guide/datasets/custom-dataset.md
@@ -9,7 +9,7 @@
 - `CustomDataset` enforces the implementation of `read`, `get_item`, and `__len__` methods in subclasses.
 - You should avoid overriding `__getitem__` and `__init__`; `CustomDataset` will raise an error if these methods are overwritten, as they are reserved for internal use.
 - Ensure that `get_item` returns a tuple (e.g., `(data, target)`); `CustomDataset` automatically checks that this method returns a tuple.
-- `CustomDataset` must respect the data format required by the training plan. `get_item` should return `data` and `target` in the format expected by the framework used for training (e.g., `np.ndarray` for scikit-learn, `torch.Tensor` for PyTorch).
+- `CustomDataset` must respect the data format required by the training plan. `get_item` should return `data` and `target` in the format expected by the framework used for training (e.g., `np.ndarray` or a `dict` of one `np.ndarray` for scikit-learn, `torch.Tensor` or a `dict` of `torch.Tensor` for PyTorch).
 
 ## How to Use
 
@@ -28,7 +28,7 @@ To create your own dataset class, inherit from `CustomDataset`. The `CustomDatas
 
 `read(self)` has to be written in the subclass. This method is called once. It should read the data from the file system and loaded in the correct format.
 
-`get_item(self, idx)` is responsible for getting a single sample from the dataset. It should return a tuple `(data, target)` for the given index. For analytics or non-target studies it can return `data, None`.  The return format should follow the framework-specific convention (e.g., `torch.Tensor` for PyTorch and `numpy.ndarray` for scikit-learn). For a complete list of supported formats, see `fedbiomed.common.data_type.DataReturnFormat`."
+`get_item(self, idx)` is responsible for getting a single sample from the dataset. It should return a tuple `(data, target)` for the given index. For analytics or non-target studies it can return `data, None`.  The return format should follow the framework-specific convention (e.g., `torch.Tensor` or a `dict` of `torch.Tensor` for PyTorch and `numpy.ndarray` or a `dict` of one `numpy.ndarray` for scikit-learn). For a complete list of supported formats, see `fedbiomed.common.data_type.DataReturnFormat`."
 
 - `__len__(self)` should returns the number of samples in the dataset.
 

--- a/fedbiomed/common/dataset/_custom_dataset.py
+++ b/fedbiomed/common/dataset/_custom_dataset.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import abstractmethod
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, Union
 
 from fedbiomed.common.constants import ErrorNumbers
 from fedbiomed.common.dataset_types import DataReturnFormat
@@ -120,17 +120,45 @@ class CustomDataset(Dataset):
             )
 
         data, target = sample
+        self._composed: dict[str, Union[bool, None]] = {
+            "data": None,
+            "target": None,
+        }
         self._check_type(data, "data")
         self._check_type(target, "target")
 
     def _check_type(self, sample: Any, type_: str) -> None:
         """Check if sample is of expected type"""
-        if not isinstance(sample, self._to_format.value):
+        # First time we see a sample of this type, determine if it is composed or not
+        if self._composed[type_] is None:
+            self._composed[type_] = not isinstance(sample, self._to_format.value)
+
+        # Check non-composed sample
+        if self._composed[type_] is False and not isinstance(
+            sample, self._to_format.value
+        ):
             raise FedbiomedError(
                 f"{ErrorNumbers.FB632.value}: "
                 f"Expected return type for the {type_} is {self._to_format.value}, "
                 f"but got {type(sample).__name__} "
             )
+
+        # Check composed sample
+        if self._composed[type_] is True:
+            if not isinstance(sample, dict):
+                raise FedbiomedError(
+                    f"{ErrorNumbers.FB632.value}: "
+                    f"Expected return type for the {type_} is dict of {self._to_format.value}, "
+                    f"but got {type(sample).__name__} "
+                )
+            if not all(
+                isinstance(elem, self._to_format.value) for elem in sample.values()
+            ):
+                raise FedbiomedError(
+                    f"{ErrorNumbers.FB632.value}: "
+                    f"Expected return type for the {type_} is dict of {self._to_format.value}, "
+                    f"but got elements of type {list(map(type, sample.values()))} "
+                )
 
     def _apply_default_types(self, data: Any, _type: str) -> Any:
         """Applies default types for training plan framework to data
@@ -144,7 +172,13 @@ class CustomDataset(Dataset):
             Converted data
         """
         try:
-            data = self._get_default_types_callable()(data)
+            if not self._composed[_type]:
+                data = self._get_default_types_callable()(data)
+            else:
+                data = {
+                    key: self._get_default_types_callable()(value)
+                    for key, value in data.items()
+                }
         except Exception as e:
             raise FedbiomedError(
                 f"{ErrorNumbers.FB632.value}: Failed to apply default training plan types "

--- a/tests/test_base_training_plan.py
+++ b/tests/test_base_training_plan.py
@@ -244,7 +244,7 @@ class TestBaseTrainingPlan(unittest.TestCase):
             result, {"Custom_1": 14.5, "Custom_2": 14.5, "Custom_3": 14.5}
         )
 
-        metric = np.array([14.5, 14.5, 14.5], dtype=np.floating)
+        metric = np.array([14.5, 14.5, 14.5], dtype=np.float64)
         result = BaseTrainingPlan._create_metric_result_dict(
             metric=metric, metric_name="Custom"
         )

--- a/tests/test_dataset/test_custom_dataset.py
+++ b/tests/test_dataset/test_custom_dataset.py
@@ -6,9 +6,10 @@ from fedbiomed.common.dataset import CustomDataset
 from fedbiomed.common.dataset_types import DataReturnFormat
 from fedbiomed.common.exceptions import FedbiomedError
 
+# Define dataset classes for testing purposes
 
-# Valid implementation for testing
-class ValidCustomDataset(CustomDataset):
+
+class ValidTorchDataset(CustomDataset):
     def read(self):
         self.data = torch.randn(10, 5)  # 10 samples, 5 features
         self.targets = torch.randint(0, 2, (10,))  # Binary targets
@@ -20,10 +21,23 @@ class ValidCustomDataset(CustomDataset):
         return self.data[idx], self.targets[idx]
 
 
-class WrongFormatDataset(CustomDataset):
+class ValidTorchComposedDataset(ValidTorchDataset):
+    def get_item(self, idx):
+        data = {
+            "modality_1": self.data[idx],
+            "modality_2": self.data[idx] * 2,
+        }
+        target = {
+            "label_1": self.targets[idx],
+            "label_2": (self.targets[idx] + 1) % 2,
+        }
+        return data, target
+
+
+class ValidNumpyDataset(CustomDataset):
     def read(self):
-        self.data = np.random.randn(10, 5)  # NumPy array instead of torch.Tensor
-        self.targets = np.random.randint(0, 2, 10)
+        self.data = np.random.randn(10, 5).astype(np.float32)
+        self.targets = np.random.randint(0, 2, (10, 1))
 
     def __len__(self):
         return 10
@@ -32,8 +46,76 @@ class WrongFormatDataset(CustomDataset):
         return self.data[idx], self.targets[idx]
 
 
+class ValidNumpyComposedDataset(ValidNumpyDataset):
+    def get_item(self, idx):
+        data = {
+            "modality_1": self.data[idx],
+            "modality_2": self.data[idx] * 2,
+        }
+        target = {
+            "label_1": self.targets[idx],
+            "label_2": (self.targets[idx] + 1) % 2,
+        }
+        return data, target
+
+
+class WrongFormatDataset(CustomDataset):
+    def read(self):
+        self.data = np.random.randn(10, 5).astype(np.float32)
+        self.targets = np.random.randint(0, 2, 10)  # Int instead of ndarray
+
+    def __len__(self):
+        return 10
+
+    def get_item(self, idx):
+        return self.data[idx], self.targets[idx]
+
+
+class WrongFormatComposedDataset(WrongFormatDataset):
+    def get_item(self, idx):
+        data = {
+            "modality_1": self.data[idx],
+            "modality_2": self.data[idx] * 2,
+        }
+        target = {
+            "label_1": self.targets[idx],  # int instead of array
+            "label_2": (self.targets[idx] + 1) % 2,
+        }
+        return data, target
+
+
+class WrongFormatChangingDataset(ValidNumpyDataset):
+    def get_item(self, idx):
+        if idx % 2 != 0:
+            return {"data": self.data[idx]}, {"target": self.targets[idx]}
+        else:
+            return self.data[idx], self.targets[idx]
+
+
+class WrongFormatChangingComposedDataset(ValidNumpyDataset):
+    def get_item(self, idx):
+        if idx % 2 != 1:
+            return {"data": self.data[idx]}, {"target": self.targets[idx]}
+        else:
+            return self.data[idx], self.targets[idx]
+
+
+class EmptyDataset(CustomDataset):
+    def read(self):
+        pass
+
+    def __len__(self):
+        return 0
+
+    def get_item(self, idx):
+        return torch.tensor([]), torch.tensor([])
+
+
+# Test dataset creation and initialization
+
+
 def test_valid_dataset_creation():
-    dataset = ValidCustomDataset()
+    dataset = ValidTorchDataset()
     dataset.complete_initialization(
         controller_kwargs={"root": "dummy_path"}, to_format=DataReturnFormat.TORCH
     )
@@ -77,14 +159,31 @@ def test_missing_len_method():
 
 
 def test_wrong_format():
-    dataset = WrongFormatDataset()
-    with pytest.raises(FedbiomedError):
-        dataset.complete_initialization(
-            controller_kwargs={"root": "dummy_path"}, to_format=DataReturnFormat.TORCH
-        )
+    _dataset_classes = [
+        WrongFormatDataset,
+        WrongFormatComposedDataset,
+    ]
+    for ds_class in _dataset_classes:
+        dataset = ds_class()
+        with pytest.raises(FedbiomedError):
+            dataset.complete_initialization(
+                controller_kwargs={"root": "dummy_path"},
+                to_format=DataReturnFormat.SKLEARN,
+            )
+
+        with pytest.raises(FedbiomedError):
+            _ = dataset[1]
+
+
+def test_wrong_format_changing_dataset():
+    dataset = WrongFormatChangingDataset()
+    dataset.complete_initialization(
+        controller_kwargs={"root": "dummy_path"},
+        to_format=DataReturnFormat.SKLEARN,
+    )
 
     with pytest.raises(FedbiomedError):
-        _ = dataset[0]
+        _ = dataset[1]
 
 
 def test_override_getitem():
@@ -121,7 +220,7 @@ def test_override_init():
 
 
 def test_initialization_parameters():
-    dataset = ValidCustomDataset()
+    dataset = ValidTorchDataset()
     path = "test_path"
     dataset.complete_initialization(
         controller_kwargs={"root": path}, to_format=DataReturnFormat.TORCH
@@ -131,7 +230,7 @@ def test_initialization_parameters():
 
 
 def test_data_access():
-    dataset = ValidCustomDataset()
+    dataset = ValidTorchDataset()
     dataset.complete_initialization(
         controller_kwargs={"root": "dummy_path"}, to_format=DataReturnFormat.TORCH
     )
@@ -143,6 +242,24 @@ def test_data_access():
         assert isinstance(target, torch.Tensor)
         assert data.shape == (5,)  # Check expected shape
         assert target.shape == ()  # Single target value
+
+
+def test_complete_initialization_missing_root_key():
+    """complete_initialization raises when 'root' key is absent from controller_kwargs."""
+    ds = ValidTorchDataset()
+    with pytest.raises(FedbiomedError, match="'root' must be provided"):
+        ds.complete_initialization(
+            controller_kwargs={}, to_format=DataReturnFormat.SKLEARN
+        )
+
+
+def test_complete_initialization_root_is_none():
+    """complete_initialization raises when 'root' is explicitly None."""
+    ds = ValidTorchDataset()
+    with pytest.raises(FedbiomedError, match="'root' must be provided"):
+        ds.complete_initialization(
+            controller_kwargs={"root": None}, to_format=DataReturnFormat.SKLEARN
+        )
 
 
 def test_read_exception_is_wrapped(tmp_path):
@@ -161,6 +278,16 @@ def test_read_exception_is_wrapped(tmp_path):
         ds.complete_initialization(
             controller_kwargs={"root": str(tmp_path)},
             to_format=DataReturnFormat.TORCH,
+        )
+
+
+def test_complete_initialization_empty_dataset():
+    """complete_initialization raises when dataset length is 0 after read()."""
+
+    ds = EmptyDataset()
+    with pytest.raises(FedbiomedError, match="dataset is empty"):
+        ds.complete_initialization(
+            controller_kwargs={"root": "dummy_path"}, to_format=DataReturnFormat.TORCH
         )
 
 
@@ -196,3 +323,80 @@ def test_get_item_must_return_tuple_of_len_2(tmp_path):
             controller_kwargs={"root": str(tmp_path)},
             to_format=DataReturnFormat.TORCH,
         )
+
+
+# Test dataset usage
+
+
+def test_getitem_not_composed():
+    """__getitem__ returns a valid non-composed result."""
+
+    _dataset_classes = [ValidTorchDataset, ValidNumpyDataset]
+    _data_formats = [DataReturnFormat.TORCH, DataReturnFormat.SKLEARN]
+    _data_types = [torch.Tensor, np.ndarray]
+
+    for ds_class, d_type, _d_format in zip(
+        _dataset_classes,
+        _data_types,
+        _data_formats,
+        strict=True,
+    ):
+        ds = ds_class()
+        ds.complete_initialization(
+            controller_kwargs={"root": "dummy_path"}, to_format=_d_format
+        )
+        result = ds.__getitem__(0)
+        assert isinstance(result, tuple) and len(result) == 2
+        data, target = result
+        assert isinstance(data, d_type)
+        assert isinstance(target, d_type)
+
+
+def test_getitem_composed():
+    """__getitem__ returns a valid composed dict result."""
+
+    _dataset_classes = [ValidTorchComposedDataset, ValidNumpyComposedDataset]
+    _data_formats = [DataReturnFormat.TORCH, DataReturnFormat.SKLEARN]
+    _data_types = [torch.Tensor, np.ndarray]
+
+    for ds_class, d_type, _d_format in zip(
+        _dataset_classes,
+        _data_types,
+        _data_formats,
+        strict=True,
+    ):
+        ds = ds_class()
+        ds.complete_initialization(
+            controller_kwargs={"root": "dummy_path"}, to_format=_d_format
+        )
+        result = ds.__getitem__(0)
+        assert isinstance(result, tuple) and len(result) == 2
+        data, target = result
+        assert isinstance(data, dict)
+        assert isinstance(target, dict)
+        assert "modality_1" in data and "modality_2" in data
+        assert "label_1" in target and "label_2" in target
+        assert isinstance(data["modality_1"], d_type)
+        assert isinstance(data["modality_2"], d_type)
+        assert isinstance(target["label_1"], d_type)
+        assert isinstance(target["label_2"], d_type)
+
+
+def test_apply_default_types_exception_is_wrapped():
+    """_apply_default_types wraps errors raised while converting data."""
+
+    ds = ValidNumpyDataset()
+    ds.complete_initialization(
+        controller_kwargs={"root": "dummy_path"},
+        to_format=DataReturnFormat.SKLEARN,
+    )
+
+    bad_data = {
+        "modality_1": np.array([1.0, 2.0], dtype=np.float32),
+        "modality_2": "not-an-array",
+    }
+
+    with pytest.raises(
+        FedbiomedError, match="Failed to apply default training plan types"
+    ):
+        ds._apply_default_types(bad_data, "data")


### PR DESCRIPTION

**PR description**

Address #1724 by supporting multi-modal `CustomDataset`.

Data and/or target can be a dict of torch.Tensor (PyTorch) / dict of np.ndarray (scikit-learn)
- this does not solve the issue in v6.2
- unit test coverage extended for CustomDataset
- tested with PyTorch (101 notebook) & scikit-learn (SGD regressor notebook)

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`