### PR TITLE
Add --force option by default on startup to docker containers

### DIFF
--- a/docker/node/entrypoint.sh
+++ b/docker/node/entrypoint.sh
@@ -22,7 +22,7 @@ cat > /home/${FEDBIOMED_USER}/start-fbm-node.sh <<'WRAPPER'
 set -a  # auto-export all variables
 source /home/${FEDBIOMED_USER}/fbm.env
 set +a
-exec fedbiomed node -p /fbm-node start --background ${FBM_NODE_START_OPTIONS}
+exec fedbiomed node -p /fbm-node start --background --force ${FBM_NODE_START_OPTIONS}
 WRAPPER
 chmod +x /home/${FEDBIOMED_USER}/start-fbm-node.sh
 

--- a/envs/vpn/docker/node/build_files/entrypoint.bash
+++ b/envs/vpn/docker/node/build_files/entrypoint.bash
@@ -42,7 +42,7 @@ su -l -c "export FBM_SECURITY_ALLOW_FEDERATED_ANALYTICS=\"${FBM_SECURITY_ALLOW_F
 su -l -c "echo \"$FBM_NODE_START_OPTIONS\" >/fbm-node/FBM_NODE_START_OPTIONS" $CONTAINER_USER
 
 # Launch node using node options
-su -l -c "fedbiomed node --path /fbm-node start $FBM_NODE_START_OPTIONS &" $CONTAINER_USER
+su -l -c "fedbiomed node --path /fbm-node start --force $FBM_NODE_START_OPTIONS &" $CONTAINER_USER
 
 echo "Node container is ready"
 sleep infinity &


### PR DESCRIPTION
Add --force option by default on startup to docker containers to avoid potential bugs with node state database.