### PR TITLE
uses unit64 instead of unit32 for masked vectors in LOM secagg

### DIFF
--- a/fedbiomed/common/secagg/_lom.py
+++ b/fedbiomed/common/secagg/_lom.py
@@ -71,15 +71,15 @@ class PRF:
             algorithms.ChaCha20(seed, self._nonce), mode=None, backend=default_backend()
         ).encryptor()
 
-        # TODO: Better handling limits for secure aggregation
-        if not (input_size + _MAX_ROUND) <= 2**32:
+        if not (input_size + _MAX_ROUND) <= 2**61:
             raise FedbiomedSecaggError(
                 f"{ErrorNumbers.FB417.value}: Can not perform encryiton due to large input vector. input_size "
-                f"({input_size}) + MAX_ROUND ({_MAX_ROUND}) allowed is greater than 2**32"
+                f"({input_size}) + MAX_ROUND ({_MAX_ROUND}) allowed is greater than 2**61 "
             )
 
         # create a list of indices from 0 to input_size where each element is concatenated with tau
-        taus = b"".join([(i + tau).to_bytes(4, "big") for i in range(input_size)])
+        taus = b"".join([(i + tau).to_bytes(8, "big") for i in range(input_size)])
+
         return encryptor.update(taus) + encryptor.finalize()
 
 
@@ -97,7 +97,7 @@ class LOM:
             nonce = secrets.token_bytes(16)
 
         self._prf: PRF = PRF(nonce)
-        self._vector_dtype: str = "uint32"
+        self._vector_dtype: str = "uint64"
         self._values_bit = np.iinfo(
             np.dtype(self._vector_dtype)
         ).bits  # should be equal to 32 bit
@@ -122,8 +122,8 @@ class LOM:
 
         Raises:
             FedBioMedError: raises if the input vector `x_u_tau` contains any
-                values that exceed  `32 - log_2(numner_of_nodes)`, where `32` is
-                the number of bit for each value (`uint32`). Not respecting the above condition
+                values that exceed  `64 - log_2(numner_of_nodes)`, where `64` is
+                the number of bit for each value (`uint64`). Not respecting the above condition
                 can lead to computation overflow.
 
         Returns:
@@ -134,13 +134,19 @@ class LOM:
         _max_param_bits = max(val.bit_length() for val in x_u_tau)
         _node_bits = math.ceil(math.log2(num_nodes))
 
-        if _max_param_bits > self._values_bit - _node_bits:
+        if _max_param_bits >= self._values_bit - _node_bits:
             _max_nodes = 2 ** (self._values_bit - _max_param_bits)
             _missing_bits = _max_param_bits + _node_bits - self._values_bit
             raise FedbiomedSecaggError(
-                f"{ErrorNumbers.FB417.value}: Computation overflow using LOM secagg "
-                f"with current settings. Cannot use more than {_max_nodes} nodes or need to "
-                f"reduce sample number on this node to use {_missing_bits} bit(s) less."
+                f"{ErrorNumbers.FB417.value}: Secure aggregation overflow detected.\n\n"
+                f"Your value requires {_max_param_bits} bits, but only {self._values_bit - _node_bits} bits "
+                f"are available ({self._values_bit}-bit dtype minus {_node_bits} bits reserved for {num_nodes} nodes).\n\n"
+                f"To fix this, choose one of the following:\n"
+                f"  1) Reduce the number of nodes to at most {_max_nodes} (currently {num_nodes}).\n"
+                f"  2) Reduce your values by at least {_missing_bits} bit(s) "
+                f"(i.e. divide them by at least {2**_missing_bits}).\n"
+                f"  3) If you are quantizing model weights, use a lower quantization range "
+                f"so that individual values fit within {self._values_bit - _node_bits} bits."
             )
 
         x_u_tau = np.array(x_u_tau, dtype=self._vector_dtype)
@@ -158,9 +164,7 @@ class LOM:
             pairwise_vector = self._prf.eval_vector(
                 seed=pairwise_seed, tau=tau, input_size=len(x_u_tau)
             )
-
             pairwise_vector = np.frombuffer(pairwise_vector, dtype=self._vector_dtype)
-
             if pair_id < node_id:
                 mask += pairwise_vector
             else:
