### PR TITLE
add .value to error msg calls taking enum error numbers

### DIFF
--- a/fedbiomed/common/dataset_controller/_mnist_controller.py
+++ b/fedbiomed/common/dataset_controller/_mnist_controller.py
@@ -50,7 +50,7 @@ class MnistController(Controller):
         except Exception as e:
             raise FedbiomedError(
                 f"{ErrorNumbers.FB632.value}: "
-                "Failed to instantiate MnistDataset object. {e}"
+                f"Failed to instantiate MnistDataset object. {e}"
             ) from e
 
         self._controller_kwargs = {

--- a/fedbiomed/common/models/_model.py
+++ b/fedbiomed/common/models/_model.py
@@ -225,5 +225,5 @@ class Model(Generic[_MT, DT], metaclass=ABCMeta):
             [isinstance(w, float) for w in weights_vector]
         ):
             raise FedbiomedModelError(
-                f"{ErrorNumbers.FB622} `weights_vector should be 1D list of float containing flatten model parameters`"
+                f"{ErrorNumbers.FB622.value} `weights_vector should be 1D list of float containing flatten model parameters`"
             )

--- a/fedbiomed/common/secagg/_secagg_crypter.py
+++ b/fedbiomed/common/secagg/_secagg_crypter.py
@@ -179,13 +179,13 @@ class SecaggCrypter:
 
         if not isinstance(params, list) or not all(isinstance(p, list) for p in params):
             raise FedbiomedSecaggCrypterError(
-                f"{ErrorNumbers.FB624}: The parameters to aggregate should be a "
+                f"{ErrorNumbers.FB624.value}: The parameters to aggregate should be a "
                 f"list containing list of parameters"
             )
 
         if not all(all(isinstance(p_, int) for p_ in p) for p in params):
             raise FedbiomedSecaggCrypterError(
-                f"{ErrorNumbers.FB624}: Invalid parameter type. The parameters "
+                f"{ErrorNumbers.FB624.value}: Invalid parameter type. The parameters "
                 f"should be of type of integers."
             )
 
@@ -416,13 +416,13 @@ class SecaggLomCrypter(SecaggCrypter):
 
         if not isinstance(params, list) or not all(isinstance(p, list) for p in params):
             raise FedbiomedSecaggCrypterError(
-                f"{ErrorNumbers.FB624}: The parameters to aggregate should be a "
+                f"{ErrorNumbers.FB624.value}: The parameters to aggregate should be a "
                 f"list containing list of parameters"
             )
 
         if not all(all(isinstance(p_, int) for p_ in p) for p in params):
             raise FedbiomedSecaggCrypterError(
-                f"{ErrorNumbers.FB624}: Invalid parameter type. The parameters "
+                f"{ErrorNumbers.FB624.value}: Invalid parameter type. The parameters "
                 f"should be of type of integers."
             )
 

--- a/fedbiomed/common/synchro.py
+++ b/fedbiomed/common/synchro.py
@@ -97,7 +97,7 @@ class EventWaitExchange:
                 # this triggered event is obsolete
                 del self._triggered_events[reqid]
                 logger.debug(
-                    f"{ErrorNumbers.FB324}: Clean obsolete entry {reqid} from triggered"
+                    f"{ErrorNumbers.FB324.value}: Clean obsolete entry {reqid} from triggered"
                     "event table."
                 )
 
@@ -160,7 +160,7 @@ class EventWaitExchange:
             or timeout > MAX_TRIGGERED_EVENT_TIMEOUT
         ):
             raise FedbiomedSynchroError(
-                f"{ErrorNumbers.FB324}: Cannot wait {timeout} seconds. "
+                f"{ErrorNumbers.FB324.value}: Cannot wait {timeout} seconds. "
                 f"Should be int or float between 0 and {MAX_TRIGGERED_EVENT_TIMEOUT}"
             )
 

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -252,13 +252,13 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         init_dep_spec = get_method_spec(self.init_dependencies)
         if len(init_dep_spec.keys()) > 0:
             raise FedbiomedTrainingPlanError(
-                f"{ErrorNumbers.FB605}: `init_dependencies` should not take any argument. "
+                f"{ErrorNumbers.FB605.value}: `init_dependencies` should not take any argument. "
                 f"Unexpected arguments: {list(init_dep_spec.keys())}"
             )
         dependencies = self.init_dependencies()
         if not isinstance(dependencies, (list, tuple)):
             raise FedbiomedTrainingPlanError(
-                f"{ErrorNumbers.FB605}: Expected dependencies are a list or "
+                f"{ErrorNumbers.FB605.value}: Expected dependencies are a list or "
                 "tuple of str, but got {type(dependencies)}"
             )
         self._add_dependency(dependencies)
@@ -293,7 +293,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         else:
             if not isinstance(from_code, str):
                 raise FedbiomedTrainingPlanError(
-                    f"{ErrorNumbers.FB605}: Expected type str for `from_code`, "
+                    f"{ErrorNumbers.FB605.value}: Expected type str for `from_code`, "
                     "got: {type(from_code)}"
                 )
             content = from_code
