### PR TITLE
avoid passing fa params for secagg on message

### DIFF
--- a/fedbiomed/node/jobs/_fa_job.py
+++ b/fedbiomed/node/jobs/_fa_job.py
@@ -248,6 +248,16 @@ class FAJob(_BaseJob):
                     errnum=ErrorNumbers.FB325.value,
                 )
 
+        # FA clipping range is fixed on the node; reject requests that try to set it.
+        if self._secagg_arguments and "secagg_clipping_range" in self._secagg_arguments:
+            return self._build_error_msg(
+                msg=(
+                    "Federated analytics requests must not specify "
+                    "'secagg_clipping_range'; it is fixed on the node."
+                ),
+                errnum=ErrorNumbers.FB325.value,
+            )
+
         try:
             dataset = self._build_dataset(DataReturnFormat.SKLEARN)
         except _InternalJobError as e:
@@ -297,18 +307,19 @@ class FAJob(_BaseJob):
 
         if secagg_round.use_secagg:
             flat, schema = flatten_fa_output(output)
-            # Oversized statistics would corrupt the aggregate if encrypted
-            clip = (
-                self._secagg_arguments.get("secagg_clipping_range")
-                or SAParameters.FA_CLIPPING_RANGE
-            )
+            # FA clipping range is fixed on the node, never taken from the request.
+            clip = SAParameters.FA_CLIPPING_RANGE
             clip_error = self._check_clipping_overflow(flat, schema, clip)
             if clip_error is not None:
                 return clip_error
             fa_round = self._secagg_arguments.get("fa_round", 1)
-            # FA uses a wider quantization range than training (node-local constant)
+            # FA uses fixed node-side ranges, never recovered from the request.
             encrypted_params = secagg_round.scheme.encrypt(
-                flat, fa_round, weight=1, target_range=SAParameters.FA_TARGET_RANGE
+                flat,
+                fa_round,
+                weight=1,
+                target_range=SAParameters.FA_TARGET_RANGE,
+                clipping_range=SAParameters.FA_CLIPPING_RANGE,
             )
 
             return FAReply(

--- a/fedbiomed/node/secagg/_secagg_round.py
+++ b/fedbiomed/node/secagg/_secagg_round.py
@@ -67,6 +67,7 @@ class _SecaggSchemeRound(ABC):
         current_round: int,
         weight: Optional[int] = None,
         target_range: Optional[int] = None,  # None -> TARGET_RANGE (training)
+        clipping_range: Optional[int] = None,  # None -> request value (training)
     ) -> List[int]:
         """Encrypts model parameters after local training.
 
@@ -126,6 +127,7 @@ class _JLSRound(_SecaggSchemeRound):
         current_round: int,
         weight: Optional[int] = None,
         target_range: Optional[int] = None,  # None -> TARGET_RANGE (training)
+        clipping_range: Optional[int] = None,  # None -> request value (training)
     ) -> List[int]:
         """Encrypts model parameters with Joye-Libert after local training.
 
@@ -145,7 +147,11 @@ class _JLSRound(_SecaggSchemeRound):
             params=params,
             key=self._secagg_servkey["context"]["server_key"],
             biprime=self._secagg_servkey["context"]["biprime"],
-            clipping_range=self._secagg_clipping_range,
+            clipping_range=(
+                clipping_range
+                if clipping_range is not None
+                else self._secagg_clipping_range
+            ),
             weight=weight,
             target_range=target_range,
         )
@@ -198,6 +204,7 @@ class _LomRound(_SecaggSchemeRound):
         current_round: int,
         weight: Optional[int] = None,
         target_range: Optional[int] = None,  # None -> TARGET_RANGE (training)
