### PR TITLE
CI not failing when cannot push to codecov

### DIFF
--- a/.github/workflows/fbm-generic-test.yml
+++ b/.github/workflows/fbm-generic-test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install Dependencies
         run: pdm install --no-default -G docs -G dev
-      
+
       - name: Configure git
         run: |
           git config --global user.name "GitHub Actions Bot"
@@ -51,7 +51,6 @@ jobs:
         os: ${{ fromJson(inputs.os-list) }}
         python-version: ${{ fromJson(inputs.python-versions) }}
 
-      
     runs-on: ${{ matrix.os }}
     if: github.event.pull_request.draft == false
     steps:
@@ -111,7 +110,7 @@ jobs:
           files: tests/coverage.xml
           flags: unittests-${{ matrix.os }} # optional
           name: codecov-umbrella # optional
-          fail_ci_if_error: true # optional (default = false)
+          fail_ci_if_error: false # may fail for PR from forks
           verbose: true # optional (default = false)
 
       - name: Notify upload impossible on m1


### PR DESCRIPTION
**PR description**

CI not failing when cannot push to codecov

No associated issue.
Cover the case of forked PR.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`