### PR TITLE
Fix target_transform validation in TabularDataset issue 1747

### DIFF
--- a/envs/vpn/README.md
+++ b/envs/vpn/README.md
@@ -206,7 +206,7 @@ Alternative: launch container with Nvidia GPU support activated. Before launchin
 ```bash
 [user@node $] NODE=node-gpu
 # - `--gpu` : default gpu policy == use GPU if available *and* requested by researcher
-[user@node $] FBM_NODE_START_OPTIONS="--gpu"
+[user@node $] FBM_NODE_START_OPTIONS=--gpu
 [user@node $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker compose up -d $NODE
 ```
   * note : `CONTAINER_{UID,GID,USER,GROUP}` are not necessary if using the same identity as in for the build, but they need to have a read/write access to the directories mounted from the host machine's filesystem.
@@ -228,7 +228,7 @@ Alternative: launch container with Nvidia GPU support activated. Before launchin
 
 Run this for all launches of the container :
 
-* if using GPU set `FBM_NODE_START_OPTIONS="--gpu"`
+* if using GPU set `FBM_NODE_START_OPTIONS=--gpu`
 * launch container
 ```bash
 # `CONTAINER_{UID,GID,USER,GROUP}` are not needed if they are the same as used for build

--- a/envs/vpn/docker/node/build_files/entrypoint.bash
+++ b/envs/vpn/docker/node/build_files/entrypoint.bash
@@ -39,7 +39,7 @@ su -l -c "export FBM_SECURITY_ALLOW_FEDERATED_ANALYTICS=\"${FBM_SECURITY_ALLOW_F
       fedbiomed component create --component NODE --path /fbm-node --exist-ok" $CONTAINER_USER
 
 # Overwrite node options file if re-launching container
-#   eg FBM_NODE_START_OPTIONS="--gpu-only" can be used for starting node forcing GPU usage
+#   eg FBM_NODE_START_OPTIONS=--gpu-only can be used for starting node forcing GPU usage
 su -l -c "echo \"$FBM_NODE_START_OPTIONS\" >/fbm-node/FBM_NODE_START_OPTIONS" $CONTAINER_USER
 
 # Launch node using node options

--- a/fedbiomed/common/dataset/_tabular_dataset.py
+++ b/fedbiomed/common/dataset/_tabular_dataset.py
@@ -98,7 +98,7 @@ class TabularDataset(Dataset):
         if self._target_columns is not None:
             self._validate_format_and_transformations(
                 self._get_item_from_sample(sample, self._target_columns),
-                transform=self._transform,
+                transform=self._target_transform,
             )
 
     def _get_item_from_sample(

--- a/tests/test_dataset/test_tabular_dataset.py
+++ b/tests/test_dataset/test_tabular_dataset.py
@@ -228,6 +228,7 @@ def test_getitem_transform_error_on_target(mocker):
 def test_validate_transform_accepts_none_identity():
     ds = TabularDataset(input_columns=[0], target_columns=[1], transform=None)
     assert ds._transform("x") == "x"
+    assert ds._target_transform("x") == "x"
 
 
 def test_validate_transform_accepts_callable():
@@ -235,12 +236,28 @@ def test_validate_transform_accepts_callable():
         input_columns=[0], target_columns=[1], transform=lambda z: z + 1
     )
     assert ds._transform(41) == 42
+    assert ds._target_transform(41) == 41
+
+
+def test_validate_target_transform_accepts_callable():
+    ds = TabularDataset(
+        input_columns=[0], target_columns=[1], target_transform=lambda z: z + 1
+    )
+    assert ds._transform(41) == 41
+    assert ds._target_transform(41) == 42
 
 
 def test_validate_transform_rejects_other_types():
     with pytest.raises(FedbiomedValueError):
         _ = TabularDataset(
             input_columns=[0], target_columns=[1], transform="not callable"
+        )
+
+
+def test_validate_target_transform_rejects_other_types():
+    with pytest.raises(FedbiomedValueError):
+        _ = TabularDataset(
+            input_columns=[0], target_columns=[1], target_transform="not callable"
         )
 
 


### PR DESCRIPTION

**PR description**

- address and complete #1747 - fix bug in target_transform validation in TabularDataset
- also fix misc FBM_NODE_START_OPTIONS syntax example in documentation


**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`