### PR TITLE
add guards to fa params to validate they are the same on ends

### DIFF
--- a/fedbiomed/node/jobs/_fa_job.py
+++ b/fedbiomed/node/jobs/_fa_job.py
@@ -248,6 +248,23 @@ class FAJob(_BaseJob):
                     errnum=ErrorNumbers.FB325.value,
                 )
 
+        # FA ranges are fixed; reject a request that disagrees with the node constants.
+        if self._secagg_arguments:
+            for key, expected in (
+                ("secagg_clipping_range", SAParameters.FA_CLIPPING_RANGE),
+                ("secagg_target_range", SAParameters.FA_TARGET_RANGE),
+            ):
+                requested = self._secagg_arguments.get(key)
+                if requested != expected:
+                    return self._build_error_msg(
+                        msg=(
+                            f"FA secagg '{key}' mismatch: request={requested}, "
+                            f"node={expected}; node and researcher must run the same "
+                            f"Fed-BioMed version."
+                        ),
+                        errnum=ErrorNumbers.FB325.value,
+                    )
+
         try:
             dataset = self._build_dataset(DataReturnFormat.SKLEARN)
         except _InternalJobError as e:

--- a/fedbiomed/researcher/federated_workflows/_federated_analytics.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_analytics.py
@@ -599,9 +599,11 @@ class FederatedAnalytics:
             researcher_id=self._researcher_id,
             insecure_validation=False,
         )
-        # FA clipping range is fixed so the researcher can set it directly
+        # Send both fixed FA ranges so the nodes can validate them against their own.
         self._secagg.clipping_range = SAParameters.FA_CLIPPING_RANGE
