### PR TITLE
Feature/1837 remove node management tab and add force option

### DIFF
--- a/envs/vpn/docker/docker-compose.yml
+++ b/envs/vpn/docker/docker-compose.yml
@@ -228,7 +228,7 @@ services:
       - CONTAINER_USER
       - CONTAINER_GROUP
     ports:
-      - "${GUI_SERVER_IP:-127.0.0.1}:8485:8485" # nginx + gunicorn HTTP server
+      - "${GUI_SERVER_IP:-127.0.0.1}:8485:8485" # nginx + flask HTTP server
       - "${GUI_SERVER_IP:-127.0.0.1}:8444:8444" # nginx + gunicorn HTTPS server
     volumes:
       # caution: /fbm-node directory must be shared with node

--- a/fedbiomed/node/cli.py
+++ b/fedbiomed/node/cli.py
@@ -374,6 +374,15 @@ class NodeControl(CLIArgumentParser):
             help="Start the node in the background. Default is `False`",
         )
 
+        start.add_argument(
+            "--force",
+            action="store_true",
+            help=(
+                "Start a new node process even when the process-state database "
+                "reports that the node is already running."
+            ),
+        )
+
         stop = self._subparser.add_parser("stop", help="Stops the node")
         stop.set_defaults(func=self.stop)
 
@@ -462,6 +471,7 @@ class NodeControl(CLIArgumentParser):
                 node_args=node_args,
                 background=background,
                 actor={"source": "cli"},
+                force=args.force,
             )
         except KeyboardInterrupt:
             node_process_manager.stop(

--- a/fedbiomed/node/node_pm.py
+++ b/fedbiomed/node/node_pm.py
@@ -339,7 +339,11 @@ class NodeProcessManager:
                     }
                     entry.started_at = (
                         existing.get("started_at")
-                        if is_existing_process_active and existing.get("started_at")
+                        if (
+                            action != "start"
+                            and is_existing_process_active
+                            and existing.get("started_at")
+                        )
                         else now
                     )
                     entry.stopped_at = None
@@ -371,6 +375,7 @@ class NodeProcessManager:
         background: bool = False,
         actor: Optional[Dict[str, Any]] = None,
         reason: Optional[str] = "start_requested",
+        force: bool = False,
     ) -> None:
         """Spawn a node subprocess.
 
@@ -379,13 +384,20 @@ class NodeProcessManager:
             background: If True, the node will be started in the background.
             actor: Optional user/source metadata for process state attribution.
             reason: Optional reason for starting the process, default is "start_requested".
+            force: Start a new process and replace its database state even when
+                the node is currently reported as running.
         """
 
-        # Start should raise an error if the user is trying to start/restart an existing node process.
         status = self.get_status()
-        if status == NodeState.RUNNING:
+        if status == NodeState.RUNNING and not force:
             logger.warning("Node process is already running. Ignoring start request.")
             return
+        if status == NodeState.RUNNING:
+            logger.warning(
+                "Forcing node startup while the database reports it as running. "
+                "The previous node process might not have closed properly; "
+                "this may cause a process leak."
+            )
 
         logger.info(f"Starting node subprocess with python={sys.executable}")
         logger.info(f"Node subprocess config root={self._config.root}")

--- a/fedbiomed_gui/ui/src/pages/node-manager/NodeManagement.js
+++ b/fedbiomed_gui/ui/src/pages/node-manager/NodeManagement.js
@@ -64,6 +64,33 @@ const mainTabs = {
 }
 
 const applicationLogBasename = 'application.log'
