### PR TITLE
test(history-monitor): strengthen payload assertions and clarify docs

### DIFF
--- a/fedbiomed/node/history_monitor.py
+++ b/fedbiomed/node/history_monitor.py
@@ -26,9 +26,10 @@ class HistoryMonitor:
 
         Args:
             node_id: Unique ID of this node
-            experiment_id: TODO
-            researcher_id: TODO
-            client: TODO
+            node_name: Human-readable name of this node
+            experiment_id: Unique identifier of the running experiment
+            researcher_id: Unique identifier of the researcher receiving feedback
+            send: Callable used to transmit a FeedbackMessage
         """
         self._node_id = node_id
         self._node_name = node_name
@@ -61,18 +62,20 @@ class HistoryMonitor:
             response to researcher.
 
         Args:
-            metric:  recorded value
-            iteration: current epoch iteration.
-            epoch: current epoch
-            total_samples: TODO
-            batch_samples: TODO
-            num_batches: TODO
-            num_samples_trained: TODO
-            train: TODO
-            test: TODO
-            test_on_global_updates: TODO
-            test_on_local_updates: TODO
+            metric: Recorded metric values (for example loss or accuracy)
+            iteration: Current iteration index within the training process
+            epoch: Current epoch index
+            total_samples: Total number of samples in the dataset
+            batch_samples: Number of samples in the current batch
+            num_batches: Number of batches for one epoch
+            num_samples_trained: Cumulative number of samples used for training
+            train: Whether this metric is emitted during training
+            test: Whether this metric is emitted during validation/testing
+            test_on_global_updates: Whether test metrics use globally updated params
+            test_on_local_updates: Whether test metrics use locally updated params
 
+        Returns:
+            None
         """
         self.send(
             FeedbackMessage(

--- a/fedbiomed/node/history_monitor.py
+++ b/fedbiomed/node/history_monitor.py
@@ -68,7 +68,8 @@ class HistoryMonitor:
             total_samples: Total number of samples in the dataset
             batch_samples: Number of samples in the current batch
             num_batches: Number of batches for one epoch
-            num_samples_trained: Cumulative number of samples used for training
+            num_samples_trained: Optional cumulative number of samples used for
+                training; None when that value is unknown or not provided
             train: Whether this metric is emitted during training
             test: Whether this metric is emitted during validation/testing
             test_on_global_updates: Whether test metrics use globally updated params

--- a/tests/test_history_monitor.py
+++ b/tests/test_history_monitor.py
@@ -6,37 +6,21 @@ from fedbiomed.node.history_monitor import HistoryMonitor
 
 
 class TestHistoryMonitor(unittest.TestCase):
-    """
-    Test `HistoryMonitor` class
-    Args:
-        unittest ([type]): [description]
-    """
+    """Tests for HistoryMonitor."""
 
     def setUp(self):
         # Messaging to pass HistoryMonitor
         self.send = MagicMock()
-
-        try:
-            self.history_monitor = HistoryMonitor(
-                node_id="test-node-id",
-                node_name="test-node-name",
-                experiment_id="1234",
-                researcher_id="researcher-id",
-                send=self.send,
-            )
-            self._history_monitor_ok = True
-        except:
-            self._history_monitor_ok = False
-
-        self.assertTrue(
-            self._history_monitor_ok, "History monitor has initialized correctly"
+        self.history_monitor = HistoryMonitor(
+            node_id="test-node-id",
+            node_name="test-node-name",
+            experiment_id="1234",
+            researcher_id="researcher-id",
+            send=self.send,
         )
 
     def tearDown(self):
-        """
-        after all tests
-        """
-        pass
+        """After all tests."""
 
     def test_send_message(self):
         """Test history monitor can add a scalar value using
@@ -55,8 +39,21 @@ class TestHistoryMonitor(unittest.TestCase):
             epoch=111,
         )
         self.assertEqual(scalar, None)
+        self.send.assert_called_once()
 
-        pass
+        feedback_message = self.send.call_args.args[0]
+        self.assertEqual(feedback_message.researcher_id, "researcher-id")
+        self.assertEqual(feedback_message.scalar.node_id, "test-node-id")
+        self.assertEqual(feedback_message.scalar.node_name, "test-node-name")
+        self.assertEqual(feedback_message.scalar.experiment_id, "1234")
+        self.assertEqual(feedback_message.scalar.metric, {"test": 123})
+        self.assertTrue(feedback_message.scalar.train)
+        self.assertFalse(feedback_message.scalar.test)
+        self.assertEqual(feedback_message.scalar.total_samples, 1234)
+        self.assertEqual(feedback_message.scalar.batch_samples, 12)
+        self.assertEqual(feedback_message.scalar.num_batches, 12)
+        self.assertEqual(feedback_message.scalar.iteration, 111)
+        self.assertEqual(feedback_message.scalar.epoch, 111)
 
     def test_send_message_error(self):
         """Test send message in case of sending wrong types"""

--- a/tests/test_history_monitor.py
+++ b/tests/test_history_monitor.py
@@ -41,7 +41,7 @@ class TestHistoryMonitor(unittest.TestCase):
         self.assertEqual(scalar, None)
         self.send.assert_called_once()
 
-        feedback_message = self.send.call_args.args[0]
+        feedback_message = self.send.call_args[0][0]
         self.assertEqual(feedback_message.researcher_id, "researcher-id")
         self.assertEqual(feedback_message.scalar.node_id, "test-node-id")
         self.assertEqual(feedback_message.scalar.node_name, "test-node-name")


### PR DESCRIPTION
## Summary
- clarify HistoryMonitor docstrings
- strengthen HistoryMonitor payload assertions in unit tests

## Validation
- python -m pytest tests/test_history_monitor.py -q
- result: 2 passed