@@ -749,14 +749,14 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         """
         if not isinstance(tags, set):
             raise FedbiomedTrainingPlanError(
-                f"{ErrorNumbers.FB605}: tag_parameters must return a set, "
+                f"{ErrorNumbers.FB605.value}: tag_parameters must return a set, "
                 f"got: {type(tags)} for parameter '{name}'"
             )
 
         invalid_tags = tags - self._allowed_tags
         if invalid_tags:
             raise FedbiomedTrainingPlanError(
-                f"{ErrorNumbers.FB605}: Invalid tags {invalid_tags} for parameter '{name}'. "
+                f"{ErrorNumbers.FB605.value}: Invalid tags {invalid_tags} for parameter '{name}'. "
                 f"Allowed tags are {self._allowed_tags}"
             )
 
@@ -797,7 +797,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
 
         if not isinstance(required_tags, set) or not isinstance(forbidden_tags, set):
             raise FedbiomedTrainingPlanError(
-                f"{ErrorNumbers.FB605}: required_tags and forbidden_tags must be sets"
+                f"{ErrorNumbers.FB605.value}: required_tags and forbidden_tags must be sets"
             )
 
         for name, value in params.items():

--- a/fedbiomed/common/training_plans/_base_training_plan.py
+++ b/fedbiomed/common/training_plans/_base_training_plan.py
@@ -259,7 +259,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
         if not isinstance(dependencies, (list, tuple)):
             raise FedbiomedTrainingPlanError(
                 f"{ErrorNumbers.FB605.value}: Expected dependencies are a list or "
-                "tuple of str, but got {type(dependencies)}"
+                f"tuple of str, but got {type(dependencies)}"
             )
         self._add_dependency(dependencies)
 
@@ -294,7 +294,7 @@ class BaseTrainingPlan(metaclass=ABCMeta):
             if not isinstance(from_code, str):
                 raise FedbiomedTrainingPlanError(
                     f"{ErrorNumbers.FB605.value}: Expected type str for `from_code`, "
-                    "got: {type(from_code)}"
+                    f"got: {type(from_code)}"
                 )
             content = from_code
 

--- a/fedbiomed/common/utils/_utils.py
+++ b/fedbiomed/common/utils/_utils.py
@@ -148,7 +148,7 @@ def import_object(module: str, obj_name: str) -> Any:
         obj_ = getattr(module, obj_name)
     except AttributeError as exp:
         raise FedbiomedError(
-            f"{ErrorNumbers.FB627}, Attribute error while loading the class "
+            f"{ErrorNumbers.FB627.value}, Attribute error while loading the class "
             f"{obj_name} from {module}. Error: {exp}"
         ) from exp
 
@@ -171,7 +171,7 @@ def import_class_from_file(module_path: str, class_name: str) -> Tuple[Any, Any]
     """
     if not os.path.isfile(module_path):
         raise FedbiomedError(
-            f"{ErrorNumbers.FB627}: Given path for importing {class_name} is not existing"
+            f"{ErrorNumbers.FB627.value}: Given path for importing {class_name} is not existing"
         )
 
     module_base_name = os.path.basename(module_path)
@@ -179,7 +179,7 @@ def import_class_from_file(module_path: str, class_name: str) -> Tuple[Any, Any]
 
     match = pattern.match(module_base_name)
     if not match:
-        raise FedbiomedError(f"{ErrorNumbers.FB627}: File is not a python file.")
+        raise FedbiomedError(f"{ErrorNumbers.FB627.value}: File is not a python file.")
 
     module = match.group(1)
     sys.path.insert(0, os.path.dirname(module_path))

--- a/fedbiomed/node/requests/_n2n_controller.py
+++ b/fedbiomed/node/requests/_n2n_controller.py
@@ -146,7 +146,7 @@ class NodeToNodeController:
         """
 
         logger.error(
-            f"{ErrorNumbers.FB324}: Failed processing overlay message, unknown inner command "
+            f"{ErrorNumbers.FB324.value}: Failed processing overlay message, unknown inner command "
             f"{inner_msg.__class__.__name__}. Do nothing."
         )
 
@@ -203,7 +203,7 @@ class NodeToNodeController:
             inner_msg.request_id,
         ):
             logger.warning(
-                f"{ErrorNumbers.FB324}: Received channel key of unregistered "
+                f"{ErrorNumbers.FB324.value}: Received channel key of unregistered "
                 f"peer node {inner_msg.node_id} "
                 f"or reply to non existing request {inner_msg.request_id}. "
                 f"Distant node may be confused or it may be an attack."

--- a/fedbiomed/node/requests/_n2n_router.py
+++ b/fedbiomed/node/requests/_n2n_router.py
@@ -91,7 +91,9 @@ class _NodeToNodeAsyncRouter:
                 del self._active_tasks[task_name]
             else:
                 # don't raise exception
-                logger.error(f"{ErrorNumbers.FB324}: task already finished {task_name}")
+                logger.error(
+                    f"{ErrorNumbers.FB324.value}: task already finished {task_name}"
+                )
 
     async def _clean_active_tasks(self) -> None:
         """Main function for background task cleaning active task list.