@@ -182,7 +186,7 @@ class LOM:
         """
         list_y_u_tau = np.array(list_y_u_tau, dtype=self._vector_dtype)
         decrypted_vector = np.sum(list_y_u_tau, axis=0)
-        decrypted_vector = decrypted_vector.astype(np.uint32)
+        decrypted_vector = decrypted_vector.astype(np.uint64)
         decrypted_vector = decrypted_vector.tolist()
 
         return decrypted_vector

--- a/tests/test_lom.py
+++ b/tests/test_lom.py
@@ -41,13 +41,13 @@ def test_01_lom_module_prf():
     input_size = 10
 
     buffer = prf.eval_vector(seed, round, input_size)
-    vector = np.frombuffer(buffer, dtype="uint32")
+    vector = np.frombuffer(buffer, dtype="uint64")
     assert len(vector) == input_size
 
     # Test with larger input size
     input_size = 10000
     buffer = prf.eval_vector(seed, round, input_size)
-    vector = np.frombuffer(buffer, dtype="uint32")
+    vector = np.frombuffer(buffer, dtype="uint64")
     assert len(vector) == input_size
 
 
@@ -109,10 +109,10 @@ def test_03_lom_protect_big_int(pairwise_keys):
     assert aggregated_vector == sum_x.tolist()
 
     with pytest.raises(FedbiomedSecaggError) as _:
-        r_int = random.getrandbits(32)
-        while r_int.bit_length() < 32:
-            # make sure `r_int` is of size 32 bit (can be shorter, making test failing)
-            r_int = random.getrandbits(32)
+        r_int = random.getrandbits(62)
+        while r_int.bit_length() < 62:
+            # make sure `r_int` is of size 62 bit (can be shorter, making test failing)
+            r_int = random.getrandbits(62)
         params = [r_int, r_int]
         protected_vector_1 = lom_1.protect(
             node_ids[0], pwkeys[0], tau, params, node_ids


### PR DESCRIPTION
**PR description**

The vector dtype was upgraded from uint32 to uint64, and the index encoding in eval_vector was widened from 4 bytes to 8 bytes per element to match.

This change introduces no weaknesses. The underlying encryption remains same as ChaCha20 with a 256-bit (32-byte) key. What does improve is the mask space per parameter:

- Before: each mask value was drawn from 32 bits = 2^32 possible values
- After: each mask value is drawn from 64 bits = 2^64 possible values
- Actually it is even stronger since an attacker a single mask value now have more candidates.

The actual change is below.

```
taus = b"".join([(i + tau).to_bytes(8, "big") for i in range(input_size)])
```

To test this implementation you can use the script below: 

```python
import secrets
import numpy as np

from fedbiomed.common.dataset._dataset import List
from fedbiomed.common.secagg import LOM


def make_pairwise_secrets(node_ids):
    secrets_map = {n: {} for n in node_ids}
    for i, a in enumerate(node_ids):
        for b in node_ids[i + 1 :]:
            shared = secrets.token_bytes(32)
            secrets_map[a][b] = shared
            secrets_map[b][a] = shared
    return secrets_map


def run(node_vectors: List[List[int]]):

    node_ids = [f"node_{i}" for i in range(len(node_vectors))]
    pairwise_secrets = make_pairwise_secrets(node_ids)
    nonce = secrets.token_bytes(16)

    tau = 1
    lom = LOM(nonce=nonce)

    masked = []
    for i, node_id in enumerate(node_ids):
        y = lom.protect(
            node_id=node_id,
            pairwise_secrets=pairwise_secrets[node_id],
            tau=tau,
            x_u_tau=node_vectors[i],
            node_ids=node_ids,
        )
        masked.append(y)
        print(f"  {node_id} Raw:    {node_vectors[i]}")
        print(f"  {node_id} Masked: {y}")

    result = lom.aggregate(masked)
    expected = np.sum(np.array(node_vectors), axis=0).tolist()

    print(f"Aggregated : {result} \n")
    print(f"Expected   : {expected} \n")


if __name__ == "__main__":
    print("smaller values")
    run([[2, 3, 4, 5, 6], [2, 3, 4, 5, 6], [2, 3, 4, 5, 6]])

    print("Edge cases large number")
    x = [[10000000000000, 1000000000, 1000000000] for i in range(100)]
    run(x)

    print("Failure for very large nubmer with a message")
    x = [[10000000000000000000, 1000000000, 1000000000] for i in range(100)]
    run(x)

```
