### PR TITLE
raise error if non numerical data is found in data ready-to-use

### DIFF
--- a/fedbiomed/common/dataset/_dataset.py
+++ b/fedbiomed/common/dataset/_dataset.py
@@ -125,7 +125,11 @@ class Dataset(ABC):
         elif np.issubdtype(x.dtype, np.integer):
             return x.astype(np.int64, copy=False)
         else:
-            return x
+            raise FedbiomedError(
+                f"{ErrorNumbers.FB632.value}: Expected numeric dtype (floating or integer) "
+                f"for sklearn format, got '{x.dtype}'. Ensure all selected columns "
+                "contain numeric data."
+            )
 
     def _get_default_types_callable(self) -> Callable:
         """Gets function to set default types according to expected format

--- a/fedbiomed/common/dataset/_tabular_dataset.py
+++ b/fedbiomed/common/dataset/_tabular_dataset.py
@@ -112,10 +112,22 @@ class TabularDataset(Dataset):
 
         Returns:
             Selected columns or None if columns is None
+
+        Raises:
+            FedbiomedError: if any selected column has a non-numeric dtype
         """
         if columns is None:
             return None
-        return sample.select(columns)
+        data = sample.select(columns)
+        non_numeric = [
+            name for name, dtype in data.schema.items() if not dtype.is_numeric()
+        ]
+        if non_numeric:
+            raise FedbiomedError(
+                f"{ErrorNumbers.FB632.value}: Column(s) {non_numeric} have non-numeric "
+                "dtype and cannot be converted. Cast to numeric types or drop them."
+            )
+        return data
 
     def __getitem__(
         self, idx: int

--- a/fedbiomed/common/dataset/_tabular_dataset.py
+++ b/fedbiomed/common/dataset/_tabular_dataset.py
@@ -15,13 +15,30 @@ from fedbiomed.common.exceptions import FedbiomedError
 from fedbiomed.common.logger import logger
 
 
+def _polars_to_torch(x: pl.DataFrame) -> "torch.Tensor":
+    try:
+        return x.to_torch().reshape(-1)
+    except TypeError as e:
+        non_numeric = [
+            name for name, dtype in x.schema.items() if not dtype.is_numeric()
+        ]
+        if non_numeric:
+            raise FedbiomedError(
+                f"{ErrorNumbers.FB632.value}: Column(s) {non_numeric} have non-numeric "
+                "dtype and cannot be converted to a torch Tensor. Encode or drop them "
+                "before creating the dataset."
+            ) from e
+        raise FedbiomedError(
+            f"{ErrorNumbers.FB632.value}: Failed to convert data to a torch Tensor: {e}"
+        ) from e
+
+
 class TabularDataset(Dataset):
     _controller_cls: type = TabularController
 
-    # Input from controller is Polars Series
     _native_to_framework = {
         DataReturnFormat.SKLEARN: lambda x: x.to_numpy().reshape(-1),
-        DataReturnFormat.TORCH: lambda x: x.to_torch().reshape(-1),
+        DataReturnFormat.TORCH: _polars_to_torch,
     }
 
     def __init__(

--- a/fedbiomed/common/dataset/_tabular_dataset.py
+++ b/fedbiomed/common/dataset/_tabular_dataset.py
@@ -142,7 +142,8 @@ class TabularDataset(Dataset):
         if non_numeric:
             raise FedbiomedError(
                 f"{ErrorNumbers.FB632.value}: Column(s) {non_numeric} have non-numeric "
-                "dtype and cannot be converted. Cast to numeric types or drop them."
+                "dtype and cannot be converted for training. Encode or drop them before "
+                "creating the dataset."
             )
         return data
 

--- a/fedbiomed/node/jobs/_fa_job.py
+++ b/fedbiomed/node/jobs/_fa_job.py
@@ -7,6 +7,8 @@ Implementation of Federated Analytics Job class of the node component
 
 from typing import Dict
 
+import polars as pl
+
 from fedbiomed.common.constants import DatasetTypes, ErrorNumbers, FedbiomedError, Stats
 from fedbiomed.common.dataloadingplan import DataLoadingPlan
 from fedbiomed.common.dataset import REGISTRY_CONTROLLERS, Dataset
@@ -79,8 +81,15 @@ class FAJob(_BaseJob):
                     f"Dataset entry contains unsupported dataset type '{data_type}'."
                 )
             case DatasetTypes.TABULAR:
-                # Take keys in 'dtypes' and pass them as ``input_columns`` to the dataset constructor
-                return {"input_columns": list(dataset_entry.get("dtypes", {}))}
+                # Keep only columns whose dtype produces a numerical numpy array via to_numpy()
+                return {
+                    "input_columns": [
+                        col
+                        for col, dtype_name in dataset_entry.get("dtypes", {}).items()
+                        if (cls := getattr(pl, dtype_name, None)) is not None
+                        and cls().is_numeric()
+                    ]
+                }
             case DatasetTypes.IMAGES | DatasetTypes.DEFAULT | DatasetTypes.MEDNIST:
                 # For image datasets, no dataset arguments are passed by default
                 return {}

--- a/tests/test_analytics/test_node_fa_job.py
+++ b/tests/test_analytics/test_node_fa_job.py
@@ -117,7 +117,7 @@ def test_build_error_msg_default_errnum(fa_job):
     [
         (
             DatasetTypes.TABULAR,
-            {"dtypes": {"col1": "int", "col2": "float"}},
+            {"dtypes": {"col1": "Int64", "col2": "Float64"}},
             {"input_columns": ["col1", "col2"]},
         ),
         (
@@ -137,6 +137,41 @@ def test_build_args_for_dataset(fa_job, dtype_enum, entry_extra, expected):
         return_value=dtype_enum,
     ):
         assert fa_job._build_args_for_dataset(entry) == expected
+
+
+@pytest.mark.parametrize(
+    "dtypes,expected_columns",
+    [
+        # All numerical
+        (
+            {"a": "Int8", "b": "Int16", "c": "Int32", "d": "Int64", "e": "Int128"},
+            ["a", "b", "c", "d", "e"],
+        ),
+        (
+            {"a": "UInt8", "b": "UInt16", "c": "UInt32", "d": "UInt64"},
+            ["a", "b", "c", "d"],
+        ),
+        ({"a": "Float32", "b": "Float64"}, ["a", "b"]),
+        # Mixed: only numerical columns returned
+        ({"num": "Int64", "text": "String", "flag": "Boolean", "dt": "Date"}, ["num"]),
+        ({"x": "Float32", "label": "String"}, ["x"]),
+        # All non-numerical: empty list
+        ({"a": "String", "b": "Boolean", "c": "Date"}, []),
+        # Empty dtypes: empty list
+        ({}, []),
+    ],
+)
+def test_build_args_for_dataset_tabular_numerical_filter(
+    fa_job, dtypes, expected_columns
+):
+    """Only columns with numerical polars dtypes are included in input_columns."""
+    entry = {"data_type": DatasetTypes.TABULAR.value, "dtypes": dtypes}
+    with patch(
+        "fedbiomed.node.jobs._fa_job.DatasetTypes.get_type_by_value",
+        return_value=DatasetTypes.TABULAR,
+    ):
+        result = fa_job._build_args_for_dataset(entry)
+    assert result["input_columns"] == expected_columns
 
 
 def test_build_args_for_dataset_custom_raises(fa_job):

--- a/tests/test_dataset/test_dataset.py
+++ b/tests/test_dataset/test_dataset.py
@@ -144,10 +144,10 @@ def test_14_default_types_sklearn():
     y_int = ds._default_types_sklearn(x_int)
     assert y_int.dtype == np.int64
 
-    # non-numeric dtype left untouched
-    x_str = np.array(["a", "b"], dtype=object)
-    y_str = ds._default_types_sklearn(x_str)
-    assert y_str is x_str
+    # non-numeric dtypes raise: object (strings) and bool
+    for bad in (np.array(["a", "b"], dtype=object), np.array([True, False])):
+        with pytest.raises(FedbiomedError):
+            ds._default_types_sklearn(bad)
 
     with pytest.raises(FedbiomedError):
         ds._default_types_sklearn([1, 2, 3])

--- a/tests/test_dataset/test_tabular_dataset.py
+++ b/tests/test_dataset/test_tabular_dataset.py
@@ -464,6 +464,89 @@ def test_apply_transforms_error_cases(mocker):
     assert "Failed to apply default training plan types to `target`" in str(exc4.value)
 
 
+# ---------- _get_item_from_sample: numeric validation ----------
+
+
+def test_get_item_from_sample_numeric_passes_non_numeric_raises():
+    ds = TabularDataset(input_columns=["a"])
+    df = pl.DataFrame({"a": [1], "b": [2.5], "name": ["Alice"], "city": ["NYC"]})
+
+    # None → None
+    assert ds._get_item_from_sample(df, None) is None
+
+    # All-numeric selection passes and returns the right columns
+    result = ds._get_item_from_sample(df, ["a", "b"])
+    assert isinstance(result, pl.DataFrame) and result.columns == ["a", "b"]
+
+    # Single string column → raises with that column name
+    with pytest.raises(FedbiomedError, match="name"):
+        ds._get_item_from_sample(df, ["a", "name"])
+
+    # Multiple non-numeric → all listed, numeric columns not mentioned
+    with pytest.raises(FedbiomedError) as exc:
+        ds._get_item_from_sample(df, ["name", "city", "a"])
+    msg = str(exc.value)
+    assert "name" in msg and "city" in msg and "age" not in msg
+
+
+@pytest.mark.parametrize("fmt", [DataReturnFormat.SKLEARN, DataReturnFormat.TORCH])
+@pytest.mark.parametrize(
+    "input_cols, target_cols, df_data, bad_col",
+    [
+        (["feature"], ["target"], {"feature": ["txt"], "target": [1]}, "feature"),
+        (["feature"], ["label"], {"feature": [1.0], "label": ["cat"]}, "label"),
+    ],
+)
+def test_complete_initialization_raises_for_non_numeric_column(
+    mocker, fmt, input_cols, target_cols, df_data, bad_col
+):
+    df = pl.DataFrame(df_data)
+
+    class StubController:
+        def get_sample(self, idx):
+            return df
+
+        def normalize_columns(self, cols):
+            return cols
+
+    ds = TabularDataset(input_columns=input_cols, target_columns=target_cols)
+    mocker.patch.object(
+        ds,
+        "_init_controller",
+        side_effect=lambda controller_kwargs: setattr(
+            ds, "_controller", StubController()
+        ),
+    )
+    with pytest.raises(FedbiomedError, match=bad_col):
+        ds.complete_initialization(controller_kwargs={}, to_format=fmt)
+
+
+@pytest.mark.parametrize(
+    "input_cols, target_cols, df_data, bad_col",
+    [
+        (["feature"], ["label"], {"feature": ["txt"], "label": [1]}, "feature"),
+        (["feature"], ["label"], {"feature": [1.0], "label": ["cat"]}, "label"),
+    ],
+)
+def test_getitem_raises_for_non_numeric_column(
+    input_cols, target_cols, df_data, bad_col
+):
+    ds = TabularDataset(input_columns=input_cols, target_columns=target_cols)
+    df = pl.DataFrame(df_data)
+
+    class StubController:
+        def get_sample(self, idx):
+            return df
+
+    ds._controller = StubController()
+    ds._input_columns = input_cols
+    ds._target_columns = target_cols
+    ds._to_format = DataReturnFormat.SKLEARN
+
+    with pytest.raises(FedbiomedError, match=bad_col):
+        _ = ds[0]
+
+
 # ---------- analytics ----------
 
 

--- a/tests/test_dataset/test_tabular_dataset.py
+++ b/tests/test_dataset/test_tabular_dataset.py
@@ -3,7 +3,7 @@ import numpy as np
 import polars as pl
 import pytest
 
-from fedbiomed.common.dataset._tabular_dataset import TabularDataset
+from fedbiomed.common.dataset._tabular_dataset import TabularDataset, _polars_to_torch
 from fedbiomed.common.dataset_types import DataReturnFormat
 from fedbiomed.common.exceptions import FedbiomedError, FedbiomedValueError
 
@@ -122,6 +122,29 @@ def test_get_format_conversion_callable_returns_torch_callable():
     ds.to_format = DataReturnFormat.TORCH
     fn = ds._get_format_conversion_callable()
     assert fn is TabularDataset._native_to_framework[DataReturnFormat.TORCH]
+
+
+def test_polars_to_torch_numeric_passes():
+    import torch
+
+    result = _polars_to_torch(pl.DataFrame({"a": [1], "b": [2.5]}))
+    assert isinstance(result, torch.Tensor) and result.shape == (2,)
+
+
+def test_polars_to_torch_string_column_raises_naming_the_column():
+    with pytest.raises(FedbiomedError, match="name"):
+        _polars_to_torch(pl.DataFrame({"a": [1], "name": ["Alice"]}))
+
+
+def test_polars_to_torch_unused_string_columns_do_not_raise():
+    """Only selected (already-filtered) columns are checked; unselected strings are irrelevant."""
+    import torch
+
+    full_df = pl.DataFrame({"age": [30], "name": ["Alice"], "score": [0.95]})
+    ds = TabularDataset(input_columns=["age", "score"])
+    selected = ds._get_item_from_sample(full_df, ["age", "score"])
+    result = _polars_to_torch(selected)
+    assert isinstance(result, torch.Tensor)
 
 
 def test_get_format_conversion_callable_raises_for_unknown_format():


### PR DESCRIPTION
Ensures data ready-to-use is in the right format

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`