### PR TITLE
enforce node set consistency for secagg and cache reuse in fa

### DIFF
--- a/fedbiomed/common/analytics/_orchestrator.py
+++ b/fedbiomed/common/analytics/_orchestrator.py
@@ -158,8 +158,13 @@ class AnalyticsOrchestrator:
         keys_map = {}
 
         if subschema is None:
-            # All keys, no subschema
-            for k in schema.keys():
+            # stats_args-only request encodes the key selection in its own structure.
+            keys = (
+                stats_args.keys()
+                if stats_args is not None and not stats
+                else schema.keys()
+            )
+            for k in keys:
                 keys_map[k] = None
         elif isinstance(subschema, (list, tuple)):
             for item in subschema:
@@ -220,9 +225,13 @@ class AnalyticsOrchestrator:
         # Validate Subschema
         if subschema is not None:
             if not isinstance(subschema, (list, tuple)):
-                raise FedbiomedError(
-                    f"Subschema for sequence must be list/tuple. Got {type(subschema)}."
-                )
+                # Single active element: accept and wrap an unwrapped subschema (e.g. a dict).
+                if len(active) == 1:
+                    subschema = [subschema]
+                else:
+                    raise FedbiomedError(
+                        f"Subschema for sequence must be list/tuple. Got {type(subschema)}."
+                    )
 
             # When the schema has exactly one active element, the child subschema may be
             # passed directly (e.g. ["col1"]) instead of wrapped (e.g. [["col1"]]).
@@ -296,12 +305,13 @@ class AnalyticsOrchestrator:
         """Validates and builds config for a ROW type leaf node."""
         # Validate Subschema
         if subschema is not None:
+            if isinstance(subschema, str):
+                subschema = [subschema]  # normalise a bare column name to a list
             if not isinstance(subschema, (list, tuple)):
                 raise FedbiomedError("Subschema for ROW must be a list of columns.")
             invalid = set(subschema) - set(schema.columns)
             if invalid:
                 raise FedbiomedError(f"Invalid columns in subschema: {invalid}")
-        selected_cols = subschema if subschema is not None else schema.columns
 
         # Validate Args
         if stats_args is not None:
@@ -310,6 +320,14 @@ class AnalyticsOrchestrator:
             invalid = set(stats_args.keys()) - set(schema.columns)
             if invalid:
                 raise FedbiomedError(f"Invalid columns in args: {invalid}")
+
+        # With no subschema and no flat stats list, stats_args names the selected columns.
+        if subschema is not None:
+            selected_cols = subschema
+        elif stats_args is not None and not stats:
+            selected_cols = list(stats_args.keys())
+        else:
+            selected_cols = schema.columns
 
         # Compile Config
         col_configs = {}

--- a/fedbiomed/researcher/federated_workflows/_federated_analytics.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_analytics.py
@@ -86,8 +86,14 @@ class FAResult:
         return next(iter(self._data.values()))
 
     @staticmethod
-    def _filter_output(output: Any, schema: list) -> Optional[Any]:
+    def _filter_output(output: Any, schema: list | dict) -> Optional[Any]:
         """Return a filtered copy of *output* keeping only keys listed in *schema*.
+
+        Accepts both the list form (``["a", {"b": ["c"]}]``) and the dict form
+        (``{"a": None, "b": ["c"]}``), mirroring the node-side orchestrator. A
+        dict schema is normalised to ``[{key: child_sub}]`` so the same per-item
+        logic applies; a bare-string child (``{"b": "c"}``) is normalised to
+        ``["c"]``.
 
         Returns ``None`` if *output* is not a filterable dict, a key is absent, a child
         schema is given for a non-dict value, or a schema item type is unsupported.
@@ -95,6 +101,9 @@ class FAResult:
         # Stat-leaves are terminal values, not filterable structural dicts.
         if not isinstance(output, dict) or FAResult._is_stat_leaf(output):
             return None
+        # Normalise a dict-form subschema ({key: child_sub}) to the list-of-items form.
+        if isinstance(schema, dict):
+            schema = [{k: v} for k, v in schema.items()]
         result: dict = {}
         for item in schema:
             if isinstance(item, str):
@@ -113,8 +122,8 @@ class FAResult:
                 )  # no sub-schema: copy subtree as-is
             elif not isinstance(output[key], dict):
                 return None  # child schema given but value is not a filterable dict
-            elif isinstance(child_sub, (list, tuple)):
-                child = FAResult._filter_output(output[key], list(child_sub))
+            elif isinstance(child_sub, (list, tuple, dict)):
+                child = FAResult._filter_output(output[key], child_sub)
                 if child is None:
                     return None
                 result[key] = child
@@ -122,7 +131,7 @@ class FAResult:
                 return None  # child_sub is an unexpected type
         return result
 
-    def _filtered_copy(self, schema: list) -> Optional["FAResult"]:
+    def _filtered_copy(self, schema: list | dict) -> Optional["FAResult"]:
         """Return a copy filtered to *schema*, or ``None`` if any node output cannot be filtered."""
         filtered_data: dict[str, Any] = {}
         for node_id, output in self._data.items():

--- a/fedbiomed/researcher/federated_workflows/_federated_analytics.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_analytics.py
@@ -707,6 +707,13 @@ class FederatedAnalytics:
 
         first_reply = next(iter(analytics_replies.values()))
         if first_reply.encrypted:
+            # Every party must contribute or secagg masks will not cancel on decryption.
+            if set(analytics_replies) != set(node_ids):
+                raise FedbiomedError(
+                    "Secure aggregation requires all nodes to reply; missing "
+                    f"contributions break mask cancellation. Expected {sorted(node_ids)}, "
+                    f"got {sorted(analytics_replies)}."
+                )
             model_params = {
                 nid: r.params_encrypted for nid, r in analytics_replies.items()
             }
@@ -744,15 +751,20 @@ class FederatedAnalytics:
         cache_key: Any,
         missing: list[str],
         dataset_schema: list[str | dict],
+        node_ids: list[str],
     ) -> Optional[FAResult]:
         """Recover missing stats from a cached superset-schema result, or None.
 