+const nodeManagementDisabledMessage = (
+    'Node management feature will be added in a future release'
+)
+
+const NodeManagement = () => (
+    <div className="node-management-page">
+        <section className="node-management-card node-management-header">
+            <div className="node-management-header-top">
+                <div className="node-management-heading">
+                    <span className="node-management-heading-icon">
+                        <EuiIcon type="node" size="xl" />
+                    </span>
+                    <div>
+                        <h1>Node Management</h1>
+                        <p>Monitor and manage node processes</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section className="node-management-card node-management-process">
+            <EuiText color="subdued">
+                <p>{nodeManagementDisabledMessage}</p>
+            </EuiText>
+        </section>
+    </div>
+)
 
 const formatValue = (value) => {
     if (value === null || value === undefined || value === '') {
@@ -202,7 +229,7 @@ const DetailItem = ({icon, label, value, valueContent}) => (
     </div>
 )
 
-const NodeManagement = ({
+const NodeManagementContent = ({
     processState,
     loading,
     actionLoading,
@@ -725,4 +752,9 @@ const mapDispatchToProps = (dispatch) => {
     }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(NodeManagement)
+export const NodeManagementEnabled = connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(NodeManagementContent)
+
+export default NodeManagement

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -840,6 +840,15 @@ def test_node_signal_trigger_term():
             },
         ),
         (
+            ["start", "--force"],
+            {
+                "gpu": False,
+                "gpu_num": 1,
+                "gpu_only": False,
+                "debug": False,
+            },
+        ),
+        (
             ["start", "--gpu", "--gpu-num", "2", "--debug"],
             {
                 "gpu": True,
@@ -908,6 +917,7 @@ def test_node_control_start_builds_node_args_and_waits(
         node_args=expected_node_args,
         background=args.background,
         actor={"source": "cli"},
+        force=args.force,
     )
 
     mock_node_process_manager.stop.assert_not_called()
@@ -950,6 +960,7 @@ def test_node_control_start_keyboard_interrupt_stops_node(mocker):
         },
         background=False,
         actor={"source": "cli"},
+        force=False,
     )
 
     mock_node_process_manager.stop.assert_called_once_with(

--- a/tests/test_node_pm.py
+++ b/tests/test_node_pm.py
@@ -475,6 +475,39 @@ def test_node_pm_05_set_process_state_resets_started_at_after_stop(mocker, _mana
     assert "stopped_at" not in state_entry
 
 
+def test_node_pm_05_set_process_state_resets_started_at_for_forced_start(
+    mocker,
+    _manager,
+):
+    manager = _manager
+    manager._node_id = "node_id1"
+
+    state_table = manager._state_table
+    state_table.get_by_id.return_value = {
+        "state": NodeState.RUNNING.value,
+        "pid": 1234,
+        "started_at": "previous-start",
+    }
+
+    mocker.patch("fedbiomed.node.node_pm._utc_now", return_value="forced-start")
+    mocker.patch.object(
+        NodeProcessManager, "_build_actor", return_value={"source": "cli"}
+    )
+
+    manager._set_process_state(
+        pid=5678,
+        state=NodeState.RUNNING,
+        action="start",
+        actor={"source": "cli"},
+        reason="start_requested",
+    )
+
+    state_entry = state_table.update_or_insert_by_id.call_args.args[1]
+    assert state_entry["pid"] == 5678
+    assert state_entry["state"] == NodeState.RUNNING.value
+    assert state_entry["started_at"] == "forced-start"
+
+
 def test_node_pm_06_start_process_already_started(mocker, _manager):
     manager = _manager
     manager.get_status = mocker.MagicMock(return_value=NodeState.RUNNING)
@@ -488,6 +521,42 @@ def test_node_pm_06_start_process_already_started(mocker, _manager):
         "Node process is already running. Ignoring start request."
     )
     mock_popen.assert_not_called()
+
+
+def test_node_pm_06_force_start_process_already_started(mocker, _manager):
+    manager = _manager
+    manager.get_status = mocker.MagicMock(return_value=NodeState.RUNNING)
+    manager._set_process_state = mocker.MagicMock()
+
+    process = mocker.MagicMock(pid=54321)
+    mock_popen = mocker.patch(
+        "fedbiomed.node.node_pm.subprocess.Popen",
+        return_value=process,
+    )
+    mock_logger = mocker.patch("fedbiomed.node.node_pm.logger")
+
+    manager.start(
+        node_args={"gpu": False},
+        background=True,
+        actor={"source": "cli"},
+        force=True,
+    )
+
+    mock_popen.assert_called_once()
+    manager._set_process_state.assert_called_once_with(
+        pid=54321,
+        state=NodeState.RUNNING,
+        action="start",
+        actor={"source": "cli"},
+        reason="start_requested",
+        node_args={"gpu": False},
+        background=True,
+    )
+    mock_logger.warning.assert_called_once_with(
+        "Forcing node startup while the database reports it as running. "
+        "The previous node process might not have closed properly; "
+        "this may cause a process leak."
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR disables the node management tab from the GUI (until the node and gui containers are merged). It also adds `--force` option when starting the node to override the node state in the database, in case of an inconsistency