### PR TITLE
corrections for jls in fa secagg

### DIFF
--- a/fedbiomed/common/secagg/_jls.py
+++ b/fedbiomed/common/secagg/_jls.py
@@ -571,17 +571,23 @@ class JoyeLibert:
 
     """
 
-    def __init__(self):
+    def __init__(self, target_range: int | None = None):
         """Constructs the class
 
-        VEParameters.TARGET_RANGE + VEParameters.WEIGHT_RANGE should be
-        equal or less than 2**32
+        Args:
+            target_range: Quantization range the values were packed into. The
+                vector-encoder slot size is derived from it, so it MUST match the
+                ``target_range`` used for quantization on encryption (and be the
+                same on encryption and decryption). Defaults to the training
+                ``SAParameters.TARGET_RANGE``. Federated analytics uses the wider
+                ``SAParameters.FA_TARGET_RANGE``; passing it here is required so
+                that ~55-bit FA values do not overflow their packing slot and
+                corrupt neighbouring values.
         """
+        target_range = target_range or SAParameters.TARGET_RANGE
         self._vector_encoder = VES(
             ptsize=SAParameters.KEY_SIZE // 2,
-            valuesize=ceil(
-                log2(SAParameters.TARGET_RANGE) + log2(SAParameters.WEIGHT_RANGE)
-            ),
+            valuesize=ceil(log2(target_range) + log2(SAParameters.WEIGHT_RANGE)),
         )
 
     def protect(

--- a/fedbiomed/common/secagg/_secagg_crypter.py
+++ b/fedbiomed/common/secagg/_secagg_crypter.py
@@ -97,6 +97,8 @@ class SecaggCrypter:
             )
 
         target_range = target_range or SAParameters.TARGET_RANGE
+        # Size the vector-encoder packing slots. Must match the decode side.
+        self._jls = JoyeLibert(target_range=target_range)
         # quantize params into [0, target_range-1] (FA uses a wider range than training)
         params = quantize(
             weights=params, clipping_range=clipping_range, target_range=target_range
@@ -191,6 +193,10 @@ class SecaggCrypter:
                 f"should be of type of integers."
             )
 
+        target_range = target_range or SAParameters.TARGET_RANGE
+        # Decode with the same slot size used to encode (derived from target_range)
+        self._jls = JoyeLibert(target_range=target_range)
+
         # TODO provide dynamically created biprime. Biprime that is used
         #  on the node-side should matched the one used for decryption
         public_param = self._setup_public_param(biprime=biprime)
@@ -218,7 +224,7 @@ class SecaggCrypter:
         aggregated_params: List[float] = reverse_quantize(
             aggregated_params,
             clipping_range=clipping_range,
-            target_range=target_range or SAParameters.TARGET_RANGE,
+            target_range=target_range,
         )
         time_elapsed = time.process_time() - start
         logger.debug(

--- a/fedbiomed/researcher/federated_workflows/_federated_analytics.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_analytics.py
@@ -655,7 +655,8 @@ class FederatedAnalytics:
             model_params = {
                 nid: r.params_encrypted for nid, r in analytics_replies.items()
             }
-            num_expected_params = len(first_reply.params_encrypted)
+            output_schema = first_reply.output_schema
+            num_expected_params = len(output_schema)
             num_nodes = len(analytics_replies)
             aggregated_flat = self._secagg.aggregate(
                 round_=self._fa_round_counter,
@@ -667,7 +668,6 @@ class FederatedAnalytics:
             # Crypter returns cross-node mean (÷num_nodes cancels quantization
             # offset); ×num_nodes restores the additive sum FA aggregators expect.
             aggregated_flat = [v * num_nodes for v in aggregated_flat]
-            output_schema = first_reply.output_schema
             aggregated_output = unflatten_fa_output(aggregated_flat, output_schema)
             if cached is None:
                 cached = FAResult(None)

--- a/tests/test_analytics/test_federated_analytics.py
+++ b/tests/test_analytics/test_federated_analytics.py
@@ -1572,6 +1572,38 @@ class TestSecaggIntegration:
         assert node_output == {"age": {"sum": 90.0, "count": 360}}
 
     @patch("fedbiomed.researcher.federated_workflows._federated_analytics.FARequestJob")
+    def test_num_expected_params_uses_schema_length(
+        self, mock_fa_job_cls, secagg_fa, mock_secagg
+    ):
+        """num_expected_params is the value count (schema length), not the payload length.
+
+        Regression test: under JLS the encrypted payload is vector-packed (many
+        values per plaintext), so ``len(params_encrypted)`` is smaller than the
+        number of statistics. Decoding must be driven by the schema length,
+        otherwise too few values are recovered and unflatten fails.
+        """
+        # 4 statistics, but only 1 packed plaintext (as JLS would produce).
+        schema = [["age", "sum"], ["age", "count"], ["bmi", "sum"], ["bmi", "count"]]
+        packed = [123456789]  # single packed plaintext, len 1 != len(schema) == 4
+        mock_fa_job_cls.return_value.execute.return_value = {
+            "node-1": _make_encrypted_reply(packed, schema),
+            "node-2": _make_encrypted_reply(packed, schema),
+        }
+        # aggregate must receive the full value count to decode all of them.
+        mock_secagg.aggregate.return_value = [225.0, 50.0, 110.0, 50.0]
+
+        result = secagg_fa.fetch_stats("mean")
+
+        assert mock_secagg.aggregate.call_args.kwargs["num_expected_params"] == len(
+            schema
+        )
+        # All four values are recovered and unflattened (no zip length mismatch).
+        assert result.node_stats("__secagg__") == {
+            "age": {"sum": 450.0, "count": 100.0},
+            "bmi": {"sum": 220.0, "count": 100.0},
+        }
+
+    @patch("fedbiomed.researcher.federated_workflows._federated_analytics.FARequestJob")
     def test_secagg_setup_called_with_node_ids(
         self, mock_fa_job_cls, secagg_fa, mock_secagg, mock_fds
     ):

--- a/tests/test_secagg_crypter.py
+++ b/tests/test_secagg_crypter.py
@@ -325,6 +325,62 @@ class TestSecaggCrypter(unittest.TestCase):
                 total_sample_size=8,
             )
 
+    def test_secagg_crypter_07_fa_wide_range_roundtrip(self):
+        """JLS round-trip with federated-analytics wide-range (~55-bit) values.
+
+        Regression test: the Joye-Libert vector encoder packs several values into
+        one plaintext. Its slot size must be derived from the (wide) FA target
+        range, otherwise ~55-bit FA statistics overflow the default training-sized
+        slots and corrupt the neighbouring packed value. With the encoder sized for
+        FA_TARGET_RANGE the two adjacent stats (count, sum) decode independently.
+        """
+        C = SAParameters.FA_CLIPPING_RANGE
+        T = SAParameters.FA_TARGET_RANGE
+        num_nodes, current_round = 2, 1
+
+        # 'year' [count, sum] held by each of two nodes (adjacent in the vector).
+        node_1_vals = [10667.0, 21516413.0]
+        node_2_vals = [17965.0, 36233008.0]
+
+        node_1 = self.secagg_crypter.encrypt(
+            num_nodes=num_nodes,
+            current_round=current_round,
+            params=node_1_vals,
+            key=10,
+            biprime=TestSecaggCrypter.biprime,
+            clipping_range=C,
+            weight=1,
+            target_range=T,
+        )
+        node_2 = self.secagg_crypter.encrypt(
+            num_nodes=num_nodes,
+            current_round=current_round,
+            params=node_2_vals,
+            key=10,
+            biprime=TestSecaggCrypter.biprime,
+            clipping_range=C,
+            weight=1,
+            target_range=T,
+        )
+
+        aggregated = self.secagg_crypter.aggregate(
+            current_round=current_round,
+            num_nodes=num_nodes,
+            params=[node_1, node_2],
+            key=-20,
+            biprime=TestSecaggCrypter.biprime,
+            total_sample_size=num_nodes,
+            clipping_range=C,
+            num_expected_params=2,
+            target_range=T,
+        )
+        # FA restores the additive sum across nodes (crypter returns the mean).
+        result = [v * num_nodes for v in aggregated]
+
+        # count = 10667 + 17965 = 28632 ; sum = 21516413 + 36233008 = 57749421
+        self.assertAlmostEqual(result[0], 28632.0, delta=1.0)
+        self.assertAlmostEqual(result[1], 57749421.0, delta=1.0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR includes changes that allow to have in place JLS in Analytics using secure aggregation.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`