-        Scans stored results for an entry containing all ``missing`` stats whose
-        schema is a superset of ``dataset_schema``. ``_filtered_copy`` returns None
-        on any missing key, so a non-None result implies a superset. On success the
-        filtered copy is stored under ``cache_key`` and returned.
+        Scans stored results for an entry from the same node set containing all
+        ``missing`` stats whose schema is a superset of ``dataset_schema``.
+        ``_filtered_copy`` returns None on any missing key, so a non-None result
+        implies a superset. On success the filtered copy is stored under
+        ``cache_key`` and returned. Results from a different node set are skipped:
+        reusing them would drop or invent node contributions.
         """
         for other in self._results_store.values():
+            if set(other.node_ids) != set(node_ids):
+                continue
             satisfiable = set(other.available_stats()) | set(other.computable_stats())
             if not all(s in satisfiable for s in missing):
                 continue
@@ -909,7 +921,7 @@ class FederatedAnalytics:
         missing = [s for s in stats if s not in satisfiable]
         if missing:
             recovered = (
-                self._recover_from_cache(cache_key, missing, dataset_schema)
+                self._recover_from_cache(cache_key, missing, dataset_schema, node_ids)
                 if dataset_schema is not None and cached is None
                 else None
             )

--- a/tests/test_analytics/test_analytics_orchestrator.py
+++ b/tests/test_analytics/test_analytics_orchestrator.py
@@ -224,6 +224,18 @@ def test_handle_dict_subschema_as_dict(orchestrator):
         assert spec_c in called_first_args
 
 
+def test_handle_dict_stats_args_only_selects_named_keys(orchestrator):
+    """stats_args-only (no subschema) selects its named keys (variance/std round 2)."""
+    schema = {"a": RowSpec(columns=["x"]), "b": RowSpec(columns=["y"])}
+    config = orchestrator._handle_dict(
+        schema,
+        subschema=None,
+        stats=None,
+        stats_args={"a": {"x": {"sum_sq_centered": {"mean": 1.0}}}},
+    )
+    assert set(config["children"].keys()) == {"a"}
+
+
 def test_handle_dict_subschema_as_dict_invalid_keys(orchestrator):
     schema = {"a": ImageSpec()}
     with pytest.raises(FedbiomedError, match="Invalid keys in subschema"):
@@ -366,6 +378,27 @@ def test_handle_sequence_subschema_already_nested_not_rewrapped(orchestrator):
 
     # [["c1", "c2"]] — subschema[0] is a list (a container), so no wrapping occurs
     assert mock_bvc.call_args[0][1] == ["c1", "c2"]
+
+
+def test_handle_sequence_dict_subschema_wraps_for_single_active(orchestrator):
+    """Dict subschema accepted (wrapped) for a single-active (dict, None) schema (MedicalFolderDataset)."""
+    schema = ({"demographics": RowSpec(columns=["AGE", "HEIGHT"])}, None)
+    config = orchestrator._build_and_validate_config(
+        schema, {"demographics": "AGE"}, ["mean"], None
+    )
+    assert len(config["children"]) == 1  # only the active (non-None) element
+    assert set(config["children"][0]["children"]["demographics"]["conf"].keys()) == {
+        "AGE"
+    }
+
+
+def test_handle_sequence_dict_subschema_errors_for_multiple_active(orchestrator):
+    """A bare dict subschema is ambiguous when the sequence has >1 active element."""
+    schema = [RowSpec(columns=["c1"]), RowSpec(columns=["c2"])]
+    with pytest.raises(FedbiomedError, match="Subschema for sequence must be list"):
+        orchestrator._handle_sequence(
+            schema, subschema={"c1": None}, stats=None, stats_args=None
+        )
 
 
 def test_handle_sequence_subschema_errors(orchestrator):
@@ -614,14 +647,32 @@ def test_handle_row_validation_errors(orchestrator):
     with pytest.raises(FedbiomedError, match="Subschema for ROW must be a list"):
         orchestrator._handle_row(schema, 123, None, None)
 
-    with pytest.raises(FedbiomedError, match="Subschema for ROW must be a list"):
-        orchestrator._handle_row(schema, "c1", None, None)
-
     with pytest.raises(FedbiomedError, match="Args for ROW must be a dict"):
         orchestrator._handle_row(schema, None, None, stats_args=["not", "a", "dict"])
 
     with pytest.raises(FedbiomedError, match="Invalid columns in args"):
         orchestrator._handle_row(schema, None, None, stats_args={"z": {}})
+
+
+def test_handle_row_stats_args_only_selects_named_columns(orchestrator):
+    """stats_args-only (no subschema) selects its named columns (variance/std round 2)."""
+    schema = RowSpec(columns=["A", "B", "C"])
+    config = orchestrator._handle_row(
+        schema, None, None, {"A": {"sum_sq_centered": {"mean": 5.0}}}
+    )
+    assert set(config["conf"].keys()) == {"A"}
+
+
+def test_build_config_dict_form_schema_selects_single_column(orchestrator):
+    """Dict-form dataset_schema {key: column} (bare-string or list child) selects only that column."""
+    schema = {"demographics": RowSpec(columns=["AGE", "HEIGHT", "WEIGHT"])}
+    for subschema in ({"demographics": "AGE"}, {"demographics": ["AGE"]}):
+        config = orchestrator._build_and_validate_config(
+            schema, subschema, ["mean"], None
+        )
+        assert set(config["children"]["demographics"]["conf"].keys()) == {"AGE"}, (
+            subschema
+        )
 
 
 # ── _handle_image ────────────────────────────────────────────────────────────

--- a/tests/test_analytics/test_federated_analytics.py
+++ b/tests/test_analytics/test_federated_analytics.py
@@ -1485,6 +1485,30 @@ class TestCacheFallback:
         )  # filtered_copy fails → new request
         assert mock_fa_job_cls.call_count == 2
 
+    @patch("fedbiomed.researcher.federated_workflows._federated_analytics.FARequestJob")
+    def test_fallback_skipped_when_node_set_differs(
+        self, mock_fa_job_cls, base_fa, mock_fds
+    ):
+        """A cached result from a different node set must not be reused."""
+        replies_two = {
+            "node-1": _make_reply({"age": {"mean": 40.0, "count": 100}}),
+            "node-2": _make_reply({"age": {"mean": 45.0, "count": 80}}),
+        }
+        replies_three = {
+            **replies_two,
+            "node-3": _make_reply({"age": {"mean": 50.0, "count": 60}}),
+        }
+        mock_fa_job_cls.return_value.execute.side_effect = [replies_two, replies_three]
+
+        base_fa.fetch_stats("mean")  # cache result for {node-1, node-2}
+        assert mock_fa_job_cls.call_count == 1
+
+        # A node joins; a schema request must NOT recover the two-node result.
+        mock_fds.node_ids.return_value = ["node-1", "node-2", "node-3"]
+        result = base_fa.fetch_stats("mean", dataset_schema=["age"])
+        assert mock_fa_job_cls.call_count == 2  # new request, fallback skipped
+        assert sorted(result.node_ids) == ["node-1", "node-2", "node-3"]
+
 
 # ---------------------------------------------------------------------------
 # TestSecaggIntegration — encrypted-path tests for FederatedAnalytics
@@ -1672,8 +1696,10 @@ class TestSecaggIntegration:
     ):
         """_secagg_setup calls secagg.setup() with the node IDs from the federated dataset."""
         schema = [["x"]]
-        reply = _make_encrypted_reply([1], schema)
-        mock_fa_job_cls.return_value.execute.return_value = {"node-1": reply}
+        mock_fa_job_cls.return_value.execute.return_value = {
+            "node-1": _make_encrypted_reply([1], schema),
+            "node-2": _make_encrypted_reply([1], schema),
+        }
         mock_fds.node_ids.return_value = ["node-1", "node-2"]
         mock_secagg.aggregate.return_value = [5.0]
 
@@ -1691,7 +1717,8 @@ class TestSecaggIntegration:
         """fa_round injected into secagg_arguments increments with each FA request."""
         schema = [["x"]]
         mock_fa_job_cls.return_value.execute.return_value = {
-            "node-1": _make_encrypted_reply([1], schema)
+            "node-1": _make_encrypted_reply([1], schema),
+            "node-2": _make_encrypted_reply([1], schema),
         }
         mock_secagg.aggregate.return_value = [1.0]
 
@@ -1710,7 +1737,8 @@ class TestSecaggIntegration:
         """train_arguments() dict (plus fa_round) is passed verbatim to FARequestJob."""
         schema = [["x"]]
         mock_fa_job_cls.return_value.execute.return_value = {
-            "node-1": _make_encrypted_reply([1], schema)
+            "node-1": _make_encrypted_reply([1], schema),
+            "node-2": _make_encrypted_reply([1], schema),
         }
         mock_secagg.aggregate.return_value = [1.0]
 
@@ -1752,10 +1780,17 @@ class TestSecaggIntegration:
         """Two sequential encrypted requests merge their aggregate outputs in FAResult."""
         schema_count = [["x", "count"]]
         schema_sum = [["x", "sum"]]
-        replies_count = {"node-1": _make_encrypted_reply([100], schema_count)}
-        replies_sum = {"node-1": _make_encrypted_reply([500], schema_sum)}
+        replies_count = {
+            "node-1": _make_encrypted_reply([100], schema_count),
+            "node-2": _make_encrypted_reply([100], schema_count),
+        }
+        replies_sum = {
+            "node-1": _make_encrypted_reply([500], schema_sum),
+            "node-2": _make_encrypted_reply([500], schema_sum),
+        }
         mock_fa_job_cls.return_value.execute.side_effect = [replies_count, replies_sum]
-        mock_secagg.aggregate.side_effect = [[100.0], [500.0]]
+        # aggregate returns the cross-node mean; ×num_nodes (2) restores the sum.
+        mock_secagg.aggregate.side_effect = [[50.0], [250.0]]
 
         secagg_fa.fetch_stats("count")
         secagg_fa.fetch_stats("mean")  # mean requires sum + count
@@ -1805,3 +1840,18 @@ class TestSecaggIntegration:
             "global statistics" in call.args[0].lower()
             for call in mock_logger.info.call_args_list
         )
+
+    @patch("fedbiomed.researcher.federated_workflows._federated_analytics.FARequestJob")
+    def test_missing_node_reply_under_secagg_raises(
+        self, mock_fa_job_cls, secagg_fa, mock_secagg
+    ):
+        """A node that does not contribute breaks mask cancellation: secagg must reject it."""
+        schema = [["age", "sum"], ["age", "count"]]
+        # node-2 is expected (from the dataset) but only node-1 replied.
+        mock_fa_job_cls.return_value.execute.return_value = {
+            "node-1": _make_encrypted_reply([100, 200], schema),
+        }
+
+        with pytest.raises(FedbiomedError, match="all nodes to reply"):
+            secagg_fa.fetch_stats("mean")
+        mock_secagg.aggregate.assert_not_called()

--- a/tests/test_analytics/test_federated_analytics.py
+++ b/tests/test_analytics/test_federated_analytics.py
@@ -1178,6 +1178,29 @@ class TestFilterOutput:
         assert result_str == result_list
         assert result_str == {"demo": {"col1": {"mean": 1.0, "count": 10}}}
 
+    # ---- _filter_output: dict-form schema ----
+
+    def test_dict_form_schema_applies_child_selection(self):
+        """Dict-form schema ({key: child}) filters the child instead of copying the subtree."""
+        output = {
+            "demographics": {
+                "AGE": {"mean": 49.9, "count": 434},
+                "HEIGHT": {"mean": 161.8, "count": 435},
+            }
+        }
+        expected = {"demographics": {"AGE": {"mean": 49.9, "count": 434}}}
+        assert FAResult._filter_output(output, {"demographics": "AGE"}) == expected
+        assert FAResult._filter_output(output, {"demographics": ["AGE"]}) == expected
+
+    def test_dict_form_schema_none_child_keeps_subtree(self):
+        """A dict-form key mapped to None keeps that whole subtree (and drops others)."""
+        output = {
+            "demographics": {"AGE": {"mean": 49.9, "count": 434}},
+            "imaging": {"T1": {"mean": 1.0, "count": 10}},
+        }
+        result = FAResult._filter_output(output, {"demographics": None})
+        assert result == {"demographics": {"AGE": {"mean": 49.9, "count": 434}}}
+
     # ---- _filter_output: None / error cases ----
 
     def test_dict_item_non_dict_value_with_child_returns_none(self):


### PR DESCRIPTION
This PR ensures no mismatch between requests using cache.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`