-        return dict(self._secagg.train_arguments())
+        secagg_arguments = dict(self._secagg.train_arguments())
+        secagg_arguments["secagg_target_range"] = SAParameters.FA_TARGET_RANGE
+        return secagg_arguments
 
     def _execute_and_update_cache(
         self,

--- a/tests/test_analytics/test_federated_analytics.py
+++ b/tests/test_analytics/test_federated_analytics.py
@@ -1489,7 +1489,7 @@ class TestSecaggIntegration:
         secagg.train_arguments.return_value = {
             "secagg_scheme": "LOM",
             "secagg_random": 0.5,
-            "secagg_clipping_range": 3,
+            "secagg_clipping_range": SAParameters.FA_CLIPPING_RANGE,
             "parties": ["node-1", "node-2"],
         }
         return secagg
@@ -1524,9 +1524,13 @@ class TestSecaggIntegration:
     def test_secagg_setup_sets_fa_clipping_range_on_scheme(
         self, secagg_fa, mock_secagg
     ):
-        """FA configures the scheme with FA_CLIPPING_RANGE (flows to nodes + aggregate)."""
-        secagg_fa._secagg_setup(["node-1", "node-2"])
+        """FA sends both fixed ranges so the nodes can validate them."""
+        secagg_arguments = secagg_fa._secagg_setup(["node-1", "node-2"])
         assert mock_secagg.clipping_range == SAParameters.FA_CLIPPING_RANGE
+        assert (
+            secagg_arguments["secagg_clipping_range"] == SAParameters.FA_CLIPPING_RANGE
+        )
+        assert secagg_arguments["secagg_target_range"] == SAParameters.FA_TARGET_RANGE
 
     @patch("fedbiomed.researcher.federated_workflows._federated_analytics.FARequestJob")
     def test_aggregate_uses_fa_ranges(self, mock_fa_job_cls, secagg_fa, mock_secagg):

--- a/tests/test_analytics/test_node_fa_job.py
+++ b/tests/test_analytics/test_node_fa_job.py
@@ -2,7 +2,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from fedbiomed.common.constants import DatasetTypes, ErrorNumbers, Stats
+from fedbiomed.common.constants import (
+    DatasetTypes,
+    ErrorNumbers,
+    SAParameters,
+    Stats,
+)
 from fedbiomed.common.dataset_types import DataReturnFormat
 from fedbiomed.common.exceptions import FedbiomedError, FedbiomedSecureAggregationError
 from fedbiomed.common.message import ErrorMessage, FAReply, FARequest
@@ -467,7 +472,8 @@ def secagg_args():
     return {
         "secagg_scheme": SecureAggregationSchemes.JOYE_LIBERT,
         "secagg_servkey_id": "serv-id",
-        "secagg_clipping_range": 3,
+        "secagg_clipping_range": SAParameters.FA_CLIPPING_RANGE,
+        "secagg_target_range": SAParameters.FA_TARGET_RANGE,
         "secagg_random": 0.5,
         "parties": ["researcher-1", "node-1", "node-2"],
         "fa_round": 2,
@@ -511,6 +517,34 @@ def test_run_secagg_force_without_args_returns_error(fa_job_args, fa_request):
 
     assert isinstance(reply, ErrorMessage)
     assert reply.errnum == ErrorNumbers.FB325.value
+
+
+@pytest.mark.parametrize(
+    "key, bad_value",
+    [
+        ("secagg_clipping_range", SAParameters.FA_CLIPPING_RANGE + 1),
+        ("secagg_clipping_range", None),  # missing
+        ("secagg_target_range", SAParameters.FA_TARGET_RANGE + 1),
+        ("secagg_target_range", None),  # missing
+    ],
+)
+def test_run_secagg_range_mismatch_rejected(
+    fa_job_args, fa_request, secagg_args, key, bad_value
+):
+    """A request whose FA range differs from (or omits) the node constant is rejected."""
+    if bad_value is None:
+        secagg_args.pop(key)
+    else:
+        secagg_args[key] = bad_value
+    job = _make_fa_job(
+        fa_job_args, fa_request, secagg_active=True, secagg_arguments=secagg_args
+    )
+
+    reply = job.run()
+
+    assert isinstance(reply, ErrorMessage)
+    assert reply.errnum == ErrorNumbers.FB325.value
+    assert key in reply.extra_msg
 
 
 def test_run_secagg_not_active_returns_error(fa_job_args, fa_request, secagg_args):
@@ -568,16 +602,15 @@ def test_run_encrypted_path_rejects_out_of_clipping_range(
     mock_secagg.use_secagg = True
     mock_secagg_cls.return_value = mock_secagg
 
-    secagg_args["secagg_clipping_range"] = (
-        3  # 'income.sum' (99) exceeds it; 'age' is fine
-    )
+    # a statistic above the fixed node-side clipping range is rejected
+    over = SAParameters.FA_CLIPPING_RANGE + 1
     job = _make_fa_job(
         fa_job_args, fa_request, secagg_active=True, secagg_arguments=secagg_args
     )
     mock_dataset = MagicMock()
     mock_dataset.compute_stats.return_value = {
         "age": {"sum": 1.0, "count": 2},
-        "income": {"sum": 99.0, "count": 2},
+        "income": {"sum": over, "count": 2},  # exceeds FA_CLIPPING_RANGE; 'age' is fine
     }
 
     with patch.object(FAJob, "_build_dataset", return_value=mock_dataset):
@@ -589,7 +622,7 @@ def test_run_encrypted_path_rejects_out_of_clipping_range(
     # The message names the offending column/stat to help the user...
     assert "income.sum" in reply.extra_msg
     # ...but never echoes the offending value (would leak an unencrypted statistic).
-    assert "99" not in reply.extra_msg
+    assert str(over) not in reply.extra_msg
 
 
 @patch("fedbiomed.node.jobs._fa_job.SecaggRound")
@@ -601,12 +634,12 @@ def test_run_encrypted_path_rejects_out_of_clipping_range_unnamed(
     mock_secagg.use_secagg = True
     mock_secagg_cls.return_value = mock_secagg
 
-    secagg_args["secagg_clipping_range"] = 3  # bare value 99 exceeds it
     job = _make_fa_job(
         fa_job_args, fa_request, secagg_active=True, secagg_arguments=secagg_args
     )
     mock_dataset = MagicMock()
-    mock_dataset.compute_stats.return_value = 99.0  # scalar → empty key-path
+    # scalar → empty key-path; exceeds the fixed FA_CLIPPING_RANGE constant
+    mock_dataset.compute_stats.return_value = float(SAParameters.FA_CLIPPING_RANGE + 1)
 
     with patch.object(FAJob, "_build_dataset", return_value=mock_dataset):
         reply = job.run()
@@ -634,7 +667,7 @@ def test_run_encrypted_path_uses_fa_round_from_args(
         fa_job_args, fa_request, secagg_active=True, secagg_arguments=secagg_args
     )
     mock_dataset = MagicMock()
-    mock_dataset.compute_stats.return_value = {"x": 1.0}  # within clipping range (3)
+    mock_dataset.compute_stats.return_value = {"x": 1.0}  # within FA_CLIPPING_RANGE
 
     with patch.object(FAJob, "_build_dataset", return_value=mock_dataset):
         job.run()


### PR DESCRIPTION
Include values in messages for secagg for validation on ends. Choose one and close another approach.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`