### PR TITLE
Fix/tests warnings

### DIFF
--- a/fedbiomed/common/dataloadingplan/_data_loading_plan.py
+++ b/fedbiomed/common/dataloadingplan/_data_loading_plan.py
@@ -108,7 +108,7 @@ class SerializationValidation:
     @staticmethod
     @validator_decorator
     def _identifier_validation_hook(full_name: str) -> Union[bool, Tuple[bool, str]]:
-        """Validates that a fully qualified name follows the syntax for python identifiers.
+        r"""Validates that a fully qualified name follows the syntax for python identifiers.
 
         Valid identifiers are of the form (in regexp) "^[a-zA-Z_]\w*$" and multiple identifiers may be combined with
         dots in a fully qualified name in case of inheritance.

--- a/fedbiomed/common/logger.py
+++ b/fedbiomed/common/logger.py
@@ -64,6 +64,13 @@ DEFAULT_LOG_FILE = "mylog.log"
 DEFAULT_APPLICATION_LOG_FILE = "application.log"
 DEFAULT_SECURITY_LOG_FILE = "security_audit.log"
 DEFAULT_LOG_LEVEL = logging.WARNING
+
+# Keys under which handlers are registered in `self._handlers`.
+HANDLER_CONSOLE = "CONSOLE"
+HANDLER_GRPC = "GRPC"
+HANDLER_FILE = "FILE"
+HANDLER_SECURITY_FILE = "SECURITY_FILE"
+HANDLER_SYSLOG = "SYSLOG"
 SYSLOG_IDENT = "fedbiomed: "
 LOG_PREFIX = "%(prefix)s"
 DEFAULT_FORMAT = f"%(asctime)s %(name)s{LOG_PREFIX} %(levelname)s - %(message)s"
@@ -407,6 +414,10 @@ class FedLogger(metaclass=SingletonMeta):
             filename: Security log file path. Defaults to 'security_audit.log'
             level: Logging level for security events. Defaults to INFO
         """
+        # Register under its own key so it doesn't collide with FILE handler
+        if HANDLER_SECURITY_FILE in self._handlers:
+            return
+
         handler = TimedRotatingFileHandler(
             filename=filename,
             when="midnight",
@@ -419,14 +430,11 @@ class FedLogger(metaclass=SingletonMeta):
         # Disable buffering to ensure immediate writes
         handler.stream.reconfigure(line_buffering=True)
 
-        handler_name = "SECURITY_FILE"
-        # Register under its own key so it doesn't collide with FILE handler
-        if handler_name not in self._handlers:
-            self._logger.debug(" adding handler for: " + handler_name)
-            self._handlers[handler_name] = handler
-            self._logger.addHandler(handler)
-            self._original_format[handler_name] = None
-            self._handler_prefix[handler_name] = ""
+        self._logger.debug(" adding handler for: " + HANDLER_SECURITY_FILE)
+        self._handlers[HANDLER_SECURITY_FILE] = handler
+        self._logger.addHandler(handler)
+        self._original_format[HANDLER_SECURITY_FILE] = None
+        self._handler_prefix[HANDLER_SECURITY_FILE] = ""
 
     def security_event(
         self,
@@ -637,7 +645,6 @@ class FedLogger(metaclass=SingletonMeta):
         # Optional compatibility knobs from stdlib docs
         handler.append_nul = False
         handler.ident = SYSLOG_IDENT
-        handler_key = "SYSLOG"
 
         handler.setLevel(self._internal_level_translator(level))
 
@@ -647,9 +654,9 @@ class FedLogger(metaclass=SingletonMeta):
         # Keep the same JSON structure as the security audit file
         handler.setFormatter(_SecurityFormatter(self._security_defaults))
 
-        self._internal_add_handler(handler_key, handler)
+        self._internal_add_handler(HANDLER_SYSLOG, handler)
 
-    def del_syslog_handler(self, handler_key: str = "SYSLOG"):
+    def del_syslog_handler(self, handler_key: str = HANDLER_SYSLOG):
         self._internal_add_handler(handler_key, None)
 
     def add_file_handler(
@@ -674,7 +681,7 @@ class FedLogger(metaclass=SingletonMeta):
         handler.setLevel(self._internal_level_translator(level))
         handler.addFilter(_ExcludeSecurityFilter())
 
-        self._internal_add_handler("FILE", handler, format)
+        self._internal_add_handler(HANDLER_FILE, handler, format)
 
     def add_application_file_handler(
         self,
@@ -696,18 +703,18 @@ class FedLogger(metaclass=SingletonMeta):
         """
 
         abs_filename = os.path.abspath(filename)
-        existing = self._handlers.get("FILE")
+        existing = self._handlers.get(HANDLER_FILE)
         if existing is not None:
             existing_filename = getattr(existing, "baseFilename", None)
             if existing_filename == abs_filename and isinstance(
                 existing, TimedRotatingFileHandler
             ):
                 existing.setLevel(self._internal_level_translator(level))
