### PR TITLE
fix: expose current round in training plans

### DIFF
--- a/docs/user-guide/researcher/training-plan.md
+++ b/docs/user-guide/researcher/training-plan.md
@@ -109,7 +109,7 @@ Fed-BioMed provides the following getter functions to access Training Plan attri
 | model arguments     | `model_args()`     | :heavy_check_mark: | :heavy_check_mark:  | |
 | training arguments  | `training_args()`  | :heavy_check_mark: | :heavy_check_mark:  | |
 | optimizer arguments | `optimizer_args()` | :heavy_check_mark: | :heavy_check_mark:  | |
-| current round | `round` | :heavy_check_mark: | :heavy_check_mark:  | current federated training round on the node, or `None` before node-side execution starts. |
+| current round | `round()` | :heavy_check_mark: | :heavy_check_mark:  | current federated training round on the node, or `None` before node-side execution starts. |
 | node is | `node_id()` | :heavy_check_mark: | :heavy_check_mark:  | |
 
 ####

--- a/docs/user-guide/researcher/training-plan.md
+++ b/docs/user-guide/researcher/training-plan.md
@@ -109,6 +109,7 @@ Fed-BioMed provides the following getter functions to access Training Plan attri
 | model arguments     | `model_args()`     | :heavy_check_mark: | :heavy_check_mark:  | |
 | training arguments  | `training_args()`  | :heavy_check_mark: | :heavy_check_mark:  | |
 | optimizer arguments | `optimizer_args()` | :heavy_check_mark: | :heavy_check_mark:  | |
+| current round | `round` | :heavy_check_mark: | :heavy_check_mark:  | current federated training round on the node, or `None` before node-side execution starts. |
 | node is | `node_id()` | :heavy_check_mark: | :heavy_check_mark:  | |
 
 ####

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -93,6 +93,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         self._loader_args: Dict[str, Any] = None
         self._training_args: Dict[str, Any] = None
         self._node_id: Optional[str] = None
+        self._round: Optional[int] = None
         self._local_params: Optional[List[str]] = None
 
         self._error_msg_import_model: str = (
@@ -974,6 +975,23 @@ class BaseTrainingPlan(metaclass=ABCMeta):
             Node id
         """
         return self._node_id
+
+    @property
+    def round(self) -> Optional[int]:
+        """Retrieve the current federated training round.
+
+        Returns:
+            Current round number, or None if not running on a node.
+        """
+        return self._round
+
+    def set_round(self, round_: int) -> None:
+        """Set the current federated training round.
+
+        Args:
+            round_: Current round number.
+        """
+        self._round = round_
 
     @property
     def local_params(self) -> Optional[List[str]]:

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -976,7 +976,6 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         """
         return self._node_id
 
-    @property
     def round(self) -> Optional[int]:
         """Retrieve the current federated training round.
 

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -326,6 +326,7 @@ class Round:
                 aggregator_args=self.aggregator_args,
                 node_id=self._node_id,
             )
+            self.training_plan.set_round(self._round)
             logger.debug(
                 f"Training plan initialized for round: experiment={self.experiment_id} "
                 f"round={self._round} plan={self.training_plan.__class__.__name__} "

--- a/tests/test_base_training_plan.py
+++ b/tests/test_base_training_plan.py
@@ -148,9 +148,9 @@ class TestBaseTrainingPlan(unittest.TestCase):
     def test_base_training_plan_06_round(self):
         """Test setting and retrieving the current training round."""
 
-        self.assertIsNone(self.tp.round)
+        self.assertIsNone(self.tp.round())
         self.tp.set_round(3)
-        self.assertEqual(self.tp.round, 3)
+        self.assertEqual(self.tp.round(), 3)
 
     def test_base_training_plan_07__create_metric_result(self):
         """

--- a/tests/test_base_training_plan.py
+++ b/tests/test_base_training_plan.py
@@ -145,7 +145,14 @@ class TestBaseTrainingPlan(unittest.TestCase):
         self.assertListEqual(self.tp.training_data_loader, train_data_loader)
         self.assertListEqual(self.tp.testing_data_loader, test_data_loader)
 
-    def test_base_training_plan_06__create_metric_result(self):
+    def test_base_training_plan_06_round(self):
+        """Test setting and retrieving the current training round."""
+
+        self.assertIsNone(self.tp.round)
+        self.tp.set_round(3)
+        self.assertEqual(self.tp.round, 3)
+
+    def test_base_training_plan_07__create_metric_result(self):
         """
         Testing private method create metric result dict
 

--- a/tests/test_round.py
+++ b/tests/test_round.py
@@ -272,6 +272,7 @@ class TestRound(unittest.TestCase):
         # `run_model_training`
         with (
             patch.object(FakeModel, "set_dataset_path"),
+            patch.object(FakeModel, "set_round") as mock_set_round,
             patch.object(FakeModel, "training_routine") as mock_training_routine,
             patch.object(
                 self.r1, "_split_train_and_test_data"
@@ -294,6 +295,7 @@ class TestRound(unittest.TestCase):
             # Set dataset is called in set_train_and_test_data
             # mock_set_dataset.assert_called_once_with(self.r1.dataset.get('path'))
             mock_split_train_and_test_data.assert_called_once()
+            mock_set_round.assert_called_once_with(self.r1._round)
 
             # Since set training data return None, training_routine should be called as None
             mock_training_routine.assert_called_once_with(


### PR DESCRIPTION
**PR description**

Fixes #1771.

This PR exposes the current federated training round to training plans via `self.round`, and sets it on the node before dataset preparation/training starts.

Relevant checks run locally:
- `python3 -m ruff check fedbiomed/common/training_plans/_base_training_plan.py fedbiomed/node/round.py tests/test_base_training_plan.py tests/test_round.py` — passed
- `python3 -m py_compile fedbiomed/common/training_plans/_base_training_plan.py fedbiomed/node/round.py tests/test_base_training_plan.py tests/test_round.py` — passed
- `python3 -m pytest tests/test_base_training_plan.py tests/test_round.py` — blocked in local environment during collection because `torchvision` is not installed

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`
