### PR TITLE
minor fix to fa

### DIFF
--- a/fedbiomed/node/jobs/_fa_job.py
+++ b/fedbiomed/node/jobs/_fa_job.py
@@ -305,7 +305,7 @@ class FAJob(_BaseJob):
                 return clip_error
             encrypted_params = secagg_round.scheme.encrypt(
                 flat,
-                fa_round=self._secagg_arguments.get("fa_round", 1),
+                current_round=self._secagg_arguments.get("fa_round", 1),
                 weight=1,
                 target_range=SAParameters.FA_TARGET_RANGE,
                 clipping_range=SAParameters.FA_CLIPPING_RANGE,

--- a/tests/test_analytics/test_node_fa_job.py
+++ b/tests/test_analytics/test_node_fa_job.py
@@ -669,7 +669,7 @@ def test_run_encrypted_path_uses_fa_round_from_args(
         job.run()
 
     call_args = mock_secagg.scheme.encrypt.call_args
-    assert call_args.kwargs["fa_round"] == 7
+    assert call_args.kwargs["current_round"] == 7
     # FA clipping range is the fixed node-side constant, not the request value
     assert call_args.kwargs["clipping_range"] == SAParameters.FA_CLIPPING_RANGE
 

--- a/tests/test_dataset/test_medical_folder_controller.py
+++ b/tests/test_dataset/test_medical_folder_controller.py
@@ -320,19 +320,20 @@ def test_prepare_df_dir_for_use_missing_modalities(temp_medical_folder):
 
 @pytest.mark.parametrize("temp_medical_folder", ["incomplete_subject"], indirect=True)
 def test_prepare_df_dir_for_use_incomplete_subject(temp_medical_folder):
-    """Test _prepare_df_dir_for_use no subject has all modalities"""
+    """Test _prepare_df_dir_for_use drops subjects missing some modalities"""
     controller = MedicalFolderController(temp_medical_folder, validate=False)
     _, df_dir = controller._prepare_df_dir_for_use(controller.df_dir)
     subjects = df_dir["subject"].unique()
     assert len(subjects) > 0
-    assert "T2" not in subjects
+    # patient2 only has T1, so it must be dropped
+    assert "patient2" not in subjects
 
 
 @pytest.mark.parametrize(
     "temp_medical_folder", ["incomplete_modalities"], indirect=True
 )
 def test_prepare_df_dir_for_use_incomplete_modalities(temp_medical_folder):
-    """Test _prepare_df_dir_for_use no subject has all modalities"""
+    """Test _prepare_df_dir_for_use raises when no subject has all modalities"""
     controller = MedicalFolderController(temp_medical_folder, validate=False)
     with pytest.raises(FedbiomedError) as exc_info:
         _ = controller._prepare_df_dir_for_use(controller.df_dir)
@@ -625,7 +626,7 @@ def test_subject_intersection_with_demographics(temp_medical_folder):
     "temp_medical_folder", ["incomplete_modalities"], indirect=True
 )
 def test_subject_modality_status(temp_medical_folder):
-    """Test _prepare_df_dir_for_use no subject has all modalities"""
+    """Test subject_modality_status reports per-subject modality availability"""
     controller = MedicalFolderController(temp_medical_folder, validate=False)
     subject_modality_status = controller.subject_modality_status()
 

--- a/tests/test_dataset/test_medical_folder_controller.py
+++ b/tests/test_dataset/test_medical_folder_controller.py
@@ -24,12 +24,12 @@ def mock_nifti_reader(monkeypatch):
     )
 
 
-@pytest.fixture(params=["default"])
+@pytest.fixture
 def temp_medical_folder(request):
     """Create a temporary medical folder structure for testing"""
     temp_dir = tempfile.mkdtemp()
 
-    match request.param:
+    match getattr(request, "param", "default"):
         case "default":
             tree_dir = {
                 "patient1": ["T1", "T2"],


### PR DESCRIPTION
This PR fix a minor issue on fa analytics regarding fa_round

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`