-                self._original_format["FILE"] = format
-                self._set_handler_formatter("FILE")
+                self._original_format[HANDLER_FILE] = format
+                self._set_handler_formatter(HANDLER_FILE)
                 return
 
-            self._internal_add_handler("FILE", None)
+            self._internal_add_handler(HANDLER_FILE, None)
             try:
                 existing.close()
             except Exception:
@@ -725,7 +732,7 @@ class FedLogger(metaclass=SingletonMeta):
         if hasattr(handler.stream, "reconfigure"):
             handler.stream.reconfigure(line_buffering=True)
 
-        self._internal_add_handler("FILE", handler, format)
+        self._internal_add_handler(HANDLER_FILE, handler, format)
 
     def add_console_handler(
         self, format: str = DEFAULT_FORMAT, level: Any = DEFAULT_LOG_LEVEL
@@ -747,7 +754,7 @@ class FedLogger(metaclass=SingletonMeta):
         # Prevent security audit logs from appearing in interactive console (e.g., IPython).
         handler.addFilter(_ExcludeSecurityFilter())
 
-        self._internal_add_handler("CONSOLE", handler, format)
+        self._internal_add_handler(HANDLER_CONSOLE, handler, format)
 
         pass
 
@@ -777,7 +784,7 @@ class FedLogger(metaclass=SingletonMeta):
         # Never transmit security audit logs to the researcher via gRPC.
         handler.addFilter(_ExcludeSecurityFilter())
 
-        self._internal_add_handler("GRPC", handler)
+        self._internal_add_handler(HANDLER_GRPC, handler)
 
         # as a side effect this will set the minimal level to ERROR
         # FIXME: alitolga: This could cause problems in the logging level,
@@ -844,10 +851,10 @@ class FedLogger(metaclass=SingletonMeta):
 
     def _set_handler_formatter(self, output: str) -> None:
         """Configure formatter for a handler based on its current level."""
-        if output not in self._handlers or output == "SECURITY_FILE":
+        if output not in self._handlers or output == HANDLER_SECURITY_FILE:
             return
 
-        if output == "GRPC":
+        if output == HANDLER_GRPC:
             return
 
         base_format = self._original_format.get(output)

--- a/fedbiomed/node/cli.py
+++ b/fedbiomed/node/cli.py
@@ -40,12 +40,12 @@ from fedbiomed.node.node_pm import NodeProcessManager
 # Please use following code generate similar intro
 # print(pyfiglet.Figlet("doom").renderText(' fedbiomed node'))
 #
-__intro__ = """
+__intro__ = r"""
 
    __         _ _     _                          _                   _
   / _|       | | |   (_)                        | |                 | |
  | |_ ___  __| | |__  _  ___  _ __ ___   ___  __| |  _ __   ___   __| | ___
- |  _/ _ \/ _` | '_ \| |/ _ \| '_ ` _ \ / _ \/ _` | | '_ \ / _ \ / _` |/ _ \\
+ |  _/ _ \/ _` | '_ \| |/ _ \| '_ ` _ \ / _ \/ _` | | '_ \ / _ \ / _` |/ _ \
  | ||  __/ (_| | |_) | | (_) | | | | | |  __/ (_| | | | | | (_) | (_| |  __/
  |_| \___|\__,_|_.__/|_|\___/|_| |_| |_|\___|\__,_| |_| |_|\___/ \__,_|\___|
 

--- a/fedbiomed/node/round.py
+++ b/fedbiomed/node/round.py
@@ -6,6 +6,7 @@ implementation of Round class of the node component
 """
 
 import os
+import shutil
 import tempfile
 import time
 import traceback
@@ -136,14 +137,14 @@ class Round:
         self._node_state_manager: NodeStateManager = NodeStateManager(
             self._dir, self._node_id, self._db
         )
-        self._temp_dir = tempfile.TemporaryDirectory()
-        self._keep_files_dir = self._temp_dir.name
+        self._keep_files_dir = tempfile.mkdtemp()
         self._persistent_model_weights = None
 
     def __del__(self):
-        """Class destructor"""
-        # remove temporary files directory
-        self._temp_dir.cleanup()
+        """Removes the round's temporary files directory."""
+        keep_files_dir = getattr(self, "_keep_files_dir", None)
+        if keep_files_dir is not None:
+            shutil.rmtree(keep_files_dir, ignore_errors=True)
 
     def _initialize_validate_training_arguments(self) -> Optional[Dict[str, Any]]:
         """Initialize and validate requested experiment/training arguments.

--- a/fedbiomed/researcher/aggregators/scaffold.py
+++ b/fedbiomed/researcher/aggregators/scaffold.py
@@ -22,7 +22,7 @@ from fedbiomed.researcher.datasets import FederatedDataset
 
 
 class Scaffold(Aggregator):
-    """
+    r"""
     Defines the Scaffold strategy
 
     Despite being an algorithm of choice for federated learning, it is observed that FedAvg

--- a/fedbiomed/researcher/cli.py
+++ b/fedbiomed/researcher/cli.py
@@ -12,7 +12,7 @@ from fedbiomed.common.cli import CLIArgumentParser, CommonCLI, ComponentDirector
 from fedbiomed.common.constants import NOTEBOOKS_FOLDER_NAME, ComponentType
 from fedbiomed.common.logger import logger
 
-__intro__ = """
+__intro__ = r"""
    __         _ _     _                          _
   / _|       | | |   (_)                        | |
  | |_ ___  __| | |__  _  ___  _ __ ___   ___  __| |

--- a/fedbiomed/researcher/filetools.py
+++ b/fedbiomed/researcher/filetools.py
@@ -194,8 +194,8 @@ def create_unique_file_link(breakpoint_folder_path: str, file_path: str) -> str:
         raise
 
     # heuristic : assume limited set of characters in filename postfix
-    re_src_prefix = re.search("(.+)\.[a-zA-Z]+$", os.path.basename(file_path))
-    re_src_postfix = re.search(".+(\.[a-zA-Z]+)$", os.path.basename(file_path))
+    re_src_prefix = re.search(r"(.+)\.[a-zA-Z]+$", os.path.basename(file_path))
+    re_src_postfix = re.search(r".+(\.[a-zA-Z]+)$", os.path.basename(file_path))
     if not re_src_prefix or not re_src_postfix:
         error_message = (
             f"Saving breakpoint error, bad filename {file_path} gives "

--- a/tests/test_fedbiosklearn.py
+++ b/tests/test_fedbiosklearn.py
@@ -72,6 +72,8 @@ class FakeTrainingArgs(dict):
 
 
 class TestDataset(Dataset):
+    __test__ = False  # fixture, not a test: don't collect
+
     def __init__(self):
         self._data = [np.array((i, i * 2)) for i in range(10)]  # simple data
         self._target = [np.array(i * 3) for i in range(10)]  # corresponding target

--- a/tests/test_generic_optimizer.py
+++ b/tests/test_generic_optimizer.py
@@ -145,6 +145,7 @@ class TestDeclearnOptimizer(unittest.TestCase):
         for curr_module_state, before_loading_module_state in zip(
             current_round_optim_state["states"]["modules"],
             optim_state_before_loading["states"]["modules"],
+            strict=True,
         ):
             self.assertNotEqual(curr_module_state, before_loading_module_state)
 
@@ -199,6 +200,7 @@ class TestDeclearnOptimizer(unittest.TestCase):
             initialized_torch_optim_wrappers,
             self._torch_zero_model_wrappers,
             fake_retrieved_grads,
+            strict=True,
         ):
             with patch.object(TorchModel, "get_gradients") as get_gradients_patch:
                 get_gradients_patch.return_value = grads.coefs
@@ -206,9 +208,10 @@ class TestDeclearnOptimizer(unittest.TestCase):
                 torch_optim_wrapper.step()
                 get_gradients_patch.assert_called_once()
 
-            for (l, val), (l_ref, val_ref) in zip(
+            for (_, val), (_, val_ref) in zip(
                 zero_model.get_weights().items(),
                 torch_optim_wrapper._model.get_weights().items(),
+                strict=True,
             ):
                 self.assertTrue(torch.isclose(val - 1, val_ref).all())
 
@@ -241,15 +244,17 @@ class TestDeclearnOptimizer(unittest.TestCase):
             initialized_sklearn_optim,
             self._sklearn_model_wrappers,
             fake_retrieved_grads,
+            strict=True,
         ):
             with patch.object(BaseSkLearnModel, "get_gradients") as get_gradients_patch:
                 get_gradients_patch.return_value = grads.coefs
                 sklearn_optim_wrapper.step()
                 get_gradients_patch.assert_called()
 
-            for (l, val), (l_ref, val_ref) in zip(
+            for (_, val), (_, val_ref) in zip(
                 zero_model.get_weights().items(),
                 sklearn_optim_wrapper._model.get_weights().items(),
+                strict=True,
             ):
                 self.assertTrue(
                     np.all(val - 1 == val_ref)
@@ -587,6 +592,7 @@ class TestDeclearnOptimizer(unittest.TestCase):
             for curr_module_state, prev_module_state in zip(
                 current_round_optim_state["states"]["modules"],
                 previous_round_optim_state["states"]["modules"],
+                strict=True,
             ):
                 if curr_module_state[0] == common_opi_module.name:
                     self.assertEqual(curr_module_state, prev_module_state)
@@ -685,7 +691,7 @@ class TestDeclearnOptimizer(unittest.TestCase):
 
         researcher_lr, node_lr = 0.03, 0.5
         data = torch.Tensor([[1, 1, 1, 1], [1, 0, 0, 1]])
-        targets = torch.Tensor([[1, 1]])
+        targets = torch.Tensor([[1, 1], [1, 1]])
 
         loss_func = torch.nn.MSELoss()
         for model in self._torch_zero_model_wrappers:
@@ -730,7 +736,7 @@ class TestTorchBasedOptimizer(unittest.TestCase):
         for model in self._fed_models:
             # first check that element of model are non zeros
             grads = model.get_gradients()
-            for l, val in grads.items():
+            for _, val in grads.items():
                 self.assertFalse(torch.isclose(val, torch.zeros(val.shape)).all())
             # initialisation of declearn optimizer wrapper
             dec_model = copy.deepcopy(model)
@@ -739,7 +745,7 @@ class TestTorchBasedOptimizer(unittest.TestCase):
             declearn_optim_wrapper.zero_grad()
             grads = dec_model.get_gradients()
 
-            for l, val in grads.items():
+            for _, val in grads.items():
                 self.assertTrue(torch.isclose(val, torch.zeros(val.shape)).all())
 
             # initialisation of native torch optimizer wrapper
@@ -749,7 +755,7 @@ class TestTorchBasedOptimizer(unittest.TestCase):
             native_torch_optim_wrapper.zero_grad()
 
             grads = torch_model.get_gradients()
-            for l, val in grads.items():
+            for _, val in grads.items():
                 self.assertTrue(torch.isclose(val, torch.zeros(val.shape)).all())
 
     def test_torchbasedoptimizer_02_step(self):
@@ -789,9 +795,10 @@ class TestTorchBasedOptimizer(unittest.TestCase):
             native_torch_optim_wrapper.step()
 
             # checks
-            for (l, dec_optim_val), (l, torch_optim_val) in zip(
+            for (_, dec_optim_val), (_, torch_optim_val) in zip(
                 declearn_optim_wrapper._model.get_weights().items(),
                 native_torch_optim_wrapper._model.get_weights().items(),
+                strict=True,
             ):
                 self.assertTrue(torch.isclose(dec_optim_val, torch_optim_val).all())
 
@@ -866,9 +873,10 @@ class TestSklearnBasedOptimizer(unittest.TestCase):
                 sk_model_declearn.train(self.data, self.targets)
                 dec_optim_w.step()
 
-            for (k, v_ref), (k, v) in zip(
+            for (_, v_ref), (_, v) in zip(
                 sk_model_native.get_weights().items(),
                 sk_model_declearn.get_weights().items(),
+                strict=True,
             ):
                 self.assertTrue(np.all(np.isclose(v, v_ref)))
 
@@ -892,10 +900,11 @@ class TestSklearnBasedOptimizer(unittest.TestCase):
                 model_weights_before_step = copy.deepcopy(model.get_weights())
                 optim_wrapper.step()
                 model_weights_after = model.get_weights()
-                for (l, grads), (l, w_before_step), (l, w_after) in zip(
+                for (_, grads), (_, w_before_step), (_, w_after) in zip(
                     model.get_gradients().items(),
                     model_weights_before_step.items(),
                     model_weights_after.items(),
+                    strict=True,
                 ):
                     # check that only the declearn learning rate is used for training the model
                     self.assertTrue(
@@ -964,7 +973,7 @@ class TestNativeTorchOptimizer(unittest.TestCase):
         # then test using a pytorch scheduler
         scheduler = LambdaLR(optimizer.optimizer, lambda e: 2 * e)
         # this pytorch scheduler increase earning rate by twice its previous value
-        for e, (x, y) in enumerate(zip(dataset, target)):
+        for e, (x, y) in enumerate(zip(dataset, target, strict=True)):
             # training a simple model in pytorch fashion
             # `e` represents epoch
             out = model.model.forward(x)
@@ -1044,7 +1053,7 @@ class TestNativeTorchOptimizer(unittest.TestCase):
         self.assertListEqual(sorted(list(lr_extracted.keys())), model_layers_names)
 
         # check that learning rates are extracted correctly according to the model layer names
-        for k, v in model.named_parameters():
+        for k, _ in model.named_parameters():
             if "block" in k:
                 self.assertEqual(lr_extracted[k], lr_block)
             elif "conv1" in k:
@@ -1082,7 +1091,7 @@ class TestNativeTorchOptimizer(unittest.TestCase):
 
             self.assertIsInstance(torch_optim.optimizer, torch.optim.Optimizer)
             self.assertIsNone(torch_optim_state)
-            for previous_optim, current_optim in (
+            for _previous_optim, _current_optim in (
                 (
                     torch_optim,
                     dec_optim,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,9 +1,10 @@
 import unittest
-import numpy as np
 from unittest.mock import patch
 
-from fedbiomed.common.metrics import Metrics, MetricTypes, _MetricCategory  # noqa
+import numpy as np
+
 from fedbiomed.common.exceptions import FedbiomedMetricError
+from fedbiomed.common.metrics import Metrics, MetricTypes, _MetricCategory  # noqa
 
 
 class TestMetrics(unittest.TestCase):
@@ -291,12 +292,16 @@ class TestMetrics(unittest.TestCase):
 
         y_true = [12, 12, 12, 12]
         y_pred = [12.5, 12.5, 12.5, 12.5]
-        r = self.metrics.evaluate(y_true, y_pred, metric=MetricTypes.PRECISION)
+        r = self.metrics.evaluate(
+            y_true, y_pred, metric=MetricTypes.PRECISION, zero_division=0
+        )
         self.assertEqual(r, 0)
 
         y_true = [12.5, 12.5, 12.5, 12.5]
         y_pred = [12, 12, 12, 12]
-        r = self.metrics.evaluate(y_true, y_pred, metric=MetricTypes.PRECISION)
+        r = self.metrics.evaluate(
+            y_true, y_pred, metric=MetricTypes.PRECISION, zero_division=0
+        )
         self.assertEqual(r, 0)
 
         y_true = [12.5, 12.5, 12.5, 12.5]
@@ -488,7 +493,7 @@ class TestMetrics(unittest.TestCase):
         y_true = [[0, 1], [0, 1], [0, 1], [0, 1]]
         y_pred = [[0, 1, 0], [0, 1, 0], [0, 1, 0], [0, 1, 0]]
         with self.assertRaises(FedbiomedMetricError):
-            result = self.metrics.evaluate(y_true, y_pred, metric=MetricTypes.ACCURACY)
+            self.metrics.evaluate(y_true, y_pred, metric=MetricTypes.ACCURACY)
 
         y_true = [
             [0, 1],
@@ -496,12 +501,12 @@ class TestMetrics(unittest.TestCase):
         ]
         y_pred = [[[0, 1], [0, 1]], [[0, 1], [0, 1]]]
         with self.assertRaises(FedbiomedMetricError):
-            result = self.metrics.evaluate(y_true, y_pred, metric=MetricTypes.ACCURACY)
+            self.metrics.evaluate(y_true, y_pred, metric=MetricTypes.ACCURACY)
 
         y_true = [[[0, 1], [0, 1]], [[0, 1], [0, 1]]]
         y_pred = [[0, 1], [0, 1]]
         with self.assertRaises(FedbiomedMetricError):
-            result = self.metrics.evaluate(y_true, y_pred, metric=MetricTypes.ACCURACY)
+            self.metrics.evaluate(y_true, y_pred, metric=MetricTypes.ACCURACY)
 
         y_true = [[0, 1], [0, 1], [0, 1], [0, 1]]
         y_pred = [[0, 1], [0, 1]]
@@ -516,7 +521,7 @@ class TestMetrics(unittest.TestCase):
         y_true = ["0", "1", "2", "1"]
         y_pred = [0, 1, 2, 1]
         with self.assertRaises(FedbiomedMetricError):
-            result = self.metrics.evaluate(y_true, y_pred, metric=MetricTypes.ACCURACY)
+            self.metrics.evaluate(y_true, y_pred, metric=MetricTypes.ACCURACY)
 
     @patch("fedbiomed.common.metrics.metrics.accuracy_score")
     @patch("fedbiomed.common.metrics.metrics.precision_score")

--- a/tests/test_node_n2n_router.py
+++ b/tests/test_node_n2n_router.py
@@ -1,11 +1,11 @@
+import asyncio
 import os
 import tempfile
-import unittest
-from unittest.mock import patch, MagicMock, AsyncMock
-import asyncio
 import time
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from fedbiomed.common.message import OverlayMessage, KeyReply, InnerMessage
+from fedbiomed.common.message import InnerMessage, KeyReply, OverlayMessage
 from fedbiomed.node.requests._n2n_router import NodeToNodeRouter, _NodeToNodeAsyncRouter
 
 
@@ -313,10 +313,27 @@ class TestNodeToNodeRouter(unittest.IsolatedAsyncioTestCase, unittest.TestCase):
             "fedbiomed.node.requests._n2n_router.NodeToNodeController", autospec=True
         )
         self.n2n_controller_patch.side_effect = AsyncMock()
+        # Sync mocks so the sync wrappers do not create un-awaited coroutines when
+        # `asyncio.run`/`run_coroutine_threadsafe` are mocked out.
+        self.run_async_patch = patch(
+            "fedbiomed.node.requests._n2n_router._NodeToNodeAsyncRouter._run_async",
+            new_callable=MagicMock,
+        )
+        self.submit_patch = patch(
+            "fedbiomed.node.requests._n2n_router._NodeToNodeAsyncRouter._submit",
+            new_callable=MagicMock,
+        )
+        self.format_outgoing_patch = patch(
+            "fedbiomed.node.requests._n2n_router.OverlayChannel.format_outgoing_overlay",
+            new_callable=MagicMock,
+        )
 
         self.async_patcher = self.async_patch.start()
         self.thread_patcher = self.thread_patch.start()
         self.n2n_controller_patcher = self.n2n_controller_patch.start()
+        self.run_async_patch.start()
+        self.submit_patch.start()
+        self.format_outgoing_patch.start()
 
         self.grpc_controller_mock = MagicMock(autospec=True)
         self.pending_requests_mock = MagicMock(autospec=True)
@@ -339,6 +356,9 @@ class TestNodeToNodeRouter(unittest.IsolatedAsyncioTestCase, unittest.TestCase):
         self.async_patch.stop()
         self.thread_patch.stop()
         self.n2n_controller_patch.stop()
+        self.run_async_patch.stop()
+        self.submit_patch.stop()
+        self.format_outgoing_patch.stop()
 
     def test_n2n_router_01_start(self):
         """Start a n2n router"""

--- a/tests/test_node_overlay.py
+++ b/tests/test_node_overlay.py
@@ -38,6 +38,11 @@ class TestNodeRequestsChannelKeys(unittest.IsolatedAsyncioTestCase, unittest.Tes
         self.channel_manager_mock = self.channel_manager_patch.start()
         self.asyncio_waitfor_mock = self.asyncio_waitfor_patch.start()
 
+        # `asyncio.wait_for` is mocked and so never awaits its argument; make the
+        # mocked `Event.wait()` return a plain value instead of a coroutine so it
+        # is not reported as an un-awaited coroutine.
+        self.asyncio_event_mock.return_value.wait = MagicMock()
+
         self.grpc_controller_mock = MagicMock(spec=GrpcController)
 
         self.inner_message = InnerMessage(

--- a/tests/test_researcher_preproc_fedcombat_model.py
+++ b/tests/test_researcher_preproc_fedcombat_model.py
@@ -225,7 +225,7 @@ def test_fedcombat_tm_instantiate_training_plan(mocker):
         "fedbiomed.researcher.federated_workflows.preproc._fedcombat._fedcombat_model.nn.MSELoss",
         new=mocker.MagicMock(),
     )
-    mock_loss.return_value = lambda x, y: float(torch.mean((x - y) ** 2))
+    mock_loss.return_value = lambda x, y: float(torch.mean((x - y) ** 2).detach())
     mocker.patch(
         "fedbiomed.researcher.federated_workflows.preproc._fedcombat._fedcombat_model.TabularDataset",
         mocker.MagicMock(spec=TabularDataset),

--- a/tests/test_secagg_node.py
+++ b/tests/test_secagg_node.py
@@ -72,9 +72,6 @@ class TestSecaggServkeySetup(SecaggTestCase):
         self.args["controller_data"] = self.mock_controller_data
         self.args["n2n_router"] = self.mock_n2n_router
 
-    def tearDown(self) -> None:
-        pass
-
     def test_secagg_key_01_init(self):
         secagg = SecaggServkeySetup(**self.args)
         self.assertTrue(hasattr(secagg, "_secagg_manager"))
@@ -107,8 +104,8 @@ class TestSecaggServkeySetup(SecaggTestCase):
         self.assertIsInstance(reply.share, int)
 
     @patch("fedbiomed.node.secagg_manager.SecaggServkeyManager.add")
-    def test_secagg_key_02_setup(self, skmanager_add):
-        """Tests key setup for additive key"""
+    def test_secagg_key_02_setup_error(self, skmanager_add):
+        """Tests key setup returns an error when pending request fails"""
         secagg_addss = SecaggServkeySetup(**self.args)
         self.mock_n2n_router.format_outgoing_overlay.return_value = (
             b"overlay",
@@ -196,11 +193,10 @@ class TestSecaggServkeySetup(SecaggTestCase):
 
                 reply = secagg_addss.setup()
             self.assertEqual(reply.success, True)
-            check_sum_share = (
-                lambda randbits, rand_ints, other_shares: randbits
-                - sum(rand_ints)
-                + sum(other_shares)
-            )
+
+            def check_sum_share(randbits, rand_ints, other_shares):
+                return randbits - sum(rand_ints) + sum(other_shares)
+
             # self.assertEqual(reply.share, 5432 - 1234 - 4321 - 1122 + 1234 + 4321 + 4321)
             self.assertEqual(
                 reply.share,
@@ -234,9 +230,6 @@ class TestSecaggDHSetup(SecaggTestCase):
         self.args["pending_requests"] = self.mock_pending_requests
         self.args["controller_data"] = self.mock_controller_data
         self.args["n2n_router"] = self.mock_n2n_router
-
-    def tearDown(self) -> None:
-        pass
 
     @patch("fedbiomed.node.secagg_manager.SecaggDhManager.add")
     @patch("fedbiomed.node.secagg._secagg_setups.DHKey.export_public_key")

--- a/tests/test_secagg_researcher.py
+++ b/tests/test_secagg_researcher.py
@@ -36,13 +36,14 @@ class BaseTestCaseSecaggContext(unittest.TestCase, MockRequestModule):  # pylint
         self.mock_skmanager = MagicMock()
         self.patch_skmanager_s.return_value = self.mock_skmanager
 
-        temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dir = tempfile.TemporaryDirectory()
         unittest.mock.MagicMock.tmp_dir = unittest.mock.PropertyMock(
-            return_value=temp_dir
+            return_value=self.temp_dir
         )
 
     def tearDown(self) -> None:
         self.patch_skmanager.stop()
+        self.temp_dir.cleanup()
         super().tearDown()
 
 

--- a/tests/test_secagg_researcher.py
+++ b/tests/test_secagg_researcher.py
@@ -253,12 +253,12 @@ class TestSecaggServkeyContext(BaseTestCaseSecaggContext):  # pylint: disable=mi
         # before running round_specific
         state = self._secagg_key_context.save_state_breakpoint()
 
-        self.assertDictContainsSubset(
+        self.assertLessEqual(
             {
                 "_status": False,
                 "_context": None,
-            },
-            state["attributes"],
+            }.items(),
+            state["attributes"].items(),
         )
         state = copy.deepcopy(state)
         loaded_secagg = SecaggServkeyContext.load_state_breakpoint(state)

--- a/tests/test_secure_aggregation.py
+++ b/tests/test_secure_aggregation.py
@@ -344,14 +344,14 @@ class TestSecureAggregationWrapper(unittest.TestCase):
         ):
             sa = SecureAggregation(scheme=scheme)
             state = sa.__getattr__("save_state_breakpoint")()
-            self.assertDictContainsSubset(
+            self.assertLessEqual(
                 {
                     "attributes": {},
                     "class": "SecureAggregation",
                     "module": "fedbiomed.researcher.secagg._secure_aggregation",
                     "arguments": {"scheme": scheme.value},
-                },
-                state,
+                }.items(),
+                state.items(),
             )
             eval(f'exec("from {state["module"]} import {state["class"]}")')
             loaded_sa = SecureAggregation.load_state_breakpoint(state)

--- a/tests/test_sklearn_data_manager.py
+++ b/tests/test_sklearn_data_manager.py
@@ -10,6 +10,8 @@ from fedbiomed.common.exceptions import FedbiomedError
 
 
 class TestDataset(Dataset):
+    __test__ = False  # fixture, not a test: don't collect
+
     def __init__(self) -> None:
         self._data = np.array([[1, 4, 3, 7], [4, 6, 3, 1], [1, 5, 3, 7], [8, 2, 6, 9]])
         self._target = np.array([5, 5, 1, 4])
@@ -170,8 +172,9 @@ class TestSkLearnDataManager(unittest.TestCase):
 
     def test_sklearn_data_manager_05_save_load_state(self):
         init_state = self.sklearn_data_manager.save_state()
-        self.assertDictContainsSubset(
-            {"testing_index": [], "training_index": [], "test_ratio": None}, init_state
+        self.assertLessEqual(
+            {"testing_index": [], "training_index": [], "test_ratio": None}.items(),
+            init_state.items(),
         )
 
         ratio = 0.5

--- a/tests/test_torchnn.py
+++ b/tests/test_torchnn.py
@@ -897,7 +897,7 @@ class TestTorchnn(unittest.TestCase):
             nn.Conv1d(1, 1, 2),
             nn.ReLU(),
             nn.Linear(4, 5),
-            nn.utils.weight_norm(nn.Linear(5, 2)),
+            nn.utils.parametrizations.weight_norm(nn.Linear(5, 2)),
             torch.nn.InstanceNorm1d(1),
             nn.Softmax(dim=0),
         )
@@ -1012,7 +1012,7 @@ class TestTorchnn(unittest.TestCase):
                 nn.Conv1d(1, 1, 2),
                 nn.ReLU(),
                 nn.Linear(4, 5),
-                nn.utils.weight_norm(nn.Linear(5, 2)),
+                nn.utils.parametrizations.weight_norm(nn.Linear(5, 2)),
                 torch.nn.InstanceNorm1d(1),
                 nn.Softmax(dim=0),
             )

--- a/tests/test_transport_client.py
+++ b/tests/test_transport_client.py
@@ -63,6 +63,12 @@ class TestGrpcClient(unittest.IsolatedAsyncioTestCase):
         task = self.client.start(on_task=on_task)
         self.assertIsInstance(task, asyncio.Future)
 
+        # Cancel the background task before it runs so it never opens a real
+        # connection socket (would otherwise leak as a ResourceWarning).
+        task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+
     async def test_grpc_client_02_send(self):
         message = {"test": "test"}
         await self.client.send(message)

--- a/tests/test_transport_controller.py
+++ b/tests/test_transport_controller.py
@@ -41,7 +41,6 @@ class TestGrpcAsyncTaskController(unittest.IsolatedAsyncioTestCase):
         f.set_result(True)
 
         self.client_mock.return_value.start.return_value = f
-        self.start = self.controller.start()
 
     def tearDown(self) -> None:
         self.client_patch.stop()
@@ -55,7 +54,7 @@ class TestGrpcAsyncTaskController(unittest.IsolatedAsyncioTestCase):
         self.client_mock.return_value.start.assert_called_once()
 
     async def test_grpc_async_controller_02_send(self):
-        await self.start
+        await self.controller.start()
         self.client_mock.return_value.start.assert_called_once()
         await self.controller.send(message=message)
         self.client_mock.return_value.send.assert_called_once_with(message)
@@ -66,7 +65,7 @@ class TestGrpcAsyncTaskController(unittest.IsolatedAsyncioTestCase):
         self.client_mock.return_value.send.assert_called_once_with(message)
 
     async def test_grpc_async_controller_03_update_id_map(self):
-        await self.start
+        await self.controller.start()
         await self.controller._update_id_ip_map(id_=self.r_id, ip="localhost:50052")
         self.assertEqual(self.controller._ip_id_map[self.r_id], "localhost:50052")
 
@@ -74,7 +73,7 @@ class TestGrpcAsyncTaskController(unittest.IsolatedAsyncioTestCase):
         task = MagicMock()
         task.done.return_value = False
         type(self.client_mock.return_value).tasks = [task]
-        await self.start
+        await self.controller.start()
         self.assertTrue(await self.controller.is_connected())
 
 
@@ -86,13 +85,21 @@ class TestGrpcController(unittest.IsolatedAsyncioTestCase):
         self.thread_patch = patch(
             "fedbiomed.transport.controller.threading.Thread", autospec=True
         )
+        # Sync mocks so `super().send()`/`super().start()` in the GrpcController
+        # wrappers do not create un-awaited coroutines when `asyncio` is mocked out.
         self.send_patch = patch(
-            "fedbiomed.transport.controller.GrpcAsyncTaskController.send", autospec=True
+            "fedbiomed.transport.controller.GrpcAsyncTaskController.send",
+            new_callable=MagicMock,
+        )
+        self.start_patch = patch(
+            "fedbiomed.transport.controller.GrpcAsyncTaskController.start",
+            new_callable=MagicMock,
         )
 
         self.async_mock = self.async_patch.start()
         self.thread_mock = self.thread_patch.start()
         self.send_mock = self.send_patch.start()
+        self.start_mock = self.start_patch.start()
 
         self.on_message = MagicMock()
 
@@ -107,6 +114,7 @@ class TestGrpcController(unittest.IsolatedAsyncioTestCase):
         self.async_patch.stop()
         self.thread_patch.stop()
         self.send_patch.stop()
+        self.start_patch.stop()
 
         return super().tearDown()
 
@@ -154,9 +162,12 @@ class TestGrpcController(unittest.IsolatedAsyncioTestCase):
         future_mock = MagicMock()
         future_mock.result.return_value = True
         self.async_mock.run_coroutine_threadsafe.return_value = future_mock
+        # Sync mock so `super().is_connected()` does not create an un-awaited
+        # coroutine when `run_coroutine_threadsafe` is mocked out.
         with patch(
-            "fedbiomed.transport.controller.GrpcAsyncTaskController.is_connected"
-        ) as is_connected:
+            "fedbiomed.transport.controller.GrpcAsyncTaskController.is_connected",
+            new_callable=MagicMock,
+        ):
             self.assertTrue(self.controller.is_connected())
 
 

--- a/tests/test_transport_server.py
+++ b/tests/test_transport_server.py
@@ -263,6 +263,19 @@ class TestGrpcServer(unittest.IsolatedAsyncioTestCase):
         )
         self.asyncio_patch = patch("fedbiomed.transport.server.asyncio")
 
+        # Replace the async methods that GrpcServer's sync wrappers invoke via
+        # super() with sync mocks, so they don't create un-awaited coroutines when
+        # asyncio is mocked out. Started before async_server_patch so the name still
+        # resolves to the real class the wrappers reach through super().
+        self.async_methods_patch = patch.multiple(
+            "fedbiomed.transport.server._GrpcAsyncServer",
+            send=MagicMock(),
+            broadcast=MagicMock(),
+            get_node=MagicMock(),
+            get_all_nodes=MagicMock(),
+        )
+        self.async_methods_patch.start()
+
         self.async_server = self.async_server_patch.start()
 
         self.server_mock = self.server_patch.start()
@@ -291,6 +304,7 @@ class TestGrpcServer(unittest.IsolatedAsyncioTestCase):
         self.agent_store_patch.stop()
         self.asyncio_patch.stop()
         self.async_server_patch.stop()
+        self.async_methods_patch.stop()
 
         return super().tearDown()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,8 @@ from fedbiomed.common.exceptions import FedbiomedError
 
 # Dummy Class for testing its source --------------------
 class TestClass:
+    __test__ = False  # fixture, not a test: don't collect
+
     def __init__(self):
         pass
 

--- a/tests/testsupport/testing_data_loading_block.py
+++ b/tests/testsupport/testing_data_loading_block.py
@@ -1,6 +1,7 @@
 from enum import Enum
-from fedbiomed.common.dataloadingplan import DataLoadingBlock
+
 from fedbiomed.common.constants import DataLoadingBlockTypes
+from fedbiomed.common.dataloadingplan import DataLoadingBlock
 
 
 class LoadingBlockTypesForTesting(DataLoadingBlockTypes, Enum):
@@ -43,5 +44,7 @@ class ModifyGetItemDP(DataLoadingBlock):
 
 # class for cheating the ABC into running the abstract methods
 class TestAbstractsBlock(DataLoadingBlock):
+    __test__ = False  # fixture, not a test: don't collect
+
     def apply(self, *args, **kwargs):
         super(TestAbstractsBlock, self).apply(*args, *kwargs)


### PR DESCRIPTION
This PR fixes some warnings present for `pytest` and `tox` execution.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`