### PR TITLE
make `round` accessible in training plan on node - continued

### DIFF
--- a/docs/user-guide/researcher/training-plan.md
+++ b/docs/user-guide/researcher/training-plan.md
@@ -109,8 +109,8 @@ Fed-BioMed provides the following getter functions to access Training Plan attri
 | model arguments     | `model_args()`     | :heavy_check_mark: | :heavy_check_mark:  | |
 | training arguments  | `training_args()`  | :heavy_check_mark: | :heavy_check_mark:  | |
 | optimizer arguments | `optimizer_args()` | :heavy_check_mark: | :heavy_check_mark:  | |
-| current round | `round()` | :heavy_check_mark: | :heavy_check_mark:  | current federated training round on the node, or `None` before node-side execution starts. |
-| node is | `node_id()` | :heavy_check_mark: | :heavy_check_mark:  | |
+| current round | `round()` | :heavy_check_mark: | :heavy_check_mark:  | current training round on node side, `None` on researcher side |
+| node id | `node_id()` | :heavy_check_mark: | :heavy_check_mark:  | ID of the node on node side, `None` on researcher side |
 
 ####
 

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -153,6 +153,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         aggregator_args: Optional[Dict[str, Any]] = None,
         initialize_optimizer: bool = True,
         node_id: Optional[str] = None,
+        round: Optional[int] = None,
     ) -> None:
         """Process model, training and optimizer arguments.
 
@@ -165,6 +166,8 @@ class BaseTrainingPlan(metaclass=ABCMeta):
                 researcher-side aggregator.
             initialize_optimizer: whether to initialize the optimizer or not. Defaults
                 to True.
+            node_id: the ID of the node executing the training plan, if applicable.
+            round: the current round of training, if applicable.
         """
 
         # Store various arguments provided by the researcher
@@ -174,7 +177,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         self._loader_args = training_args.loader_arguments() or {}
         self._training_args = training_args.pure_training_arguments()
         self._node_id = node_id
-
+        self._set_round(round)
         # Set random seed: the seed can be either None or an int provided by the researcher.
         # when it is None, both random.seed and np.random.seed rely on the OS to generate a random seed.
         rseed = training_args.get("random_seed")
@@ -984,7 +987,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         """
         return self._round
 
-    def set_round(self, round_: int) -> None:
+    def _set_round(self, round_: int) -> None:
         """Set the current federated training round.
 
         Args:

--- a/fedbiomed/common/training_plans/_sklearn_models.py
+++ b/fedbiomed/common/training_plans/_sklearn_models.py
@@ -300,6 +300,7 @@ class FedPerceptron(FedSGDClassifier):
         training_args: Dict[str, Any],
         aggregator_args: Optional[Dict[str, Any]] = None,
         node_id: Optional[str] = None,
+        round: Optional[int] = None,
         **kwargs,
     ) -> None:
         # get default values of Perceptron model (different from SGDClassifier model default values)
@@ -307,7 +308,7 @@ class FedPerceptron(FedSGDClassifier):
 
         # make sure loss used is perceptron loss - can not be changed by user
         model_args["loss"] = "perceptron"
-        super().post_init(model_args, training_args, node_id=node_id)
+        super().post_init(model_args, training_args, node_id=node_id, round=round)
         self._model.set_params(loss="perceptron")
 
         # Since we are using the SGDClassifier as a base model,

--- a/fedbiomed/common/training_plans/_sklearn_training_plan.py
+++ b/fedbiomed/common/training_plans/_sklearn_training_plan.py
@@ -91,6 +91,7 @@ class SKLearnTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         aggregator_args: Optional[Dict[str, Any]] = None,
         initialize_optimizer: bool = True,
         node_id: Optional[str] = None,
+        round: Optional[int] = None,
     ) -> None:
         """Process model, training and optimizer arguments.
 
@@ -102,9 +103,13 @@ class SKLearnTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
             aggregator_args: Arguments managed by and shared with the
                 researcher-side aggregator.
             initialize_optimizer: Unused.
+            node_id: the ID of the node executing the training plan, if applicable.
+            round: the current round of training, if applicable.
         """
         model_args.setdefault("verbose", 1)
