### PR TITLE
correct api calls to nodes when secagg is active

### DIFF
--- a/docs/developer/federated-analytics.md
+++ b/docs/developer/federated-analytics.md
@@ -105,7 +105,7 @@ Once all nodes have replied, `FAResult` calls `AGGREGATORS_MAP` to combine per-n
 When the experiment runs with `secagg=True`, the per-node summaries are encrypted rather than returned in plaintext:
 
 - **Node side** (`_fa_job.py`): the stat output tree is flattened to a vector (`flatten_fa_output`, quantized, and encrypted with the active scheme. The `FAReply` then carries `params_encrypted` and `output_schema` instead of `output`.
-- **Researcher side** (`_federated_analytics.py`): the encrypted vectors are summed and decrypted via `SecureAggregation.aggregate`, unflattened back into a stat tree (`unflatten_fa_output`), and stored under a single virtual node `__secagg__`. The usual `AGGREGATORS_MAP` then derives the global stats from those combined primitives.
+- **Researcher side** (`_federated_analytics.py`): the encrypted vectors are summed and decrypted via `SecureAggregation.aggregate`, unflattened back into a stat tree (`unflatten_fa_output`), and stored under a single virtual node `__secagg__`. The usual `AGGREGATORS_MAP` then derives the global stats from those combined primitives. The real participating node IDs are kept separately so `FAResult.node_ids` still reports them (not the `__secagg__` sentinel); `node_stats()` has no per-node values to return and falls back to `global_stats()`.
 
 Only the summed primitives are ever recovered — never any individual node's values. See [Secure Aggregation](../user-guide/secagg/introduction.md).
 

--- a/docs/user-guide/researcher/federated-analytics.md
+++ b/docs/user-guide/researcher/federated-analytics.md
@@ -164,17 +164,17 @@ exp.analytics.variance()   # the two-pass variance/std scheme works transparentl
 
 ### What changes in the result
 
-Because individual contributions are masked, the result no longer exposes a value *per node*. All contributions are combined under a single virtual node, `__secagg__`:
+Because individual contributions are masked, the result no longer exposes a value *per node* — only the aggregate can be recovered. The API is otherwise unchanged:
 
 ```python
 result = exp.analytics.fetch_stats("mean")
 
-result.node_ids              # ['__secagg__']  — no per-node breakdown
-result.node_stats()          # {'__secagg__': {...aggregated primitives...}}
+result.node_ids              # real participating nodes — per-node values still hidden
+result.node_stats()          # no per-node values: logs an info message and returns global_stats()
 result.global_stats("mean")  # identical to the plaintext result
 ```
 
-`global_stats()` behaves exactly as in the plaintext case; only `node_stats()` differs, since per-node values are no longer available.
+`global_stats()` and `node_ids` behave as in the plaintext case; only `node_stats()` differs, falling back to the global aggregate since per-node values are no longer available.
 
 ### Choosing the scheme
 

--- a/fedbiomed/researcher/federated_workflows/_federated_analytics.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_analytics.py
@@ -35,6 +35,9 @@ class FAResult:
         self._data: dict[str, Any] = {}  # {node_id: raw_orchestrator_output}
         # Cache for the list of computable stats, set to None on every merge.
         self._computable_stats_cache: Optional[list[str]] = None
+        # Real participating node IDs under secure aggregation, where per-node data
+        # is collapsed into the ``__secagg__`` virtual node. None for plaintext.
+        self._secagg_node_ids: Optional[list[str]] = None
         if replies:
             self.merge(replies)
 
@@ -129,6 +132,8 @@ class FAResult:
             filtered_data[node_id] = out
         result = FAResult(None)
         result._data = filtered_data
+        if self._secagg_node_ids is not None:
+            result._secagg_node_ids = list(self._secagg_node_ids)
         return result
 
     @staticmethod
@@ -185,17 +190,26 @@ class FAResult:
                 combined._data[nid] = FAResult._deep_merge(combined._data[nid], out)
             else:
                 combined._data[nid] = copy.deepcopy(out)
+        secagg_node_ids = a._secagg_node_ids or b._secagg_node_ids
+        if secagg_node_ids is not None:
+            combined._secagg_node_ids = list(secagg_node_ids)
         return combined
 
     # ------------------------------------------------------------------
     # Mutation
     # ------------------------------------------------------------------
 
-    def _merge_aggregate(self, output: dict) -> None:
+    def _merge_aggregate(
+        self, output: dict, node_ids: Optional[list[str]] = None
+    ) -> None:
         """Merge a pre-built aggregate output into the secagg virtual node.
 
         Used by the encrypted reply path where all node contributions have been
         decrypted and unflattened into a single aggregate dict by the researcher.
+
+        Args:
+            output: The decrypted, unflattened aggregate output.
+            node_ids: Real participating node IDs, recorded for reporting.
         """
         if "__secagg__" not in self._data:
             self._data["__secagg__"] = output
@@ -203,6 +217,8 @@ class FAResult:
             self._data["__secagg__"] = FAResult._deep_merge(
                 self._data["__secagg__"], output
             )
+        if node_ids is not None:
+            self._secagg_node_ids = list(node_ids)
         self._computable_stats_cache = None
 
     def merge(self, replies: dict[str, FAReply]) -> None:
@@ -236,7 +252,13 @@ class FAResult:
 
     @property
     def node_ids(self) -> list[str]:
-        """List of node IDs present in the result."""
+        """List of node IDs present in the result.
+
+        Under secure aggregation, reports the real participating node IDs rather
+        than the ``__secagg__`` virtual node.
+        """
+        if self._secagg_node_ids is not None:
+            return list(self._secagg_node_ids)
         return list(self._data.keys())
 
     @property
@@ -306,17 +328,29 @@ class FAResult:
     def node_stats(self, node_id: Optional[str] = None) -> Any:
         """Return a copy of the raw statistics output for one or all nodes.
 
+        Under secure aggregation per-node statistics do not exist, so an info
+        message is logged and :meth:`global_stats` is returned instead.
+
         Args:
             node_id: Identifier of the node. When omitted, returns a dict
                 mapping every node ID to its output.
 
         Returns:
             Per-node output when *node_id* is given, or a ``{node_id: output}``
-            dict for all nodes when omitted.
+            dict for all nodes when omitted. Under secure aggregation, the result
+            of :meth:`global_stats` regardless of *node_id*.
 
         Raises:
             FedbiomedError: If *node_id* is not found.
         """
+        if self._secagg_node_ids is not None:
+            logger.info(
+                "Per-node statistics are not available under secure aggregation: "
+                "node contributions are encrypted and only their aggregate is "
+                "recoverable. Returning global statistics instead."
+            )
+            return self.global_stats()
+
         if node_id is None:
             return {nid: copy.deepcopy(output) for nid, output in self._data.items()}
 
@@ -693,7 +727,9 @@ class FederatedAnalytics:
             aggregated_output = unflatten_fa_output(aggregated_flat, output_schema)
             if cached is None:
                 cached = FAResult(None)
-            cached._merge_aggregate(aggregated_output)
+            cached._merge_aggregate(
+                aggregated_output, node_ids=list(analytics_replies.keys())
+            )
         else:
             if cached is None:
                 cached = FAResult(analytics_replies)

--- a/notebooks/federated_analytics.ipynb
+++ b/notebooks/federated_analytics.ipynb
@@ -311,7 +311,7 @@
    "id": "4bdbc0d47145",
    "metadata": {},
    "source": [
-    "The call is identical to the plaintext case, but the per-node values are now hidden: the result holds a single aggregated entry under the virtual node id `__secagg__`."
+    "The call is identical to the plaintext case, but the per-node values are no longer recoverable: only the aggregate can be reconstructed. `node_ids` still reports the real participating nodes, while `node_stats()` falls back to the global aggregate."
    ]
   },
   {
@@ -331,7 +331,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result.node_ids        # single '__secagg__' entry — no per-node values"
+    "result.node_ids        # real participating nodes (per-node values still hidden)"
    ]
   },
   {
@@ -341,7 +341,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result.node_stats()    # only the aggregate is available"
+    "result.node_stats()    # no per-node values: logs an info message and returns the global aggregate"
    ]
   },
   {

--- a/tests/test_analytics/test_federated_analytics.py
+++ b/tests/test_analytics/test_federated_analytics.py
@@ -380,6 +380,17 @@ class TestFAResult:
             # One sequence, one scalar
             FAResult._deep_merge([1], 1)
 
+    def test_combine_preserves_secagg_node_ids(self):
+        """_combine (variance two-pass fold) keeps the real participating node IDs."""
+        a = FAResult(None)
+        a._data = {"__secagg__": {"age": {"count": 100, "sum": 4000.0}}}
+        a._secagg_node_ids = ["node-1", "node-2"]
+        b = FAResult(None)
+        b._data = {"__secagg__": {"age": {"sum_sq_centered": 200.0}}}
+
+        combined = FAResult._combine(a, b)
+        assert combined._secagg_node_ids == ["node-1", "node-2"]
+
     # --- node_stats ---
 
     def test_node_stats_returns_dict_by_default(self):
@@ -1270,6 +1281,15 @@ class TestFilterOutput:
         assert isinstance(filtered, FAResult)
         assert filtered._data["n1"] == {}
 
+    def test_filtered_copy_preserves_secagg_node_ids(self):
+        """Filtering a secagg result keeps the real participating node IDs."""
+        result = FAResult(None)
+        result._data = {"__secagg__": {"age": {"mean": 40.0, "count": 100}}}
+        result._secagg_node_ids = ["node-1", "node-2"]
+
+        filtered = result._filtered_copy(["age"])
+        assert filtered._secagg_node_ids == ["node-1", "node-2"]
+
 
 # ---------------------------------------------------------------------------
 # TestCacheFallback
@@ -1609,10 +1629,10 @@ class TestSecaggIntegration:
 
         mock_secagg.aggregate.assert_called_once()
         assert isinstance(result, FAResult)
-        # The aggregated output is stored under "__secagg__"
-        assert "__secagg__" in result.node_ids
-        node_output = result.node_stats("__secagg__")
-        assert node_output == {"age": {"sum": 90.0, "count": 360}}
+        # Real participating node IDs are still reported under secure aggregation.
+        assert sorted(result.node_ids) == ["node-1", "node-2"]
+        # The aggregated output is stored under the "__secagg__" virtual node.
+        assert result._data["__secagg__"] == {"age": {"sum": 90.0, "count": 360}}
 
     @patch("fedbiomed.researcher.federated_workflows._federated_analytics.FARequestJob")
     def test_num_expected_params_uses_schema_length(
@@ -1641,7 +1661,7 @@ class TestSecaggIntegration:
             schema
         )
         # All four values are recovered and unflattened (no zip length mismatch).
-        assert result.node_stats("__secagg__") == {
+        assert result._data["__secagg__"] == {
             "age": {"sum": 450.0, "count": 100.0},
             "bmi": {"sum": 220.0, "count": 100.0},
         }
@@ -1742,6 +1762,46 @@ class TestSecaggIntegration:
 
         output = secagg_fa._results_store[
             list(secagg_fa._results_store.keys())[-1]
-        ].node_stats("__secagg__")
+        ]._data["__secagg__"]
         assert output["x"]["count"] == 100.0
         assert output["x"]["sum"] == 500.0
+
+    @patch("fedbiomed.researcher.federated_workflows._federated_analytics.FARequestJob")
+    def test_node_ids_reports_real_nodes_under_secagg(
+        self, mock_fa_job_cls, secagg_fa, mock_secagg
+    ):
+        """node_ids reports the real participating nodes, not the __secagg__ sentinel."""
+        schema = [["age", "sum"], ["age", "count"]]
+        mock_fa_job_cls.return_value.execute.return_value = {
+            "node-1": _make_encrypted_reply([100, 200], schema),
+            "node-2": _make_encrypted_reply([150, 300], schema),
+        }
+        mock_secagg.aggregate.return_value = [45.0, 180]
+
+        result = secagg_fa.fetch_stats("mean")
+
+        assert sorted(result.node_ids) == ["node-1", "node-2"]
+        assert "__secagg__" not in result.node_ids
+
+    @patch("fedbiomed.researcher.federated_workflows._federated_analytics.logger")
+    @patch("fedbiomed.researcher.federated_workflows._federated_analytics.FARequestJob")
+    def test_node_stats_redirects_to_global_under_secagg(
+        self, mock_fa_job_cls, mock_logger, secagg_fa, mock_secagg
+    ):
+        """Under secagg, node_stats logs an info message and returns global_stats."""
+        schema = [["age", "sum"], ["age", "count"]]
+        mock_fa_job_cls.return_value.execute.return_value = {
+            "node-1": _make_encrypted_reply([100, 200], schema),
+            "node-2": _make_encrypted_reply([150, 300], schema),
+        }
+        mock_secagg.aggregate.return_value = [45.0, 180]
+
+        result = secagg_fa.fetch_stats("mean")
+
+        # Both the all-nodes and the per-node forms redirect to global_stats.
+        assert result.node_stats("node-1") == result.global_stats()
+        assert result.node_stats() == result.global_stats()
+        assert any(
+            "global statistics" in call.args[0].lower()
+            for call in mock_logger.info.call_args_list
+        )


### PR DESCRIPTION
This PR puts in place changes requested to federated analytics api when secure aggregation is active.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`