### PR TITLE
Feature/separate node from its context

### DIFF
--- a/fedbiomed/common/cli.py
+++ b/fedbiomed/common/cli.py
@@ -17,7 +17,6 @@ from typing import Dict, List
 from fedbiomed.common.certificate_manager import CertificateManager
 from fedbiomed.common.config import Config
 from fedbiomed.common.constants import (
-    CONFIG_FOLDER_NAME,
     DB_FOLDER_NAME,
     ComponentType,
     __version__,
@@ -432,11 +431,7 @@ class CommonCLI:
         Args:
             args: Parser arguments
         """
-        self._certificate_manager.set_db(
-            db_path=os.path.join(
-                self.config.root, "etc", self.config.get("default", "db")
-            )
-        )
+        self._certificate_manager.set_db(db_path=self.config.getpath("default", "db"))
 
         try:
             self._certificate_manager.register_certificate(
@@ -457,19 +452,11 @@ class CommonCLI:
         """Lists saved certificates"""
         print(f"{GRN}Listing registered certificates...{NC}")
 
-        self._certificate_manager.set_db(
-            db_path=os.path.join(
-                self.config.root, "etc", self.config.get("default", "db")
-            )
-        )
+        self._certificate_manager.set_db(db_path=self.config.getpath("default", "db"))
         self._certificate_manager.list(verbose=True)
 
     def _delete_certificate(self, args: argparse.Namespace):
-        self._certificate_manager.set_db(
-            db_path=os.path.join(
-                self.config.root, "etc", self.config.get("default", "db")
-            )
-        )
+        self._certificate_manager.set_db(db_path=self.config.getpath("default", "db"))
         certificates = self._certificate_manager.list(verbose=False)
         options = [d["party_id"] for d in certificates]
         msg = "Select the certificate to delete:\n"
@@ -493,13 +480,7 @@ class CommonCLI:
     def _prepare_certificate_for_registration(self, args: argparse.Namespace):
         """Prints instruction to registration of the certificate by the other parties"""
 
-        certificate = read_file(
-            os.path.join(
-                self.config.root,
-                CONFIG_FOLDER_NAME,
-                self.config.get("certificate", "public_key"),
-            )
-        )
+        certificate = read_file(self.config.getpath("certificate", "public_key"))
 
         print("Hi There! \n\n")
         print("Please find following certificate to register \n")

--- a/fedbiomed/common/config.py
+++ b/fedbiomed/common/config.py
@@ -219,8 +219,16 @@ class Config(metaclass=ABCMeta):
 
         return self._cfg.getint(section, key, **kwargs)
 
+    def getpath(self, section, key, **kwargs) -> str:
+        """Absolute path for a config value stored relative to the config folder"""
+        return os.path.abspath(
+            os.path.join(
+                self.root, CONFIG_FOLDER_NAME, self.get(section, key, **kwargs)
+            )
+        )
+
     def _get(self, section, key, **kwargs) -> str:
-        """ """
+        """Returns value for given key and section"""
         environ_key = f"FBM_{section.upper()}_{key.upper()}"
         return os.environ.get(environ_key, self._cfg.get(section, key, **kwargs))
 

--- a/fedbiomed/node/cli.py
+++ b/fedbiomed/node/cli.py
@@ -34,7 +34,7 @@ from fedbiomed.node.cli_utils import (
     view_training_plan,
 )
 from fedbiomed.node.config import node_component
-from fedbiomed.node.node import Node
+from fedbiomed.node.node import NodeContext
 from fedbiomed.node.node_pm import NodeProcessManager
 
 # Please use following code generate similar intro
@@ -63,7 +63,7 @@ def intro():
 class DatasetArgumentParser(CLIArgumentParser):
     """Initializes CLI options for dataset actions"""
 
-    _node: Node
+    _context: NodeContext
     _mnist_path = None
 
     def initialize(self):
@@ -134,18 +134,25 @@ class DatasetArgumentParser(CLIArgumentParser):
 
         if args.mnist != "":
             if args.mnist is None:
-                mnist_path = os.path.join(self._node.config.root, NODE_DATA_FOLDER)
+                mnist_path = os.path.join(self._context.config.root, NODE_DATA_FOLDER)
             else:
                 mnist_path = args.mnist
             return add_database(
-                self._node.dataset_manager, interactive=False, path=mnist_path
+                self._context.dataset_manager, interactive=False, path=mnist_path
             )
 
         if args.file:
             return self._add_dataset_from_file(path=args.file)
 
         # All operation is handled by CLI utils add_database
-        return add_database(self._node.dataset_manager)
+<<<<<<< Updated upstream
+        return add_database(self._context.dataset_manager)
+=======
+        return add_database(
+            self._context.dataset_manager,
+            initialdir=os.path.join(self._context.config.root, NODE_DATA_FOLDER),
+        )
+>>>>>>> Stashed changes
 
     def list(self, unused_args):
         """List datasets
@@ -154,7 +161,7 @@ class DatasetArgumentParser(CLIArgumentParser):
           unused_args: Empty arguments since `list` command no positional args.
         """
         print("Listing your data available")
-        data = self._node.dataset_manager.list_my_datasets(verbose=True)
+        data = self._context.dataset_manager.list_my_datasets(verbose=True)
         if len(data) == 0:
             print("No data has been set up.")
 
@@ -162,12 +169,12 @@ class DatasetArgumentParser(CLIArgumentParser):
         """Deletes datasets"""
 
         if args.all:
-            return delete_all_database(self._node.dataset_manager)
+            return delete_all_database(self._context.dataset_manager)
 
         if args.mnist:
-            return delete_database(self._node.dataset_manager, interactive=False)
+            return delete_database(self._context.dataset_manager, interactive=False)
 
-        return delete_database(self._node.dataset_manager)
+        return delete_database(self._context.dataset_manager)
 
     def _add_dataset_from_file(self, path):
         print("Dataset description file provided: adding these data")
@@ -201,14 +208,14 @@ class DatasetArgumentParser(CLIArgumentParser):
         elif elements[0]:
             # p is relative (does not start with /)
             # prepend with topdir
-            elements = [self._node.config.root] + elements
+            elements = [self._context.config.root] + elements
 
         # rebuild the path with these (eventually) new elements
         data["path"] = os.path.join(os.path.sep, *elements)
 
         # add the dataset to local database (not interactive)
         add_database(
-            self._node.dataset_manager,
+            self._context.dataset_manager,
             interactive=False,
             path=data["path"],
             data_type=data["data_type"],
@@ -222,7 +229,7 @@ class DatasetArgumentParser(CLIArgumentParser):
 class TrainingPlanArgumentParser(CLIArgumentParser):
     """Argument parser for training-plan operations"""
 
-    _node: Node
+    _context: NodeContext
 
     def initialize(self):
         self._parser = self._subparser.add_parser(
@@ -295,39 +302,39 @@ class TrainingPlanArgumentParser(CLIArgumentParser):
 
     def delete(self, args):
         """Deletes training plan"""
-        delete_training_plan(self._node.tp_security_manager, id=args.id)
+        delete_training_plan(self._context.tp_security_manager, id=args.id)
 
     def register(self):
         """Registers training plan"""
-        register_training_plan(self._node.tp_security_manager)
+        register_training_plan(self._context.tp_security_manager)
 
     def list(self):
         """Lists training plans"""
-        self._node.tp_security_manager.list_training_plans(verbose=True)
+        self._context.tp_security_manager.list_training_plans(verbose=True)
 
     def view(self):
         """Views training plan"""
-        view_training_plan(self._node.tp_security_manager)
+        view_training_plan(self._context.tp_security_manager)
 
     def approve(self, args):
         """Approves training plan"""
-        approve_training_plan(self._node.tp_security_manager, id=args.id)
+        approve_training_plan(self._context.tp_security_manager, id=args.id)
 
     def reject(self, args):
         """Approves training plan"""
         reject_training_plan(
-            self._node.tp_security_manager, id=args.id, notes=args.notes
+            self._context.tp_security_manager, id=args.id, notes=args.notes
         )
 
     def update(self):
         """Updates training plan"""
-        update_training_plan(self._node.tp_security_manager)
+        update_training_plan(self._context.tp_security_manager)
 
 
 class NodeControl(CLIArgumentParser):
     """CLI argument parser for starting the node"""
 
-    _node: Node
+    _context: NodeContext
 
     def initialize(self):
         """Initializes missing control argument parser"""
@@ -450,7 +457,7 @@ class NodeControl(CLIArgumentParser):
             "debug": True if args.debug else False,
         }
 
-        node_process_manager = NodeProcessManager(self._node.config)
+        node_process_manager = NodeProcessManager(self._context.config)
         background = True if args.background else False
         try:
             if background:
@@ -482,7 +489,7 @@ class NodeControl(CLIArgumentParser):
 
     def stop(self):
         """Stops the node"""
-        node_process_manager = NodeProcessManager(self._node.config)
+        node_process_manager = NodeProcessManager(self._context.config)
         node_process_manager.stop(
             actor={"source": "cli"},
             reason="cli_stop_command",
@@ -502,7 +509,7 @@ class NodeControl(CLIArgumentParser):
         if args.debug is not None:
             node_args["debug"] = args.debug
 
-        node_process_manager = NodeProcessManager(self._node.config)
+        node_process_manager = NodeProcessManager(self._context.config)
         node_process_manager.restart(
             node_args=node_args,
             background=args.background,
@@ -512,13 +519,13 @@ class NodeControl(CLIArgumentParser):
 
     def status(self):
         """Shows the node status"""
-        node_process_manager = NodeProcessManager(self._node.config)
+        node_process_manager = NodeProcessManager(self._context.config)
         status = node_process_manager.get_status()
         print(f"Node status: {status}")
 
 
 class GUIControl(CLIArgumentParser):
-    _node: Node
+    _context: NodeContext
 
     def initialize(self):
         """Initializes GUI commands"""
@@ -617,7 +624,7 @@ class GUIControl(CLIArgumentParser):
         fedbiomed_root = os.path.abspath(args.path)
 
         if args.data_folder == "":
-            data_folder = os.path.join(self._node.config.root, NODE_DATA_FOLDER)
+            data_folder = os.path.join(self._context.config.root, NODE_DATA_FOLDER)
         else:
             data_folder = os.path.abspath(args.data_folder)
         if not os.path.isdir(data_folder):
@@ -673,6 +680,14 @@ class GUIControl(CLIArgumentParser):
 
 
 class NodeCLI(CommonCLI):
+    """The `fedbiomed node` command line application.
+
+    Defines and parses what a user can type, then hands over to the matching
+    action. Decides which action runs and, through `--path`, on which node;
+    what the action then acts on is the `NodeContext` it passes to every
+    subparser.
+    """
+
     _arg_parsers_classes: List[type] = [
         NodeControl,
         DatasetArgumentParser,
@@ -709,19 +724,19 @@ class NodeCLI(CommonCLI):
                     os.environ["FBM_NODE_COMPONENT_ROOT"] = component_dir
                 config = node_component.initiate(root=component_dir)
                 self._this.config = config
-                node = Node(config)
-                # Set node object to make it accessible
-                ComponentDirectoryActionNode._this._node = node
+                context = NodeContext(config)
+                # Set context object to make it accessible
+                ComponentDirectoryActionNode._this._context = context
                 os.environ[f"FEDBIOMED_ACTIVE_{self._component.name}_ID"] = config.get(
                     "default", "id"
                 )
 
-                # Set node in all subparsers
+                # Set context in all subparsers
                 for (
                     _,
                     parser,
                 ) in ComponentDirectoryActionNode._this._arg_parsers.items():
-                    parser._node = node
+                    parser._context = context
 
         super().initialize()
 

--- a/fedbiomed/node/cli.py
+++ b/fedbiomed/node/cli.py
@@ -145,15 +145,11 @@ class DatasetArgumentParser(CLIArgumentParser):
             return self._add_dataset_from_file(path=args.file)
 
         # All operation is handled by CLI utils add_database
-<<<<<<< Updated upstream
-        return add_database(self._context.dataset_manager)
-=======
         return add_database(
             self._context.dataset_manager,
             initialdir=os.path.join(self._context.config.root, NODE_DATA_FOLDER),
         )
->>>>>>> Stashed changes
-
+    
     def list(self, unused_args):
         """List datasets
 

--- a/fedbiomed/node/cli_utils/_database.py
+++ b/fedbiomed/node/cli_utils/_database.py
@@ -62,6 +62,7 @@ def add_database(
     description: Optional[str] = None,
     data_type: Optional[str] = None,
     dataset_parameters: Optional[dict] = None,
+    initialdir: Optional[str] = None,
 ) -> None:
     """Adds a dataset to the node database.
 
@@ -78,6 +79,8 @@ def add_database(
         description: Human readable description of the dataset.
         data_type: Keyword for the data type of the dataset.
         dataset_parameters: Parameters for the dataset manager
+        initialdir: Directory the interactive path picker opens on. Defaults to the
+            current directory.
     """
     data_loading_plan = None
 
@@ -104,7 +107,7 @@ def add_database(
             name, description, tags = _predefined[data_type]
             if interactive:
                 tags = _confirm_predefined_dataset_tags(name, tags)
-                path = validated_path_input(data_type)
+                path = validated_path_input(data_type, initialdir=initialdir)
 
         else:
             while True:
@@ -132,7 +135,7 @@ def add_database(
             if data_type == "medical-folder":
                 path, dataset_parameters, data_loading_plan = (
                     add_medical_folder_dataset_from_cli(
-                        dataset_parameters, data_loading_plan
+                        dataset_parameters, data_loading_plan, initialdir=initialdir
                     )
                 )
             elif data_type == "custom":
@@ -143,7 +146,7 @@ def add_database(
                     print(f"Path not found: {abs_path}. Please try again.")
                 path = str(abs_path)
             else:
-                path = validated_path_input(data_type)
+                path = validated_path_input(data_type, initialdir=initialdir)
 
         if interactive and data_loading_plan is not None:
             while True:

--- a/fedbiomed/node/cli_utils/_io.py
+++ b/fedbiomed/node/cli_utils/_io.py
@@ -35,11 +35,12 @@ def validated_data_type_input() -> str:
     return valid_options[t]
 
 
-def pick_with_tkinter(type: str = "csv") -> str | None:
+def pick_with_tkinter(type: str = "csv", initialdir: str | None = None) -> str | None:
     """Opens a tkinter dialog to pick a file or directory.
 
     Args:
         type: `'csv'` or `'txt'` opens a file picker; any other value opens a directory picker.
+        initialdir: Directory the dialog opens on. Defaults to the current directory.
 
     Returns:
         The selected path, or None if cancelled or the GUI failed.
@@ -56,9 +57,9 @@ def pick_with_tkinter(type: str = "csv") -> str | None:
 
     try:
         path = (
-            filedialog.askopenfilename(filetypes=filetypes)
+            filedialog.askopenfilename(filetypes=filetypes, initialdir=initialdir)
             if is_file_mode
-            else filedialog.askdirectory()
+            else filedialog.askdirectory(initialdir=initialdir)
         )
         if not path:
             logger.warning(empty_msg)
@@ -97,17 +98,18 @@ def _prompt_path_cli(type: str) -> str:
         return str(path_obj)
 
 
-def validated_path_input(type: str) -> str:
+def validated_path_input(type: str, initialdir: str | None = None) -> str:
     """Returns a validated path, trying the GUI first then falling back to CLI.
 
     Args:
         type: `'csv'` or `'txt'` for a file picker; any other value for a directory picker.
+        initialdir: Directory the picker opens on. Defaults to the current directory.
 
     Returns:
         The selected, validated path.
     """
     if filedialog is not None:
-        path = pick_with_tkinter(type=type)
+        path = pick_with_tkinter(type=type, initialdir=initialdir)
         if path is not None:
             return path
         logger.warning("GUI failed. Falling back to CLI.")

--- a/fedbiomed/node/cli_utils/_medical_folder_dataset.py
+++ b/fedbiomed/node/cli_utils/_medical_folder_dataset.py
@@ -13,9 +13,10 @@ from fedbiomed.node.cli_utils._io import validated_path_input
 def add_medical_folder_dataset_from_cli(
     dataset_parameters: Optional[dict],
     dlp: Optional[DataLoadingPlan],
+    initialdir: Optional[str] = None,
 ) -> Tuple[str, dict, DataLoadingPlan]:
     print("Please select the root folder of the Medical Folder dataset")
-    path = validated_path_input(type="dir")
+    path = validated_path_input(type="dir", initialdir=initialdir)
     controller = MedicalFolderController(path)
     dataset_parameters = {} if dataset_parameters is None else dataset_parameters
     print(dataset_parameters)
@@ -23,7 +24,7 @@ def add_medical_folder_dataset_from_cli(
     if choice.lower() == "y":
         # get tabular file
         print("Please select the demographics file (must be CSV or TSV)")
-        tabular_file_path = validated_path_input(type="csv")
+        tabular_file_path = validated_path_input(type="csv", initialdir=initialdir)
         # get index col from user
         column_values = controller.demographics_column_names(tabular_file_path)
         print("\nHere are all the columns contained in demographics file:\n")

--- a/fedbiomed/node/node.py
+++ b/fedbiomed/node/node.py
@@ -11,7 +11,7 @@ import traceback
 from typing import Callable, Optional, Union
 
 from fedbiomed import __version__
-from fedbiomed.common.constants import CONFIG_FOLDER_NAME, ComponentType, ErrorNumbers
+from fedbiomed.common.constants import ComponentType, ErrorNumbers
 from fedbiomed.common.exceptions import FedbiomedError
 from fedbiomed.common.logger import logger
 from fedbiomed.common.message import (
@@ -100,11 +100,7 @@ class Node:
             ],
             on_message=self.on_message,
         )
-        self._db_path = os.path.abspath(
-            os.path.join(
-                self._config.root, CONFIG_FOLDER_NAME, self._config.get("default", "db")
-            )
-        )
+        self._db_path = self._config.getpath("default", "db")
 
         self._pending_requests = EventWaitExchange(remove_delivered=True)
         self._controller_data = EventWaitExchange(remove_delivered=False)

--- a/fedbiomed/node/node.py
+++ b/fedbiomed/node/node.py
@@ -50,6 +50,48 @@ from fedbiomed.transport.client import ResearcherCredentials
 from fedbiomed.transport.controller import GrpcController
 
 
+class NodeContext:
+    """What a node command acts on: the node's local state.
+
+    Holds what the node keeps on disk -- its configuration, datasets and
+    training plans -- and nothing else: what the user typed belongs to
+    `NodeCLI`, running a node to `node_pm`.
+
+    Acting on this state needs neither a running node nor the means to run
+    one, so commands get this rather than a `Node`. A running node holds one
+    of these too, as the local state it operates on.
+
+    The managers are public so callers can swap them, notably for testing.
+    """
+
+    dataset_manager: DatasetManager
+    tp_security_manager: TrainingPlanSecurityManager
+
+    def __init__(self, config: NodeConfig) -> None:
+        """Constructor of the class.
+
+        Args:
+            config: Configuration of the node the commands act on.
+        """
+        self._config = config
+        self.dataset_manager = DatasetManager(
+            path=self.config.getpath("default", "db"),
+            min_samples=self.config.getint("security", "minimum_samples"),
+        )
+        self.tp_security_manager = TrainingPlanSecurityManager(
+            db=self.config.getpath("default", "db"),
+            node_id=self.config.get("default", "id"),
+            node_name=self.config.get("default", "name"),
+            hashing=self.config.get("security", "hashing_algorithm"),
+            tp_approval=self.config.getbool("security", "training_plan_approval"),
+        )
+
+    @property
+    def config(self) -> NodeConfig:
+        """Configuration of the node the commands act on."""
+        return self._config
+
+
 class Node:
     """Core code of the node component.
 
@@ -57,10 +99,9 @@ class Node:
     with the researcher through the `Messaging`, parsing messages from the researcher,
     either treating them instantly or queuing them,
     executing tasks requested by researcher stored in the queue.
-    """
 
-    tp_security_manager: TrainingPlanSecurityManager
-    dataset_manager: DatasetManager
+    Owns a `NodeContext`: the local state it operates on.
+    """
 
     def __init__(
         self,
@@ -78,54 +119,38 @@ class Node:
             "FBM_DEBUG", ""
         ).lower() in ("1", "true", "yes")
 
-        self._config = config
-        self._node_id = self._config.get("default", "id")
-        self._node_name = self._config.get("default", "name")
+        self._context = NodeContext(config)
+        self._node_id = self.config.get("default", "id")
+        self._node_name = self.config.get("default", "name")
 
         self._tasks_queue = TasksQueue(
-            os.path.join(self._config.root, "var", f"queue_{self._node_id}"),
-            str(os.path.join(self._config.root, "var", "tmp")),
+            os.path.join(self.config.root, "var", f"queue_{self._node_id}"),
+            str(os.path.join(self.config.root, "var", "tmp")),
         )
 
         self._grpc_client = GrpcController(
             node_id=self._node_id,
             researchers=[
                 ResearcherCredentials(
-                    port=self._config.get("researcher", "port"),
-                    host=self._config.get("researcher", "ip"),
-                    certificate=self._config.get(
-                        "researcher", "certificate", fallback=None
-                    ),
+                    port=self.config.get("researcher", "port"),
+                    host=self.config.get("researcher", "ip"),
                 )
             ],
             on_message=self.on_message,
         )
-        self._db_path = self._config.getpath("default", "db")
 
         self._pending_requests = EventWaitExchange(remove_delivered=True)
         self._controller_data = EventWaitExchange(remove_delivered=False)
         self._n2n_router = NodeToNodeRouter(
             self._node_id,
-            self._db_path,
+            self.config.getpath("default", "db"),
             self._grpc_client,
             self._pending_requests,
             self._controller_data,
         )
 
-        self.dataset_manager = DatasetManager(
-            path=self._db_path,
-            min_samples=self._config.getint("security", "minimum_samples"),
-        )
-        self.tp_security_manager = TrainingPlanSecurityManager(
-            db=self._db_path,
-            node_id=self._node_id,
-            node_name=self._node_name,
-            hashing=self._config.get("security", "hashing_algorithm"),
-            tp_approval=self._config.getbool("security", "training_plan_approval"),
-        )
-
         # Initialize security audit logging
-        logger.set_security_logs(root_path=self._config.root)
+        logger.set_security_logs(root_path=self.config.root)
 
         logger.configure_security(
             component_id=self._node_id,
@@ -139,7 +164,7 @@ class Node:
             status="success",
             researcher_id=None,
             node_name=self._node_name,
-            config_path=self._config.root,
+            config_path=self.config.root,
         )
 
     @property
@@ -155,7 +180,25 @@ class Node:
     @property
     def config(self):
         """Return node config"""
-        return self._config
+        return self._context.config
+
+    @property
+    def dataset_manager(self) -> DatasetManager:
+        """Manager of the node's datasets, held by its context."""
+        return self._context.dataset_manager
+
+    @dataset_manager.setter
+    def dataset_manager(self, manager: DatasetManager) -> None:
+        self._context.dataset_manager = manager
+
+    @property
+    def tp_security_manager(self) -> TrainingPlanSecurityManager:
+        """Manager of the node's training plans, held by its context."""
+        return self._context.tp_security_manager
+
+    @tp_security_manager.setter
+    def tp_security_manager(self, manager: TrainingPlanSecurityManager) -> None:
+        self._context.tp_security_manager = manager
 
     def add_task(self, task: dict):
         """Adds a task to the pending tasks queue.
@@ -350,7 +393,7 @@ class Node:
         }
 
         secagg_manager = SecaggManager(
-            db=self._db_path, element=msg.get_param("element")
+            db=self.config.getpath("default", "db"), element=msg.get_param("element")
         )()
 
         status = secagg_manager.remove(
@@ -387,7 +430,7 @@ class Node:
         # Needed when using node to node communications
         setup_arguments.update(
             {
-                "db": self._db_path,
+                "db": self.config.getpath("default", "db"),
                 "node_id": self._node_id,
                 "node_name": self._node_name,
                 "n2n_router": self._n2n_router,
@@ -473,8 +516,8 @@ class Node:
             logger.debug("No data loading plan metadata for dataset=%s", dataset_id)
 
         round_ = Round(
-            root_dir=self._config.root,
-            db=self._db_path,
+            root_dir=self.config.root,
+            db=self.config.getpath("default", "db"),
             node_id=self._node_id,
             node_name=self._node_name,
             training_plan=msg.get_param("training_plan"),
@@ -571,16 +614,16 @@ class Node:
                                     item.get_param("training_plan_class"),
                                 )
                                 msg = round_.run_model_training(
-                                    tp_approval=self._config.getbool(
+                                    tp_approval=self.config.getbool(
                                         "security", "training_plan_approval"
                                     ),
-                                    secagg_insecure_validation=self._config.getbool(
+                                    secagg_insecure_validation=self.config.getbool(
                                         "security", "secagg_insecure_validation"
                                     ),
-                                    secagg_active=self._config.getbool(
+                                    secagg_active=self.config.getbool(
                                         "security", "secure_aggregation"
                                     ),
-                                    force_secagg=self._config.getbool(
+                                    force_secagg=self.config.getbool(
                                         "security", "force_secure_aggregation"
                                     ),
                                     secagg_arguments=item.get_param("secagg_arguments"),
@@ -634,7 +677,7 @@ class Node:
                                 status="initiated",
                             )
                             fa_job = FAJob(
-                                root_dir=self._config.root,
+                                root_dir=self.config.root,
                                 dataset_manager=self.dataset_manager,
                                 node_id=self._node_id,
                                 node_name=self._node_name,
@@ -642,11 +685,11 @@ class Node:
                                 allow_fa=self.config.getbool(
                                     "security", "allow_federated_analytics"
                                 ),
-                                db=self._db_path,
-                                secagg_active=self._config.getbool(
+                                db=self.config.getpath("default", "db"),
+                                secagg_active=self.config.getbool(
                                     "security", "secure_aggregation"
                                 ),
-                                force_secagg=self._config.getbool(
+                                force_secagg=self.config.getbool(
                                     "security", "force_secure_aggregation"
                                 ),
                                 secagg_arguments=item.get_param("secagg_arguments"),
@@ -666,12 +709,12 @@ class Node:
                                 status="initiated",
                             )
                             preproc_job = PreprocJob(
-                                root_dir=self._config.root,
+                                root_dir=self.config.root,
                                 dataset_manager=self.dataset_manager,
                                 node_id=self._node_id,
                                 node_name=self._node_name,
                                 request=item,
-                                db=self._db_path,
+                                db=self.config.getpath("default", "db"),
                                 allow_preproc=self.config.getbool(
                                     "security", "allow_preproc"
                                 ),
@@ -748,8 +791,8 @@ class Node:
                 regardless of specific researcher.
             request_id: Optional request i to reply as error to a request.
         """
-        researcher_host = self._config.get("researcher", "ip")
-        researcher_port = self._config.get("researcher", "port")
+        researcher_host = self.config.get("researcher", "ip")
+        researcher_port = self.config.get("researcher", "port")
         try:
             connected = self.is_connected()
         except Exception:

--- a/fedbiomed/node/node_pm.py
+++ b/fedbiomed/node/node_pm.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, Optional, Union
 
 import psutil
 
-from fedbiomed.common.constants import CONFIG_FOLDER_NAME, ErrorNumbers
+from fedbiomed.common.constants import ErrorNumbers
 from fedbiomed.common.exceptions import FedbiomedError
 from fedbiomed.common.logger import DEFAULT_APPLICATION_LOG_FILE, logger
 from fedbiomed.node.config import NodeConfig
@@ -188,25 +188,11 @@ class NodeProcessManager:
 
     def _get_state_table(self) -> NodeProcessStateTable:
         """Get the state table instance."""
-        db_path = os.path.abspath(
-            os.path.join(
-                self._config.root,
-                CONFIG_FOLDER_NAME,
-                self._config.get("default", "db"),
-            )
-        )
-        return NodeProcessStateTable(db_path)
+        return NodeProcessStateTable(self._config.getpath("default", "db"))
 
     def _get_history_table(self) -> NodeProcessStateHistoryTable:
         """Get the history table instance."""
-        db_path = os.path.abspath(
-            os.path.join(
-                self._config.root,
-                CONFIG_FOLDER_NAME,
-                self._config.get("default", "db"),
-            )
-        )
-        return NodeProcessStateHistoryTable(db_path)
+        return NodeProcessStateHistoryTable(self._config.getpath("default", "db"))
 
     def _cleanup_process_state_history(self, days: int = 30) -> None:
         """Remove process-state history entries older than the given number of days.

--- a/fedbiomed/node/node_pm.py
+++ b/fedbiomed/node/node_pm.py
@@ -68,10 +68,8 @@ def _start_node_process(config_path: str, node_args: Union[str, dict]) -> None:
     config = NodeConfig(root=config_path)
     node_args = json.loads(node_args) if isinstance(node_args, str) else node_args
 
-    _node = Node(config, node_args)
-
-    logger.info(str(_node))
-    logger.info(f"Node name: {_node.config.get('default', 'name')}")
+    # Built inside the try below: building it can fail on a bad configuration.
+    _node: Optional[Node] = None
 
     def _node_signal_handler(signum: int, frame: Union[FrameType, None]):
         """Signal handler that terminates the process.
@@ -112,12 +110,17 @@ def _start_node_process(config_path: str, node_args: Union[str, dict]) -> None:
             time.sleep(0.5)
             sys.exit(signum)
 
-    if getattr(_node, "_debug", False):
-        logger.setLevel("DEBUG")
-    else:
-        logger.setLevel("INFO")
-
     try:
+        _node = Node(config, node_args)
+
+        logger.info(str(_node))
+        logger.info(f"Node name: {_node.config.get('default', 'name')}")
+
+        if getattr(_node, "_debug", False):
+            logger.setLevel("DEBUG")
+        else:
+            logger.setLevel("INFO")
+
         signal.signal(signal.SIGTERM, _node_signal_handler)
         signal.signal(signal.SIGINT, _node_signal_handler)
         logger.info("Launching node...")
@@ -162,7 +165,8 @@ def _start_node_process(config_path: str, node_args: Union[str, dict]) -> None:
             error_message=str(exp),
             exception_type=type(exp).__name__,
         )
-        _node.send_error(ErrorNumbers.FB300, extra_msg="Error = " + str(exp))
+        if _node:
+            _node.send_error(ErrorNumbers.FB300, extra_msg="Error = " + str(exp))
         logger.critical(f"Node stopped. {exp}")
 
 

--- a/fedbiomed/researcher/config.py
+++ b/fedbiomed/researcher/config.py
@@ -92,9 +92,7 @@ class ResearcherConfig(Config):
                 "EXPERIMENTS_DIR": os.path.join(
                     self.root, VAR_FOLDER_NAME, "experiments"
                 ),
-                "DB": os.path.join(
-                    self.root, CONFIG_FOLDER_NAME, self._cfg.get("default", "db")
-                ),
+                "DB": self.getpath("default", "db"),
             }
         )
 

--- a/fedbiomed/researcher/requests/_requests.py
+++ b/fedbiomed/researcher/requests/_requests.py
@@ -16,7 +16,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import tabulate
 from python_minifier import minify
 
-from fedbiomed.common.constants import CONFIG_FOLDER_NAME, REQUEST_PREFIX, MessageType
+from fedbiomed.common.constants import REQUEST_PREFIX, MessageType
 from fedbiomed.common.logger import logger
 from fedbiomed.common.message import (
     ApprovalRequest,
@@ -344,12 +344,8 @@ class Requests(metaclass=SingletonMeta):
 
         server_host = config.get("server", "host")
         server_port = config.get("server", "port")
-        cert_priv = os.path.join(
-            config.root, CONFIG_FOLDER_NAME, config.get("certificate", "private_key")
-        )
-        cert_pub = os.path.join(
-            config.root, CONFIG_FOLDER_NAME, config.get("certificate", "public_key")
-        )
+        cert_priv = config.getpath("certificate", "private_key")
+        cert_pub = config.getpath("certificate", "public_key")
 
         # Creates grpc server and starts it
         self._researcher_id = config.get("default", "id")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -655,7 +655,7 @@ def test_add_medical_folder_dataset_no_demographics(
     assert result_dlp is None
 
     # Verify mocks were called correctly
-    mock_validated_path.assert_called_once_with(type="dir")
+    mock_validated_path.assert_called_once_with(type="dir", initialdir=None)
     mock_controller_class.assert_called_once_with(test_path)
     mock_input.assert_called_once_with(
         "\nWould you like to select a demographics csv file? [y/N]\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,7 @@ from fedbiomed.node.cli_utils._medical_folder_dataset import (
     add_medical_folder_dataset_from_cli,
     get_map_modalities2folders_from_cli,
 )
+from fedbiomed.node.node import NodeContext
 from fedbiomed.node.node_pm import _node_signal_trigger_term, _start_node_process
 
 # ============================================================================
@@ -88,7 +89,7 @@ class TestTrainingPlanArgumentParser(unittest.TestCase):
         self.parser = argparse.ArgumentParser()
         self.subparsers = self.parser.add_subparsers()
         self.tp_arg_pars = TrainingPlanArgumentParser(self.subparsers)
-        self.tp_arg_pars._node = MagicMock()
+        self.tp_arg_pars._context = MagicMock()
 
     def test_01_training_plan_argument_parser_initialize(self):
         """Tests training plan parser initialization"""
@@ -147,8 +148,8 @@ class TestDatasetArgumentParser(unittest.TestCase):
         self.parser = argparse.ArgumentParser()
         self.subparsers = self.parser.add_subparsers()
         self.dataset_arg_pars = DatasetArgumentParser(self.subparsers)
-        self.node = MagicMock()
-        self.dataset_arg_pars._node = self.node
+        self.context = MagicMock()
+        self.dataset_arg_pars._context = self.context
 
     def test_01_dataset_argument_parser_initialize(self):
         """Test initialization"""
@@ -181,7 +182,7 @@ class TestDatasetArgumentParser(unittest.TestCase):
             args = self.parser.parse_args(["dataset", "add", "--mnist", "test"])
             self.dataset_arg_pars.add(args)
             m.assert_called_once_with(
-                self.node.dataset_manager, interactive=False, path="test"
+                self.context.dataset_manager, interactive=False, path="test"
             )
             m.reset_mock()
 
@@ -191,25 +192,27 @@ class TestDatasetArgumentParser(unittest.TestCase):
         with patch.object(fedbiomed.node.cli, "delete_database") as m:
             args = self.parser.parse_args(["dataset", "delete"])
             self.dataset_arg_pars.delete(args)
-            m.assert_called_once_with(self.node.dataset_manager)
+            m.assert_called_once_with(self.context.dataset_manager)
 
         with patch.object(fedbiomed.node.cli, "delete_all_database") as m:
             args = self.parser.parse_args(["dataset", "delete", "--all"])
             self.dataset_arg_pars.delete(args)
-            m.assert_called_once_with(self.node.dataset_manager)
+            m.assert_called_once_with(self.context.dataset_manager)
             m.reset_mock()
 
         with patch.object(fedbiomed.node.cli, "delete_database") as m:
             args = self.parser.parse_args(["dataset", "delete", "--mnist"])
             self.dataset_arg_pars.delete(args)
-            m.assert_called_once_with(self.node.dataset_manager, interactive=False)
+            m.assert_called_once_with(self.context.dataset_manager, interactive=False)
 
     def test_04_dataset_argument_parser_list(self):
         self.dataset_arg_pars.initialize()
         args = self.parser.parse_args(["dataset", "list"])
         self.dataset_arg_pars.list(args)
 
-        self.node.dataset_manager.list_my_datasets.assert_called_once_with(verbose=True)
+        self.context.dataset_manager.list_my_datasets.assert_called_once_with(
+            verbose=True
+        )
 
     def test_05_dataset_argument_parser_add_file(self):
         """Tests add() dispatches to _add_dataset_from_file when --file is given."""
@@ -224,13 +227,13 @@ class TestDatasetArgumentParser(unittest.TestCase):
     def test_06_dataset_argument_parser_add_mnist_default_path(self):
         """Tests add() uses node data folder when --mnist is given without a value."""
         self.dataset_arg_pars.initialize()
-        self.node.config.root = "/test/root"
+        self.context.config.root = "/test/root"
         with patch.object(fedbiomed.node.cli, "add_database") as m:
             args = self.parser.parse_args(["dataset", "add", "--mnist"])
             self.dataset_arg_pars.add(args)
             expected_path = os.path.join("/test/root", NODE_DATA_FOLDER)
             m.assert_called_once_with(
-                self.node.dataset_manager, interactive=False, path=expected_path
+                self.context.dataset_manager, interactive=False, path=expected_path
             )
 
     def test_07_add_dataset_from_file_absolute_path(self):
@@ -248,7 +251,7 @@ class TestDatasetArgumentParser(unittest.TestCase):
             with patch.object(fedbiomed.node.cli, "add_database") as m:
                 self.dataset_arg_pars._add_dataset_from_file(path=json_path)
                 m.assert_called_once_with(
-                    self.node.dataset_manager,
+                    self.context.dataset_manager,
                     interactive=False,
                     path="/absolute/data/path",
                     data_type="csv",
@@ -261,7 +264,7 @@ class TestDatasetArgumentParser(unittest.TestCase):
     def test_08_add_dataset_from_file_relative_path(self):
         """Tests _add_dataset_from_file prepends config.root for relative paths."""
         self.dataset_arg_pars.initialize()
-        self.node.config.root = "/test/root"
+        self.context.config.root = "/test/root"
         dataset_json = {
             "path": "relative/data",
             "data_type": "csv",
@@ -311,8 +314,8 @@ class TestNodeControl(unittest.TestCase):
         self.parser = argparse.ArgumentParser()
         self.subparsers = self.parser.add_subparsers()
         self.control = NodeControl(self.subparsers)
-        self.node = MagicMock()
-        self.control._node = self.node
+        self.context = MagicMock()
+        self.control._context = self.context
 
     def test_01_node_control_initialize(self):
         """Tests initialize"""
@@ -352,6 +355,37 @@ class TestNodeControl(unittest.TestCase):
             _start_node_process("config.ini", args)
             logger.critical.assert_called_once()
 
+    @patch("fedbiomed.node.node_pm.NodeConfig", autospec=True)
+    @patch("fedbiomed.node.node_pm.Node", autospec=True)
+    def test_04_node_control__start_reports_failure_to_build_node(
+        self, mock_node, mock_node_config
+    ):
+        """Tests that a node that cannot be built is reported, not raised"""
+        mock_node_config.return_value = MagicMock()
+        mock_node.side_effect = FedbiomedError(
+            "FB619: no researcher certificate is registered"
+        )
+
+        with patch("fedbiomed.node.node_pm.logger") as logger:
+            _start_node_process("config.ini", {"gpu": False})
+
+            logger.critical.assert_called_once()
+            self.assertIn("FB619", logger.critical.call_args[0][0])
+
+    @patch("fedbiomed.node.node_pm.NodeConfig", autospec=True)
+    @patch("fedbiomed.node.node_pm.Node", autospec=True)
+    def test_05_node_control__start_unexpected_failure_to_build_node(
+        self, mock_node, mock_node_config
+    ):
+        """Tests reporting an unexpected error when there is no node to report with"""
+        mock_node_config.return_value = MagicMock()
+        mock_node.side_effect = Exception("unexpected")
+
+        with patch("fedbiomed.node.node_pm.logger") as logger:
+            _start_node_process("config.ini", {"gpu": False})
+
+            logger.critical.assert_called_once()
+
 
 class TestGUIControl(unittest.TestCase):
     """Tests for GUIControl argument parser."""
@@ -360,8 +394,8 @@ class TestGUIControl(unittest.TestCase):
         self.parser = argparse.ArgumentParser()
         self.subparsers = self.parser.add_subparsers()
         self.control = GUIControl(self.subparsers)
-        self.node = MagicMock()
-        self.control._node = self.node
+        self.context = MagicMock()
+        self.control._context = self.context
 
     def test_01_gui_control_initialize(self):
         """Tests gui subparser and all its start options are registered."""
@@ -394,7 +428,7 @@ class TestGUIControl(unittest.TestCase):
     ):
         """Tests forward() launches gunicorn when development mode is off."""
         self.control.initialize()
-        self.node.config.root = "/node/root"
+        self.context.config.root = "/node/root"
         mock_importlib.import_module.return_value.__file__ = (
             "/path/to/fedbiomed_gui/__init__.py"
         )
@@ -429,7 +463,7 @@ class TestGUIControl(unittest.TestCase):
     ):
         """Tests forward() uses flask when development mode is on."""
         self.control.initialize()
-        self.node.config.root = "/node/root"
+        self.context.config.root = "/node/root"
         mock_importlib.import_module.return_value.__file__ = (
             "/path/to/fedbiomed_gui/__init__.py"
         )
@@ -458,7 +492,7 @@ class TestGUIControl(unittest.TestCase):
     ):
         """Tests forward() passes --keyfile/--certfile to gunicorn when SSL is configured."""
         self.control.initialize()
-        self.node.config.root = "/node/root"
+        self.context.config.root = "/node/root"
         mock_importlib.import_module.return_value.__file__ = (
             "/path/to/fedbiomed_gui/__init__.py"
         )
@@ -484,7 +518,7 @@ class TestGUIControl(unittest.TestCase):
     def test_05_gui_control_forward_invalid_data_folder(self, mock_isdir):
         """Tests forward() raises FedbiomedError when the data folder does not exist."""
         self.control.initialize()
-        self.node.config.root = "/node/root"
+        self.context.config.root = "/node/root"
 
         args = argparse.Namespace(
             path="/some/fedbiomed/path",
@@ -540,25 +574,51 @@ class TestStartNodeProcess(unittest.TestCase):
 class TestNodeCLI(unittest.TestCase):
     """Tests main NodeCLI"""
 
-    @patch("fedbiomed.node.cli.Node")
+    @patch("fedbiomed.node.node.TrainingPlanSecurityManager")
+    @patch("fedbiomed.node.node.DatasetManager")
     @patch("fedbiomed.node.cli.node_component.initiate")
     @patch("builtins.input")
-    def test_01_node_cli_init(self, input_patch, mock_initiate, mock_node):
+    def test_01_node_cli_init(
+        self, input_patch, mock_initiate, mock_dataset_manager, mock_tp_manager
+    ):
         """Tests initialization"""
         input_patch.return_value = "y"
         mock_config = MagicMock()
         mock_config.get.return_value = "test-node-id"
         mock_initiate.return_value = mock_config
-        mock_node.return_value.dataset_manager.list_my_datasets.return_value = []
+        mock_dataset_manager.return_value.list_my_datasets.return_value = []
 
         self.node_cli = NodeCLI()
         self.node_cli.parse_args(["--path", "/fake/fbm-node", "dataset", "list"])
 
         mock_initiate.assert_called_once_with(root=os.path.abspath("/fake/fbm-node"))
-        mock_node.assert_called_once_with(mock_config)
-        mock_node.return_value.dataset_manager.list_my_datasets.assert_called_once_with(
+        mock_dataset_manager.assert_called_once()
+        mock_dataset_manager.return_value.list_my_datasets.assert_called_once_with(
             verbose=True
         )
+
+
+class TestNodeContext(unittest.TestCase):
+    """Tests the local state the node CLI acts on"""
+
+    @patch("fedbiomed.node.node.TrainingPlanSecurityManager")
+    @patch("fedbiomed.node.node.DatasetManager")
+    def setUp(self, mock_dataset, mock_tp):
+        self.config = MagicMock()
+        self.mock_dataset = mock_dataset
+        self.mock_tp = mock_tp
+        self.context = NodeContext(self.config)
+
+    def test_01_exposes_config(self):
+        """Tests that the context exposes the component configuration"""
+        self.assertIs(self.context.config, self.config)
+
+    def test_02_builds_both_managers_at_construction(self):
+        """Tests that both managers are built when the context is created"""
+        self.mock_dataset.assert_called_once()
+        self.mock_tp.assert_called_once()
+        self.assertIs(self.context.dataset_manager, self.mock_dataset.return_value)
+        self.assertIs(self.context.tp_security_manager, self.mock_tp.return_value)
 
 
 # ============================================================================
@@ -896,8 +956,8 @@ def test_node_control_start_builds_node_args_and_waits(
     control = NodeControl(subparsers)
     control.initialize()
 
-    node = MagicMock()
-    control._node = node
+    context = MagicMock()
+    control._context = context
 
     mock_intro = mocker.patch("fedbiomed.node.cli.intro")
 
@@ -911,7 +971,7 @@ def test_node_control_start_builds_node_args_and_waits(
     control.start(args)
 
     mock_intro.assert_called_once_with()
-    mock_node_process_manager_cls.assert_called_once_with(node.config)
+    mock_node_process_manager_cls.assert_called_once_with(context.config)
 
     mock_node_process_manager.start.assert_called_once_with(
         node_args=expected_node_args,
@@ -930,8 +990,8 @@ def test_node_control_start_keyboard_interrupt_stops_node(mocker):
     control = NodeControl(subparsers)
     control.initialize()
 
-    node = MagicMock()
-    control._node = node
+    context = MagicMock()
+    control._context = context
 
     mock_intro = mocker.patch("fedbiomed.node.cli.intro")
 
@@ -949,7 +1009,7 @@ def test_node_control_start_keyboard_interrupt_stops_node(mocker):
     assert exc.value.code == 0
 
     mock_intro.assert_called_once_with()
-    mock_node_process_manager_cls.assert_called_once_with(node.config)
+    mock_node_process_manager_cls.assert_called_once_with(context.config)
 
     mock_node_process_manager.start.assert_called_once_with(
         node_args={
@@ -997,8 +1057,8 @@ def test_node_control_restart_passes_only_supplied_overrides(
     control = NodeControl(subparsers)
     control.initialize()
 
-    node = MagicMock()
-    control._node = node
+    context = MagicMock()
+    control._context = context
 
     mock_node_process_manager_cls = mocker.patch(
         "fedbiomed.node.cli.NodeProcessManager"


### PR DESCRIPTION
This PR separates node from its context (config). It means that now interacting with the databases for datasets or training plans does not initialize communication channel. This will allow to add certificates dynamically without raising errors.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`