@@ -150,7 +152,7 @@ class _NodeToNodeAsyncRouter:
         # FIXME: Never raises QueueFull maxsize=0 by default
         except asyncio.QueueFull as e:
             logger.error(
-                f"{ErrorNumbers.FB324}: Failed submitting message to node to node router. "
+                f"{ErrorNumbers.FB324.value}: Failed submitting message to node to node router. "
                 f"Discard message. Exception: {type(e).__name__}. Error message: {e}"
             )
 
@@ -165,7 +167,7 @@ class _NodeToNodeAsyncRouter:
             try:
                 if overlay_msg.dest_node_id != self._node_id:
                     logger.error(
-                        f"{ErrorNumbers.FB324}: Node {self._node_id} received an overlay "
+                        f"{ErrorNumbers.FB324.value}: Node {self._node_id} received an overlay "
                         f"message sent to {overlay_msg.dest_node_id}. Maybe malicious activity. "
                         "Ignore message."
                     )
@@ -192,7 +194,7 @@ class _NodeToNodeAsyncRouter:
 
             except asyncio.CancelledError as e:
                 logger.error(
-                    f"{ErrorNumbers.FB324}: Task {asyncio.current_task().get_name()} was cancelled "
+                    f"{ErrorNumbers.FB324.value}: Task {asyncio.current_task().get_name()} was cancelled "
                     f"before completing. Error message: {e}. Overlay message: "
                     f"{overlay_msg.overlay.__name__}"
                 )
@@ -203,7 +205,7 @@ class _NodeToNodeAsyncRouter:
 
         except Exception as e:
             logger.error(
-                f"{ErrorNumbers.FB324}: Failed processing overlay message. Exception: "
+                f"{ErrorNumbers.FB324.value}: Failed processing overlay message. Exception: "
                 f"{type(e).__name__}. Error message: {e}. Overlay message: "
                 f"{overlay_msg.overlay}"
             )

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -433,7 +433,7 @@ class Round:
                     )
                 except FedbiomedError as e:
                     logger.error(
-                        f"{ErrorNumbers.FB314}: During the validation phase on global parameter updates; "
+                        f"{ErrorNumbers.FB314.value}: During the validation phase on global parameter updates; "
                         f"{repr(e)}",
                         researcher_id=self.researcher_id,
                     )
@@ -451,7 +451,7 @@ class Round:
                     )
             else:
                 logger.error(
-                    f"{ErrorNumbers.FB314}: Can not execute validation routine due to missing testing dataset"
+                    f"{ErrorNumbers.FB314.value}: Can not execute validation routine due to missing testing dataset"
                     f"Please make sure that `test_ratio` has been set correctly",
                     researcher_id=self.researcher_id,
                 )

--- a/fedbiomed/node/training_plan_security_manager.py
+++ b/fedbiomed/node/training_plan_security_manager.py
@@ -193,7 +193,7 @@ class TrainingPlanSecurityManager:
             if training_plans_name_get:
                 raise FedbiomedTrainingPlanSecurityManagerError(
                     f"{ErrorNumbers.FB606.value}:  there is already a existing training plan with "
-                    "same name: '{name}' Please use different name"
+                    f"same name: '{name}' Please use different name"
                 )
 
         if hash_ is not None or algorithm is not None:
@@ -779,7 +779,7 @@ class TrainingPlanSecurityManager:
                     self._check_training_plan_not_existing(None, hash_, algorithm)
                     logger.info(
                         f"Recreating hashing for : {training_plan_info['name']} \t"
-                        '{training_plan_info["training_plan_id"]}'
+                        f"{training_plan_info['training_plan_id']}"
                     )
 
                     self._db.update(

--- a/fedbiomed/researcher/federated_workflows/_federated_workflow.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_workflow.py
@@ -832,7 +832,7 @@ class FederatedWorkflow(ABC):
         if not isinstance(scheme, SecureAggregationSchemes):
             raise FedbiomedExperimentError(
                 f"{ErrorNumbers.FB410.value}: Expected `scheme` argument "
-                "`SecureAggregationSchemes`, but got {type(scheme)}"
+                f"`SecureAggregationSchemes`, but got {type(scheme)}"
             )
 
         if isinstance(secagg, bool):

--- a/fedbiomed/researcher/secagg/_secagg_context.py
+++ b/fedbiomed/researcher/secagg/_secagg_context.py
@@ -82,7 +82,7 @@ class SecaggContext(ABC):
         except ValidatorError as e:
             raise FedbiomedSecaggError(
                 f"{ErrorNumbers.FB415.value}: bad parameter "
-                "`secagg_id` must be a None or non-empty string: {e}"
+                f"`secagg_id` must be a None or non-empty string: {e}"
             ) from e
 
         try:


### PR DESCRIPTION
This PR adds `.value` to Error number enums.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`