### PR TITLE
fix: add missing .value to ErrorNumbers enum in transport f-strings (Fixes #1801)

### DIFF
--- a/fedbiomed/transport/client.py
+++ b/fedbiomed/transport/client.py
@@ -363,7 +363,7 @@ class GrpcClient:
         """
         if self._id is not None and self._id != id_:
             msg = (
-                f"{ErrorNumbers.FB628}: Suspected malicious researcher activity ! "
+                f"{ErrorNumbers.FB628.value}: Suspected malicious researcher activity ! "
                 f"Researcher ID changed for {self._researcher.host}:{self._researcher.port} from "
                 f"`{self._id}` to `{id_}`"
             )
@@ -428,7 +428,7 @@ class Listener:
             exp: Base exception to use
         """
         raise FedbiomedCommunicationError(
-            f"{ErrorNumbers.FB628}: {self.__class__.__name__} has stopped due to unknown reason: "
+            f"{ErrorNumbers.FB628.value}: {self.__class__.__name__} has stopped due to unknown reason: "
             f"{type(exp).__name__} : {exp}"
         ) from exp
 

--- a/fedbiomed/transport/controller.py
+++ b/fedbiomed/transport/controller.py
@@ -218,12 +218,12 @@ class GrpcController(GrpcAsyncTaskController):
         """
         if not isinstance(message, Message):
             raise FedbiomedCommunicationError(
-                f"{ErrorNumbers.FB628}: bad argument type for message, expected `Message`, got `{type(message)}`"
+                f"{ErrorNumbers.FB628.value}: bad argument type for message, expected `Message`, got `{type(message)}`"
             )
 
         if not self._is_started.is_set():
             raise FedbiomedCommunicationError(
-                f"{ErrorNumbers.FB628}: Communication client is not initialized."
+                f"{ErrorNumbers.FB628.value}: Communication client is not initialized."
             )
 
         asyncio.run_coroutine_threadsafe(super().send(message, broadcast), self._loop)
@@ -241,7 +241,7 @@ class GrpcController(GrpcAsyncTaskController):
         """
         if self._thread is None or not self._is_started.is_set():
             raise FedbiomedCommunicationError(
-                f"{ErrorNumbers.FB628}: Communication client is not initialized."
+                f"{ErrorNumbers.FB628.value}: Communication client is not initialized."
             )
 
         if not self._thread.is_alive():

--- a/fedbiomed/transport/server.py
+++ b/fedbiomed/transport/server.py
@@ -552,7 +552,7 @@ class GrpcServer(_GrpcAsyncServer):
         """
         if not isinstance(message, Message):
             raise FedbiomedCommunicationError(
-                f"{ErrorNumbers.FB628}: bad argument type for message, expected `Message`, got `{type(message)}`"
+                f"{ErrorNumbers.FB628.value}: bad argument type for message, expected `Message`, got `{type(message)}`"
             )
 
         if not self._is_started.is_set():
@@ -575,12 +575,12 @@ class GrpcServer(_GrpcAsyncServer):
         """
         if not isinstance(message, Message):
             raise FedbiomedCommunicationError(
-                f"{ErrorNumbers.FB628}: bad argument type for message, expected `Message`, got `{type(message)}`"
+                f"{ErrorNumbers.FB628.value}: bad argument type for message, expected `Message`, got `{type(message)}`"
             )
 
         if not self._is_started.is_set():
             raise FedbiomedCommunicationError(
-                f"{ErrorNumbers.FB628}: Can not broadcast given message. "
+                f"{ErrorNumbers.FB628.value}: Can not broadcast given message. "
                 "Communication client is not initialized."
             )
 
@@ -597,7 +597,7 @@ class GrpcServer(_GrpcAsyncServer):
         """
         if not self._is_started.is_set():
             raise FedbiomedCommunicationError(
-                f"{ErrorNumbers.FB628}: Error while getting all nodes "
+                f"{ErrorNumbers.FB628.value}: Error while getting all nodes "
                 "connected:  Communication client is not initialized."
             )
 
@@ -617,7 +617,7 @@ class GrpcServer(_GrpcAsyncServer):
         """
         if not self._is_started.is_set():
             raise FedbiomedCommunicationError(
-                f"{ErrorNumbers.FB628}: Error while getting node '{node_id}':"
+                f"{ErrorNumbers.FB628.value}: Error while getting node '{node_id}':"
                 "Communication client is not initialized."
             )
 
@@ -636,7 +636,7 @@ class GrpcServer(_GrpcAsyncServer):
         """
         if not self._is_started.is_set():
             raise FedbiomedCommunicationError(
-                f"{ErrorNumbers.FB628}: Can not check if thread is alive."
+                f"{ErrorNumbers.FB628.value}: Can not check if thread is alive."
                 "Communication client is not initialized."
             )
 


### PR DESCRIPTION
Fixes #1801

## Problem

In the `fedbiomed/transport/` module, 11 error messages use `{ErrorNumbers.FB628}` in f-strings instead of `{ErrorNumbers.FB628.value}`. Since `ErrorNumbers` is an `Enum` subclass, the f-string displays the enum representation `ErrorNumbers.FB628` instead of the actual error code string `FB628: Communication error`.

This is inconsistent with the rest of the codebase (e.g., `secagg_manager.py`, `metrics.py`) which correctly uses `.value`.

**Before:**
```
ErrorNumbers.FB628: bad argument type for message, expected `Message`, got `<class 'str'>`
```

**After:**
```
FB628: Communication error: bad argument type for message, expected `Message`, got `<class 'str'>`
```

## Solution

Added `.value` to all `ErrorNumbers.FB628` references in f-strings across the transport module, matching the pattern used consistently in `secagg_manager.py` and `metrics.py`.

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-19 | Fix ErrorNumbers.FB628 missing .value in transport f-strings | rtmalikian |

### Files Changed
- `fedbiomed/transport/server.py` — Added `.value` to 6 ErrorNumbers.FB628 references
- `fedbiomed/transport/controller.py` — Added `.value` to 3 ErrorNumbers.FB628 references
- `fedbiomed/transport/client.py` — Added `.value` to 2 ErrorNumbers.FB628 references

### Verification
- Syntax check passed: `python3.12 -c "import ast; ast.parse(open('file.py').read())"` for all 3 files
- Verified all 12 ErrorNumbers.FB628 references now include `.value`
- No double-replacement on line 560 of server.py which already had `.value`

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **MiMo v2.5 Pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