-        super().post_init(model_args, training_args, aggregator_args, node_id=node_id)
+        super().post_init(
+            model_args, training_args, aggregator_args, node_id=node_id, round=round
+        )
         self._model = SkLearnModel(self._model_cls)
         self._batch_maxnum = self._training_args.get("batch_maxnum", self._batch_maxnum)
         self._warn_about_training_args()

--- a/fedbiomed/common/training_plans/_torchnn.py
+++ b/fedbiomed/common/training_plans/_torchnn.py
@@ -138,6 +138,7 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
         aggregator_args: Optional[Dict[str, Any]] = None,
         initialize_optimizer: bool = True,
         node_id: Optional[str] = None,
+        round: Optional[int] = None,
     ) -> None:
         """Process model, training and optimizer arguments.
 
@@ -150,12 +151,16 @@ class TorchTrainingPlan(BaseTrainingPlan, metaclass=ABCMeta):
                 researcher-side aggregator.
             initialize_optimizer: If True, configures optimizer. It has to be True for node
                 side configuration to prepare optimizer for the training.
+            node_id: the ID of the node executing the training plan, if applicable.
+            round: the current round of training, if applicable.
         Raises:
             FedbiomedTrainingPlanError: If the provided arguments do not
                 match expectations, or if the optimizer, model and dependencies
                 configuration goes wrong.
         """
-        super().post_init(model_args, training_args, aggregator_args, node_id=node_id)
+        super().post_init(
+            model_args, training_args, aggregator_args, node_id=node_id, round=round
+        )
         # Assign scalar attributes.
         self._use_gpu = self._training_args.get("use_gpu")
         self._batch_maxnum = self._training_args.get("batch_maxnum")

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -325,8 +325,8 @@ class Round:
                 training_args=self.training_arguments,
                 aggregator_args=self.aggregator_args,
                 node_id=self._node_id,
+                round=self._round,
             )
-            self.training_plan.set_round(self._round)
             logger.debug(
                 f"Training plan initialized for round: experiment={self.experiment_id} "
                 f"round={self._round} plan={self.training_plan.__class__.__name__} "

--- a/fedbiomed/researcher/federated_workflows/_training_plan_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_training_plan_workflow.py
@@ -157,6 +157,8 @@ class TrainingPlanWorkflow(FederatedWorkflow, ABC):
             model_args={} if self._model_args is None else self._model_args,
             training_args=self._training_args,
             initialize_optimizer=False,
+            # node_id does not exist on researcher side
+            # round_current does not exist at this stage
         )
 
         return training_plan, training_plan_file

--- a/tests/test_base_training_plan.py
+++ b/tests/test_base_training_plan.py
@@ -149,7 +149,7 @@ class TestBaseTrainingPlan(unittest.TestCase):
         """Test setting and retrieving the current training round."""
 
         self.assertIsNone(self.tp.round())
-        self.tp.set_round(3)
+        self.tp._set_round(3)
         self.assertEqual(self.tp.round(), 3)
 
     def test_base_training_plan_07__create_metric_result(self):

--- a/tests/test_round.py
+++ b/tests/test_round.py
@@ -272,7 +272,7 @@ class TestRound(unittest.TestCase):
         # `run_model_training`
         with (
             patch.object(FakeModel, "set_dataset_path"),
-            patch.object(FakeModel, "set_round") as mock_set_round,
+            patch.object(FakeModel, "_set_round") as mock_set_round,
             patch.object(FakeModel, "training_routine") as mock_training_routine,
             patch.object(
                 self.r1, "_split_train_and_test_data"

--- a/tests/testsupport/fake_training_plan.py
+++ b/tests/testsupport/fake_training_plan.py
@@ -50,9 +50,12 @@ class FakeModel(BaseTrainingPlan):
         training_args: Dict[str, Any],
         aggregator_args: Optional[Dict[str, Any]] = None,
         node_id: Optional[str] = None,
+        round: Optional[int] = None,
     ) -> None:
         """Fake 'post_init', that does not make use of input arguments."""
-        super().post_init(model_args, training_args, aggregator_args, node_id=node_id)
+        super().post_init(
+            model_args, training_args, aggregator_args, node_id=node_id, round=round
+        )
 
     def model(self):
         return self._model


### PR DESCRIPTION
**PR description**

Completes #1771 (as a complement of PR #1772)

Refactors initial implementation to use `post_init()` to pass the round rather than an adhoc `set_round()` call

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`