+        clipping_range: Optional[int] = None,  # None -> request value (training)
     ) -> List[int]:
         """Encrypts model parameters with LOM after local training.
 
@@ -215,7 +222,11 @@ class _LomRound(_SecaggSchemeRound):
             current_round=current_round,
             params=params,
             pairwise_secrets=self._secagg_dh["context"],
-            clipping_range=self._secagg_clipping_range,
+            clipping_range=(
+                clipping_range
+                if clipping_range is not None
+                else self._secagg_clipping_range
+            ),
             weight=weight,
             target_range=target_range,
         )

--- a/fedbiomed/researcher/federated_workflows/_federated_analytics.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_analytics.py
@@ -599,9 +599,12 @@ class FederatedAnalytics:
             researcher_id=self._researcher_id,
             insecure_validation=False,
         )
-        # FA clipping range is fixed so the researcher can set it directly
+        # FA clipping range is fixed: pin it locally for decryption, but never send
+        # it to the nodes (they apply their own constant).
         self._secagg.clipping_range = SAParameters.FA_CLIPPING_RANGE
-        return dict(self._secagg.train_arguments())
+        secagg_arguments = dict(self._secagg.train_arguments())
+        secagg_arguments.pop("secagg_clipping_range", None)
+        return secagg_arguments
 
     def _execute_and_update_cache(
         self,

--- a/tests/test_analytics/test_federated_analytics.py
+++ b/tests/test_analytics/test_federated_analytics.py
@@ -1524,9 +1524,12 @@ class TestSecaggIntegration:
     def test_secagg_setup_sets_fa_clipping_range_on_scheme(
         self, secagg_fa, mock_secagg
     ):
-        """FA configures the scheme with FA_CLIPPING_RANGE (flows to nodes + aggregate)."""
-        secagg_fa._secagg_setup(["node-1", "node-2"])
+        """FA pins FA_CLIPPING_RANGE locally but never forwards it to the nodes."""
+        secagg_arguments = secagg_fa._secagg_setup(["node-1", "node-2"])
+        # pinned locally for decryption
         assert mock_secagg.clipping_range == SAParameters.FA_CLIPPING_RANGE
+        # but never sent to the nodes
+        assert "secagg_clipping_range" not in secagg_arguments
 
     @patch("fedbiomed.researcher.federated_workflows._federated_analytics.FARequestJob")
     def test_aggregate_uses_fa_ranges(self, mock_fa_job_cls, secagg_fa, mock_secagg):

--- a/tests/test_analytics/test_node_fa_job.py
+++ b/tests/test_analytics/test_node_fa_job.py
@@ -2,7 +2,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from fedbiomed.common.constants import DatasetTypes, ErrorNumbers, Stats
+from fedbiomed.common.constants import (
+    DatasetTypes,
+    ErrorNumbers,
+    SAParameters,
+    Stats,
+)
 from fedbiomed.common.dataset_types import DataReturnFormat
 from fedbiomed.common.exceptions import FedbiomedError, FedbiomedSecureAggregationError
 from fedbiomed.common.message import ErrorMessage, FAReply, FARequest
@@ -467,7 +472,6 @@ def secagg_args():
     return {
         "secagg_scheme": SecureAggregationSchemes.JOYE_LIBERT,
         "secagg_servkey_id": "serv-id",
-        "secagg_clipping_range": 3,
         "secagg_random": 0.5,
         "parties": ["researcher-1", "node-1", "node-2"],
         "fa_round": 2,
@@ -511,6 +515,22 @@ def test_run_secagg_force_without_args_returns_error(fa_job_args, fa_request):
 
     assert isinstance(reply, ErrorMessage)
     assert reply.errnum == ErrorNumbers.FB325.value
+
+
+def test_run_secagg_request_with_clipping_range_rejected(
+    fa_job_args, fa_request, secagg_args
+):
+    """A request carrying secagg_clipping_range is rejected: it is fixed on the node."""
+    secagg_args["secagg_clipping_range"] = 3
+    job = _make_fa_job(
+        fa_job_args, fa_request, secagg_active=True, secagg_arguments=secagg_args
+    )
+
+    reply = job.run()
+
+    assert isinstance(reply, ErrorMessage)
+    assert reply.errnum == ErrorNumbers.FB325.value
+    assert "secagg_clipping_range" in reply.extra_msg
 
 
 def test_run_secagg_not_active_returns_error(fa_job_args, fa_request, secagg_args):
@@ -568,16 +588,15 @@ def test_run_encrypted_path_rejects_out_of_clipping_range(
     mock_secagg.use_secagg = True
     mock_secagg_cls.return_value = mock_secagg
 
-    secagg_args["secagg_clipping_range"] = (
-        3  # 'income.sum' (99) exceeds it; 'age' is fine
-    )
+    # a statistic above the fixed node-side clipping range is rejected
+    over = SAParameters.FA_CLIPPING_RANGE + 1
     job = _make_fa_job(
         fa_job_args, fa_request, secagg_active=True, secagg_arguments=secagg_args
     )
     mock_dataset = MagicMock()
     mock_dataset.compute_stats.return_value = {
         "age": {"sum": 1.0, "count": 2},
-        "income": {"sum": 99.0, "count": 2},
+        "income": {"sum": over, "count": 2},  # exceeds FA_CLIPPING_RANGE; 'age' is fine
     }
 
     with patch.object(FAJob, "_build_dataset", return_value=mock_dataset):
@@ -589,7 +608,7 @@ def test_run_encrypted_path_rejects_out_of_clipping_range(
     # The message names the offending column/stat to help the user...
     assert "income.sum" in reply.extra_msg
     # ...but never echoes the offending value (would leak an unencrypted statistic).
-    assert "99" not in reply.extra_msg
+    assert str(over) not in reply.extra_msg
 
 
 @patch("fedbiomed.node.jobs._fa_job.SecaggRound")
@@ -601,12 +620,12 @@ def test_run_encrypted_path_rejects_out_of_clipping_range_unnamed(
     mock_secagg.use_secagg = True
     mock_secagg_cls.return_value = mock_secagg
 
-    secagg_args["secagg_clipping_range"] = 3  # bare value 99 exceeds it
     job = _make_fa_job(
         fa_job_args, fa_request, secagg_active=True, secagg_arguments=secagg_args
     )
     mock_dataset = MagicMock()
-    mock_dataset.compute_stats.return_value = 99.0  # scalar → empty key-path
+    # scalar → empty key-path; exceeds the fixed FA_CLIPPING_RANGE constant
+    mock_dataset.compute_stats.return_value = float(SAParameters.FA_CLIPPING_RANGE + 1)
 
     with patch.object(FAJob, "_build_dataset", return_value=mock_dataset):
         reply = job.run()
@@ -634,13 +653,15 @@ def test_run_encrypted_path_uses_fa_round_from_args(
         fa_job_args, fa_request, secagg_active=True, secagg_arguments=secagg_args
     )
     mock_dataset = MagicMock()
-    mock_dataset.compute_stats.return_value = {"x": 1.0}  # within clipping range (3)
+    mock_dataset.compute_stats.return_value = {"x": 1.0}  # within FA_CLIPPING_RANGE
 
     with patch.object(FAJob, "_build_dataset", return_value=mock_dataset):
         job.run()
 
     call_args = mock_secagg.scheme.encrypt.call_args
     assert call_args[0][1] == 7  # fa_round positional arg
+    # FA clipping range is the fixed node-side constant, not the request value
+    assert call_args.kwargs["clipping_range"] == SAParameters.FA_CLIPPING_RANGE
 
 
 @patch("fedbiomed.node.jobs._fa_job.SecaggRound")

--- a/tests/test_node_secagg.py
+++ b/tests/test_node_secagg.py
@@ -332,6 +332,62 @@ def test_secagg_round_encrypt_forwards_target_range(
     assert mock_crypter.return_value.encrypt.call_args.kwargs["target_range"] == 999
 
 
+@pytest.mark.parametrize(
+    "args_fixture, manager_fixture, get_ret, crypter, node_id",
+    [
+        (
+            "lom_args",
+            "mock_dhmanager",
+            {"parties": ["node-1", "node-2"], "context": {"node-2": b"\x02" * 32}},
+            "SecaggLomCrypter",
+            "node-1",
+        ),
+        (
+            "jls_args",
+            "mock_skmanager",
+            {
+                "parties": ["researcher-1", "node-1", "node-2"],
+                "context": {"server_key": 12345, "biprime": 1156},
+            },
+            "SecaggCrypter",
+            "test-node-id",
+        ),
+    ],
+)
+def test_secagg_round_encrypt_clipping_range_override(
+    request,
+    db,
+    mock_skmanager,
+    mock_dhmanager,
+    args_fixture,
+    manager_fixture,
+    get_ret,
+    crypter,
+    node_id,
+):
+    """clipping_range overrides the request value; None falls back to it (3)."""
+    request.getfixturevalue(manager_fixture).return_value.get.return_value = get_ret
+    with patch(f"fedbiomed.node.secagg._secagg_round.{crypter}") as mock_crypter:
+        secagg_round = SecaggRound(
+            db=db,
+            node_id=node_id,
+            secagg_active=True,
+            force_secagg=True,
+            secagg_arguments=request.getfixturevalue(args_fixture),
+            experiment_id="exp-id",
+        )
+        # explicit override forwarded to the crypter
+        secagg_round.scheme.encrypt(
+            params=[1.0, 1.0], current_round=1, clipping_range=999
+        )
+        assert (
+            mock_crypter.return_value.encrypt.call_args.kwargs["clipping_range"] == 999
+        )
+        # None falls back to the request's secagg_clipping_range (3)
+        secagg_round.scheme.encrypt(params=[1.0, 1.0], current_round=1)
+        assert mock_crypter.return_value.encrypt.call_args.kwargs["clipping_range"] == 3
+
+
 def test_secagg_round_no_secagg_plaintext_path(db, mock_skmanager, mock_dhmanager):
     """No secagg_arguments and force_secagg=False → plaintext path, use_secagg=False."""
     secagg_round = SecaggRound(


### PR DESCRIPTION
Avoid completely passing fa params of secagg in the messages. If `fa_clipping_range` or `fa_target_range` change at some point, discrepancies might pass silently. Choose one and close the another approach.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`