### PR TITLE
fix issue due to wrong initialization with torch.Tensor

### DIFF
--- a/tests/test_torch_data_manager.py
+++ b/tests/test_torch_data_manager.py
@@ -16,20 +16,20 @@ class TestTorchDataManager(unittest.TestCase):
 
         def __init__(self):
             self.X_train = [
-                torch.Tensor([1, 2, 3]),
-                torch.Tensor([4, 5, 6]),
-                torch.Tensor([7, 8, 9]),
-                torch.Tensor([10, 11, 12]),
-                torch.Tensor([13, 14, 15]),
-                torch.Tensor([16, 17, 18]),
+                torch.tensor([1.0, 2.0, 3.0]),
+                torch.tensor([4.0, 5.0, 6.0]),
+                torch.tensor([7.0, 8.0, 9.0]),
+                torch.tensor([10.0, 11.0, 12.0]),
+                torch.tensor([13.0, 14.0, 15.0]),
+                torch.tensor([16.0, 17.0, 18.0]),
             ]
             self.Y_train = [
-                torch.Tensor(1),
-                torch.Tensor(2),
-                torch.Tensor(3),
-                torch.Tensor(4),
-                torch.Tensor(5),
-                torch.Tensor(6),
+                torch.tensor(1.0),
+                torch.tensor(2.0),
+                torch.tensor(3.0),
+                torch.tensor(4.0),
+                torch.tensor(5.0),
+                torch.tensor(6.0),
             ]
 
         def load(self):


### PR DESCRIPTION
This PR correct minor issue related to test fixture dataset that uses wrong call.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`