### PR TITLE
CI PR 4 - Add Docker and VPN compatibility testing

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -15,6 +15,11 @@ inputs:
     required: false
     default: 'false'
 
+  python-version:
+    description: Python version used by the image
+    required: false
+    default: '3.11'
+
 runs:
   using: "composite"
   steps:
@@ -64,6 +69,7 @@ runs:
       run: |
         docker build ${{ steps.tag-args.outputs.TAG_ARGS }} \
           --build-arg FBM_IMAGE_VERSION=${{ steps.meta.outputs.version }} \
+          --build-arg PYTHON_VERSION=${{ inputs.python-version }} \
           -f ${{ inputs.file }} . 
       shell: bash -l {0}
     

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -1,9 +1,5 @@
 ---
 name: Tests and Publish Fed-BioMed Docker Images
-description: |
-  Builds for testing and deployment of Fed-BioMed docker images. Deployment is done if
-  a new tag is pushed, or a new commit is pushed to develop. It is to keep "dev" version
-  pushed in docker hub. 
 
 on:
   push:
@@ -13,6 +9,13 @@ on:
     tags:
       - 'v*.*.*'  # Triggers on tags like v1.2.3
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # Published images intentionally use one documented runtime.
+  PYTHON_VERSION: "3.11"
 
 jobs:
   build-and-push:
@@ -27,6 +30,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.FBM_DOCKER_USERNAME }}
@@ -35,7 +39,8 @@ jobs:
       - name: Check if image has to be pushed
         id: test  
         run: | 
-          if [[ ( "${GITHUB_REF_NAME}" == "master" && "${GITHUB_EVENT_NAME}" == "push" ) || \
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" || \
+                ( "${GITHUB_REF_NAME}" == "master" && "${GITHUB_EVENT_NAME}" == "push" ) || \
                  ( "${GITHUB_REF_NAME}" == "develop" && "${GITHUB_EVENT_NAME}" == "push" ) || \
                  "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
             echo "TEST_BUILD=true" >> $GITHUB_OUTPUT
@@ -48,6 +53,7 @@ jobs:
         with:
           image-names: fedbiomed/base
           file: docker/base/Dockerfile
+          python-version: ${{ env.PYTHON_VERSION }}
           test: ${{ steps.test.outputs.TEST_BUILD }}
 
       - name: Build and Publish/Test Fed-BioMed Node Image
@@ -55,6 +61,7 @@ jobs:
         with:
           image-names: fedbiomed/node
           file: docker/node/Dockerfile
+          python-version: ${{ env.PYTHON_VERSION }}
           test: ${{ steps.test.outputs.TEST_BUILD }}
       
       - name: Build and Publish/Test Researcher Image
@@ -62,4 +69,5 @@ jobs:
         with:
           image-names: fedbiomed/researcher
           file: docker/researcher/Dockerfile
+          python-version: ${{ env.PYTHON_VERSION }}
           test: ${{ steps.test.outputs.TEST_BUILD }}

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -1,55 +1,187 @@
 ---
-name: Fed-BioMed VPN Docker Image and Container Test
-run-name: fedbiomed-docker-container-test
+name: Fed-BioMed Docker Compatibility Tests
+run-name: Fed-BioMed Docker Compatibility Tests
 
 on:
+  pull_request:
+    branches:
+      - develop
   schedule:
-    - cron: '0 1 * * *'  # Run every day at 1 am on default branch: develop
+    # Monday at 01:17 UTC, representing Sunday night operationally.
+    - cron: "17 1 * * 1"
   push:
     branches:
-      - "master"
+      - master
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: fedbiomed-docker-compatibility
+  cancel-in-progress: false
+
 jobs:
-  run-docker-test:
-    name: VPN Image/Docker Test
+  hosted-build-smoke:
+    name: Build smoke / Python ${{ matrix.python-version }} / Ubuntu latest
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - [self-hosted, ubuntu-24-04]
-        python-version:
-          - "3.10"
-          - "3.11"
-    runs-on: ${{ matrix.os }}
+        include:
+          - python-version: "3.10"
+            python-tag: "310"
+          - python-version: "3.11"
+            python-tag: "311"
+          - python-version: "3.12"
+            python-tag: "312"
+          - python-version: "3.13"
+            python-tag: "313"
+          - python-version: "3.14"
+            python-tag: "314"
+    env:
+      PYTHON_VERSION: ${{ matrix.python-version }}
+      IMAGE_TAG: ci-${{ github.run_id }}-${{ github.run_attempt }}-py${{ matrix.python-tag }}
     steps:
-      - name: Checkout to repository
+      - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install docker if it is not existing
-        if: runner.os == 'macOS'
-        run: |
-          if ! command -v docker &>/dev/null; then
-            echo "Docker is not installed. Proceeding to install..."
-            brew install --cask docker
-          else
-            echo "Docker is already installed."
-          fi
-          docker compose --help
-          if ! docker compose version; then
-            echo "failed to execute docker compose version"
-          fi
-        shell: bash -l {0}
 
-      - name: Run docker test
+      - name: Build base image
         run: |
-          ./tests/vpn_test.sh
-        shell: bash -l {0}
+          docker build \
+            --build-arg "PYTHON_VERSION=$PYTHON_VERSION" \
+            --tag "fedbiomed/base:$IMAGE_TAG" \
+            --file docker/base/Dockerfile \
+            .
 
-      - name: Clean
+      - name: Build node image
+        run: |
+          docker build \
+            --build-arg "FBM_IMAGE_VERSION=$IMAGE_TAG" \
+            --build-arg "PYTHON_VERSION=$PYTHON_VERSION" \
+            --tag "fedbiomed/node:$IMAGE_TAG" \
+            --file docker/node/Dockerfile \
+            .
+
+      - name: Build researcher image
+        run: |
+          docker build \
+            --build-arg "FBM_IMAGE_VERSION=$IMAGE_TAG" \
+            --build-arg "PYTHON_VERSION=$PYTHON_VERSION" \
+            --tag "fedbiomed/researcher:$IMAGE_TAG" \
+            --file docker/researcher/Dockerfile \
+            .
+
+      - name: Verify image Python and commands
+        run: |
+          verify_python() {
+            local image="$1"
+            local actual
+            actual=$(docker run --rm --entrypoint python "$image" -c \
+              'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+            test "$actual" = "$PYTHON_VERSION"
+          }
+
+          verify_python "fedbiomed/base:$IMAGE_TAG"
+          verify_python "fedbiomed/node:$IMAGE_TAG"
+          verify_python "fedbiomed/researcher:$IMAGE_TAG"
+
+          docker run --rm --entrypoint fedbiomed \
+            "fedbiomed/base:$IMAGE_TAG" --help
+          docker run --rm --entrypoint fedbiomed \
+            "fedbiomed/node:$IMAGE_TAG" node --help
+          docker run --rm --entrypoint fedbiomed \
+            "fedbiomed/researcher:$IMAGE_TAG" researcher --help
+
+      - name: Remove test images
         if: always()
         run: |
-          # Fix possible permission issues
-          sudo chown -R $(whoami):$(whoami) envs/vpn/docker || true
-          ./scripts/fedbiomed_vpn clean image
-          docker system prune -af
-        shell: bash -l {0}
+          docker image rm --force \
+            "fedbiomed/researcher:$IMAGE_TAG" \
+            "fedbiomed/node:$IMAGE_TAG" \
+            "fedbiomed/base:$IMAGE_TAG" || true
+
+  vpn-functional:
+    name: VPN functional / Python ${{ matrix.python-version }} / ${{ matrix.runner-name }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include:
+          - python-version: "3.10"
+            python-tag: "310"
+            runner: ubuntu-latest
+            runner-name: Ubuntu latest
+            runner-tag: ubuntu-latest
+            persistent-cache: false
+          - python-version: "3.14"
+            python-tag: "314"
+            runner: ubuntu-latest
+            runner-name: Ubuntu latest
+            runner-tag: ubuntu-latest
+            persistent-cache: false
+          - python-version: "3.10"
+            python-tag: "310"
+            runner: [self-hosted, ubuntu-24-04]
+            runner-name: Self-hosted Ubuntu
+            runner-tag: self-hosted-ubuntu
+            persistent-cache: true
+          - python-version: "3.14"
+            python-tag: "314"
+            runner: [self-hosted, ubuntu-24-04]
+            runner-name: Self-hosted Ubuntu
+            runner-tag: self-hosted-ubuntu
+            persistent-cache: true
+    env:
+      PYTHON_VERSION: ${{ matrix.python-version }}
+      # Compatibility CI is CPU-only. Deployment keeps the GPU-capable defaults.
+      FBM_VPN_NODE_BASE_SERVICE: basenode-no-gpu
+      FBM_PYTORCH_INDEX_URL: https://download.pytorch.org/whl/cpu
+      FBM_EXPECT_CPU_TORCH: "true"
+      FBM_CONTAINER_VERSION_TAG: ci-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.runner-tag }}-py${{ matrix.python-tag }}
+      FBM_CONTAINER_INSTANCE_ID: ci-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.runner-tag }}-py${{ matrix.python-tag }}
+      COMPOSE_PROJECT_NAME: fedbiomed-vpn-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.runner-tag }}-py${{ matrix.python-tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Verify Docker and VPN prerequisites
+        run: |
+          docker version
+          docker compose version
+          test -c /dev/net/tun
+          df -h
+          docker system df
+
+      - name: Bound persistent Docker build cache
+        if: matrix.persistent-cache
+        run: |
+          docker builder prune \
+            --all \
+            --force \
+            --keep-storage 8gb
+
+      - name: Run VPN functional test
+        run: ./tests/vpn_test.sh
+
+      - name: Clean this VPN test run
+        if: always()
+        run: |
+          sudo chown -R "$(id -u):$(id -g)" envs/vpn/docker || true
+          ./scripts/fedbiomed_vpn clean image || true
+          docker compose \
+            --file envs/vpn/docker/docker-compose.yml \
+            --project-name "$COMPOSE_PROJECT_NAME" \
+            down --remove-orphans || true
+
+      - name: Prune persistent Docker build cache
+        if: ${{ always() && matrix.persistent-cache }}
+        run: |
+          docker builder prune \
+            --all \
+            --force \
+            --keep-storage 8gb || true
+          docker system df || true

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,3 +1,5 @@
+ARG PYTHON_VERSION=3.11
+
 # Stage 1: Build Node.js frontend
 FROM node:20-bullseye AS node-build
 WORKDIR /build
@@ -14,7 +16,7 @@ COPY fedbiomed_gui/ui/ ./
 RUN yarn build
 
 # Stage 2: Build Python package without hatch hook
-FROM python:3.11-slim-bullseye AS python-build
+FROM python:${PYTHON_VERSION}-slim-bookworm AS python-build
 
 ARG FEDBIOMED_GID=2101
 ARG FEDBIOMED_UID=2101
@@ -38,17 +40,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy all required files for pip install
-COPY --chown=${FEDBIOMED_USER}:${FEDBIOMED_GROUP} pyproject.toml README.md ./
-COPY --chown=${FEDBIOMED_USER}:${FEDBIOMED_GROUP} fedbiomed ./fedbiomed
-COPY --chown=${FEDBIOMED_USER}:${FEDBIOMED_GROUP} envs/common ./envs/common
-COPY --chown=${FEDBIOMED_USER}:${FEDBIOMED_GROUP} envs/vpn ./envs/vpn
-COPY --chown=${FEDBIOMED_USER}:${FEDBIOMED_GROUP} notebooks ./notebooks
-COPY --chown=${FEDBIOMED_USER}:${FEDBIOMED_GROUP} docs/tutorials ./docs/tutorials
-COPY --chown=${FEDBIOMED_USER}:${FEDBIOMED_GROUP} scripts ./scripts
-COPY --chown=${FEDBIOMED_USER}:${FEDBIOMED_GROUP} hatch_build.py ./hatch_build.py
+COPY --chown=${FEDBIOMED_UID}:${FEDBIOMED_GID} pyproject.toml README.md ./
+COPY --chown=${FEDBIOMED_UID}:${FEDBIOMED_GID} fedbiomed ./fedbiomed
+COPY --chown=${FEDBIOMED_UID}:${FEDBIOMED_GID} envs/common ./envs/common
+COPY --chown=${FEDBIOMED_UID}:${FEDBIOMED_GID} envs/vpn ./envs/vpn
+COPY --chown=${FEDBIOMED_UID}:${FEDBIOMED_GID} notebooks ./notebooks
+COPY --chown=${FEDBIOMED_UID}:${FEDBIOMED_GID} docs/tutorials ./docs/tutorials
+COPY --chown=${FEDBIOMED_UID}:${FEDBIOMED_GID} scripts ./scripts
+COPY --chown=${FEDBIOMED_UID}:${FEDBIOMED_GID} hatch_build.py ./hatch_build.py
 
 # Copy fedbiomed_gui structure (needed for pyproject.toml packages)
-COPY --chown=${FEDBIOMED_USER}:${FEDBIOMED_GROUP} fedbiomed_gui ./fedbiomed_gui
+COPY --chown=${FEDBIOMED_UID}:${FEDBIOMED_GID} fedbiomed_gui ./fedbiomed_gui
 
 # Copy pre-built frontend from node-build stage
 COPY --from=node-build /build/build ./fedbiomed_gui/ui/build
@@ -58,7 +60,9 @@ RUN sed -i '/hatch\.build\.hooks/,/^$/d' pyproject.toml && pip install --no-cach
     pip wheel --no-cache-dir --wheel-dir /wheels '.[researcher, node, gui]'
 
 # Stage 3: Final runtime image
-FROM debian:bullseye-slim
+FROM python:${PYTHON_VERSION}-slim-bookworm
+
+ARG PYTHON_VERSION
 
 ARG FEDBIOMED_GID=2101
 ARG FEDBIOMED_UID=2101
@@ -75,8 +79,8 @@ ENV FEDBIOMED_GID=${FEDBIOMED_GID} \
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
-    libssl1.1 \
-    libffi7 \
+    libssl3 \
+    libffi8 \
     libbz2-1.0 \
     libjpeg62-turbo \
     libpng16-16 \
@@ -84,7 +88,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libreadline8 \
     libsqlite3-0 \
     zlib1g \
-#    python3-tk \
     libgmp10 \
     libmpfr6 \
     libmpc3 \
@@ -93,8 +96,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tini \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy Python from official image
-COPY --from=python:3.11-slim-bullseye /usr/local/ /usr/local/
+RUN ACTUAL_PYTHON=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")') && \
+    test "$ACTUAL_PYTHON" = "$PYTHON_VERSION"
 
 # Create user and directories
 RUN groupadd --gid $FEDBIOMED_GID $FEDBIOMED_GROUP && \

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -3,6 +3,8 @@ ARG FBM_IMAGE_VERSION
 
 FROM fedbiomed/base:${FBM_IMAGE_VERSION:-latest} AS fedbiomed-base
 
+ARG PYTHON_VERSION=3.11
+
 # Redeclare ARGs from base image to make them available at build time
 ARG FEDBIOMED_USER=fedbiomed
 ARG FEDBIOMED_GROUP=fedbiomed
@@ -14,6 +16,9 @@ ENV FEDBIOMED_USER=${FEDBIOMED_USER}
 ENV FEDBIOMED_GROUP=${FEDBIOMED_GROUP}
 ENV FEDBIOMED_UID=${FEDBIOMED_UID}
 ENV FEDBIOMED_GID=${FEDBIOMED_GID}
+
+RUN ACTUAL_PYTHON=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")') && \
+    test "$ACTUAL_PYTHON" = "$PYTHON_VERSION"
 
 # Copy node entry point file
 COPY --chown=$FEDBIOMED_USER:$FEDBIOMED_GROUP docker/node/entrypoint.sh /entrypoint.sh

--- a/docker/researcher/Dockerfile
+++ b/docker/researcher/Dockerfile
@@ -3,6 +3,8 @@ ARG FBM_IMAGE_VERSION
 
 FROM fedbiomed/base:${FBM_IMAGE_VERSION:-latest} AS fedbiomed-base
 
+ARG PYTHON_VERSION=3.11
+
 # Redeclare ARGs from base image to make them available at build time
 ARG FEDBIOMED_USER=fedbiomed
 ARG FEDBIOMED_GROUP=fedbiomed
@@ -14,6 +16,9 @@ ENV FEDBIOMED_USER=${FEDBIOMED_USER}
 ENV FEDBIOMED_GROUP=${FEDBIOMED_GROUP}
 ENV FEDBIOMED_UID=${FEDBIOMED_UID}
 ENV FEDBIOMED_GID=${FEDBIOMED_GID}
+
+RUN ACTUAL_PYTHON=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")') && \
+    test "$ACTUAL_PYTHON" = "$PYTHON_VERSION"
 
 # jupyter notebook
 EXPOSE 8888

--- a/envs/vpn/README.md
+++ b/envs/vpn/README.md
@@ -290,6 +290,7 @@ Run this only at first launch of container or after cleaning :
 
 * build container
 ```bash
+[user@node $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker compose build base
 [user@node $] CONTAINER_UID=$(id -u) CONTAINER_GID=$(id -g) CONTAINER_USER=$(id -un | sed 's/[^[:alnum:]]/_/g') CONTAINER_GROUP=$(id -gn | sed 's/[^[:alnum:]]/_/g') docker compose build gui
 ```
 
@@ -312,6 +313,7 @@ On the build machine
 * in this example, we build the container with user `fedbiomed` (id `1234`) and group `fedbiomed` (id `1234`). Account name and id used on the node machine may differ (see below).
 * build container
 ```bash
+[user@build $] CONTAINER_UID=1234 CONTAINER_GID=1234 CONTAINER_USER=fedbiomed CONTAINER_GROUP=fedbiomed docker compose build base
 [user@build $] CONTAINER_UID=1234 CONTAINER_GID=1234 CONTAINER_USER=fedbiomed CONTAINER_GROUP=fedbiomed docker compose build gui
 ```
 * save image for container

--- a/envs/vpn/docker/.env
+++ b/envs/vpn/docker/.env
@@ -15,3 +15,6 @@ FBM_CONTAINER_VERSION_TAG=${FBM_CONTAINER_VERSION_TAG:-6.3.3}
 # This is purely local for deployment on one machine: if an instance has some components
 # on another machine, the ID does not need to be coherent.
 FBM_CONTAINER_INSTANCE_ID=${FBM_CONTAINER_INSTANCE_ID:-default}
+
+# Python runtime used by all images in this VPN deployment
+PYTHON_VERSION=${PYTHON_VERSION:-3.10}

--- a/envs/vpn/docker/base/build_files/Dockerfile
+++ b/envs/vpn/docker/base/build_files/Dockerfile
@@ -1,8 +1,9 @@
+ARG PYTHON_VERSION=3.10
+
 # temporary builder image for wireguard tools
 # - need coherent system version with base image
 # - may need update for properly compiling boringtun
-# - 2023-05: `bookworm` is not officially released, stick to `bullseye` for now
-FROM debian:bullseye-slim AS builder
+FROM debian:bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -y git build-essential curl
 
@@ -20,9 +21,23 @@ RUN apt-get install -y wireguard-tools
 
 # docker base image for VPN server, Fed-BioMed node and researcher
 # - need proper python version for Fed-BioMed
-FROM python:3.10-slim-bullseye
+FROM python:${PYTHON_VERSION}-slim-bookworm
+
+ARG PYTHON_VERSION
 
 RUN apt-get update && apt-get install -y iptables iproute2 iputils-ping bash vim net-tools procps build-essential kmod
+
+RUN ACTUAL_PYTHON=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")') && \
+    test "$ACTUAL_PYTHON" = "$PYTHON_VERSION"
+
+# CI may request CPU-only PyTorch. Normal deployment leaves this unset and
+# resolves the project dependencies through the standard package index.
+ARG FBM_PYTORCH_INDEX_URL=""
+RUN if [ -n "$FBM_PYTORCH_INDEX_URL" ]; then \
+        python -m pip install --no-cache-dir \
+            --index-url "$FBM_PYTORCH_INDEX_URL" \
+            torch torchvision; \
+    fi
 
 # get wireguard from builder image
 COPY --from=builder /root/.cargo/bin/boringtun /usr/bin/

--- a/envs/vpn/docker/docker-compose.yml
+++ b/envs/vpn/docker/docker-compose.yml
@@ -12,6 +12,8 @@ x-node: &standard-node
       - CONTAINER_USER
       - CONTAINER_GROUP
       - FBM_CONTAINER_VERSION_TAG
+      - PYTHON_VERSION
+      - FBM_PYTORCH_INDEX_URL
   image: fedbiomed/vpn-node:${FBM_CONTAINER_VERSION_TAG:-unknown}
   networks:
     - fedbiomed_node
@@ -76,6 +78,9 @@ services:
     hostname: fedbiomed-vpn-base-${FBM_CONTAINER_INSTANCE_ID:-unknown}
     build:
       context: ./base/build_files
+      args:
+        - PYTHON_VERSION
+        - FBM_PYTORCH_INDEX_URL
     image: "fedbiomed/vpn-base:${FBM_CONTAINER_VERSION_TAG:-unknown}"
     networks:
       - fedbiomed_misc
@@ -91,6 +96,9 @@ services:
     hostname: fedbiomed-vpn-base-node-no-gpu-${FBM_CONTAINER_INSTANCE_ID:-unknown}
     build:
       context: ./base/build_files
+      args:
+        - PYTHON_VERSION
+        - FBM_PYTORCH_INDEX_URL
     image: fedbiomed/vpn-basenode:${FBM_CONTAINER_VERSION_TAG:-unknown}
     networks:
       - fedbiomed_misc
@@ -121,6 +129,7 @@ services:
         - CONTAINER_USER # build and use other account than "root"
         - CONTAINER_GROUP # build and use other group than "root"
         - FBM_CONTAINER_VERSION_TAG
+        - PYTHON_VERSION
     image: fedbiomed/vpn-vpnserver:${FBM_CONTAINER_VERSION_TAG:-unknown}
     networks:
       - fedbiomed_vpnserver
@@ -148,6 +157,8 @@ services:
   # using gpu (need image with gpu support)
   node-gpu:
     <<: *standard-node
+    container_name: fedbiomed-vpn-node-${FBM_CONTAINER_INSTANCE_ID:-unknown}-gpu
+    hostname: fedbiomed-vpn-node-${FBM_CONTAINER_INSTANCE_ID:-unknown}-gpu
     runtime: nvidia
     #
     ## alternate syntax from the `Compose` specification, needs both
@@ -169,6 +180,8 @@ services:
   # using gpu (need image with gpu support)
   node2-gpu:
     <<: *standard-node2
+    container_name: fedbiomed-vpn-node2-${FBM_CONTAINER_INSTANCE_ID:-unknown}-gpu
+    hostname: fedbiomed-vpn-node2-${FBM_CONTAINER_INSTANCE_ID:-unknown}-gpu
     runtime: nvidia
 
   #
@@ -184,6 +197,7 @@ services:
         - CONTAINER_GID
         - CONTAINER_USER
         - CONTAINER_GROUP
+        - FBM_CONTAINER_VERSION_TAG
         - PYTHON_VERSION
     image: fedbiomed/vpn-gui:${FBM_CONTAINER_VERSION_TAG:-unknown}
     networks:
@@ -248,6 +262,7 @@ services:
         - CONTAINER_USER
         - CONTAINER_GROUP
         - FBM_CONTAINER_VERSION_TAG
+        - PYTHON_VERSION
     image: fedbiomed/vpn-researcher:${FBM_CONTAINER_VERSION_TAG:-unknown}
     networks:
       - fedbiomed_researcher

--- a/envs/vpn/docker/gui/build_files/Dockerfile
+++ b/envs/vpn/docker/gui/build_files/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.10-slim-bullseye
+ARG FBM_CONTAINER_VERSION_TAG
+FROM fedbiomed/vpn-base:${FBM_CONTAINER_VERSION_TAG:-unknown}
 
 # nginx + flask HTTP server for node1
 EXPOSE 8484
@@ -25,12 +26,10 @@ ENV CONTAINER_USER=${CONTAINER_USER:-root}
 ENV CONTAINER_GROUP=${CONTAINER_GROUP:-root}
 
 RUN apt-get update && apt-get install -y gcc apt-utils wget procps systemd \
-	gettext-base libgmp3-dev libmpfr-dev libmpc-dev apt-utils wget git \
-	python-tk python${PYTHON_VERSION} python3-pip
+	gettext-base libgmp3-dev libmpfr-dev libmpc-dev apt-utils wget git
 
-
-RUN python --version
-
+RUN ACTUAL_PYTHON=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")') && \
+    test "$ACTUAL_PYTHON" = "$PYTHON_VERSION"
 
 # Install nodejs -----------------------------------------------------------------
 RUN wget -qO- https://deb.nodesource.com/setup_23.x | bash -
@@ -84,8 +83,10 @@ WORKDIR /fedbiomed
 # Set container user
 USER $CONTAINER_USER:$CONTAINER_GROUP
 
-# Installs fedbiomed and necessary modules
-RUN pip install --no-warn-script-location '.[gui]'
+# Installs fedbiomed and necessary modules without retaining downloaded wheels
+# or transient front-end dependencies created by the package build hook.
+RUN python -m pip install --no-cache-dir --no-warn-script-location '.[gui]' && \
+    rm -rf "$HOME/.cache/yarn" /fedbiomed/fedbiomed_gui/ui/node_modules
 
 # Changedir to main directory
 WORKDIR /

--- a/envs/vpn/docker/node/build_files/Dockerfile
+++ b/envs/vpn/docker/node/build_files/Dockerfile
@@ -7,6 +7,7 @@ ARG CONTAINER_GROUP
 ARG CONTAINER_USER
 
 ARG PYTHON_VERSION="3.10"
+ARG FBM_PYTORCH_INDEX_URL=""
 
 # assign default values even when variable exists and is empty
 # (ARG default value only applies when variable is non existent)
@@ -18,20 +19,11 @@ ENV CONTAINER_USER=${CONTAINER_USER:-root}
 ENV CONTAINER_GROUP=${CONTAINER_GROUP:-root}
 
 
-RUN apt-get update && apt-get install -y libgmp3-dev libmpfr-dev libmpc-dev apt-utils wget git \
-	python-tk python${PYTHON_VERSION} python3-pip
+RUN apt-get update && apt-get install -y libgmp3-dev libmpfr-dev libmpc-dev apt-utils git \
+	rsync
 
-# Create alias
-RUN ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python && \
-    ln -sf /usr/bin/pip3 /usr/bin/pip
-
-RUN apt-get -y install rsync
-
-# Install nodejs -----------------------------------------------------------------
-RUN wget -qO- https://deb.nodesource.com/setup_23.x | bash -
-RUN apt-get install -y nodejs
-RUN npm install --global yarn@1.22
-
+RUN ACTUAL_PYTHON=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")') && \
+    test "$ACTUAL_PYTHON" = "$PYTHON_VERSION"
 
 # read config.env in interactive shells & setup for reading it in entrypoint
 COPY ./envs/vpn/docker/node/build_files/bashrc_append /tmp
@@ -74,8 +66,16 @@ WORKDIR /fedbiomed
 # Set container user
 USER $CONTAINER_USER:$CONTAINER_GROUP
 
-# Installs fedbiomed and necessary modules
-RUN /bin/pip install --no-warn-script-location -I '.[node]'
+# Installs fedbiomed and necessary modules without retaining downloaded wheels.
+# CI preserves CPU PyTorch from the base; deployment retains the original
+# ignore-installed behavior and standard dependency resolution.
+RUN if [ -n "$FBM_PYTORCH_INDEX_URL" ]; then \
+        FBM_SKIP_FRONTEND_BUILD=1 \
+            python -m pip install --no-cache-dir --no-warn-script-location '.[node]'; \
+    else \
+        FBM_SKIP_FRONTEND_BUILD=1 \
+            python -m pip install --no-cache-dir --no-warn-script-location -I '.[node]'; \
+    fi
 
 # transmit build-time values to running container
 ENV CONTAINER_BUILD_USER=${CONTAINER_USER}

--- a/envs/vpn/docker/researcher/build_files/Dockerfile
+++ b/envs/vpn/docker/researcher/build_files/Dockerfile
@@ -24,18 +24,10 @@ ENV CONTAINER_GROUP=${CONTAINER_GROUP:-root}
 
 RUN apt-get update && apt-get install -y libgmp3-dev openssl \
 	libreadline-dev xz-utils libncurses-dev libffi-dev \
-	libmpfr-dev libmpc-dev apt-utils wget socat git \
-	python-tk python${PYTHON_VERSION} python3-pip
+	libmpfr-dev libmpc-dev apt-utils socat git
 
-# Create alias
-RUN ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python && \
-    ln -sf /usr/bin/pip3 /usr/bin/pip
-
-# Install nodejs -----------------------------------------------------------------
-RUN wget -qO- https://deb.nodesource.com/setup_23.x | bash -
-RUN apt-get install -y nodejs
-RUN npm install --global yarn@1.22
-
+RUN ACTUAL_PYTHON=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")') && \
+    test "$ACTUAL_PYTHON" = "$PYTHON_VERSION"
 
 # read config.env in interactive shells & setup for reading it in entrypoint
 COPY ./envs/vpn/docker/researcher/build_files/bashrc_append /tmp
@@ -79,8 +71,10 @@ WORKDIR /fedbiomed
 # Set container user
 USER $CONTAINER_USER:$CONTAINER_GROUP
 
-# Install fedbiomed and its requirements
-RUN pip install --no-warn-script-location '.[researcher]'
+# The researcher does not serve the node GUI. Skip its React build and install
+# only Fed-BioMed and the researcher dependencies.
+RUN FBM_SKIP_FRONTEND_BUILD=1 \
+    python -m pip install --no-cache-dir --no-warn-script-location '.[researcher]'
 
 # transmit build-time values to running container
 ENV CONTAINER_BUILD_USER=${CONTAINER_USER}

--- a/envs/vpn/docker/vpnserver/build_files/Dockerfile
+++ b/envs/vpn/docker/vpnserver/build_files/Dockerfile
@@ -1,6 +1,8 @@
 ARG FBM_CONTAINER_VERSION_TAG
 FROM fedbiomed/vpn-base:${FBM_CONTAINER_VERSION_TAG:-unknown}
 
+ARG PYTHON_VERSION=3.10
+
 WORKDIR /fedbiomed
 
 # wireguard server
@@ -18,6 +20,9 @@ ENV CONTAINER_GID=${CONTAINER_GID:-0}
 # alpine does not accept users/groups with numerical names
 ENV CONTAINER_USER=${CONTAINER_USER:-root}
 ENV CONTAINER_GROUP=${CONTAINER_GROUP:-root}
+
+RUN ACTUAL_PYTHON=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")') && \
+    test "$ACTUAL_PYTHON" = "$PYTHON_VERSION"
 
 # read config.env in interactive shells & setup for reading it in entrypoint
 COPY ./bashrc_append /tmp

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -16,6 +16,14 @@ class CustomBuildHook(BuildHookInterface):
         # Code in this function will run before building
         super().initialize(version, build_data)
 
+        if os.environ.get("FBM_SKIP_FRONTEND_BUILD", "").lower() in {
+            "1",
+            "true",
+            "yes",
+        }:
+            logger.info("Skipping node front-end build")
+            return
+
         logger.info("Building node front-end")
         yarn = shutil.which("yarn")
 

--- a/scripts/fedbiomed_vpn
+++ b/scripts/fedbiomed_vpn
@@ -301,7 +301,6 @@ containers_clean() {
         docker image rm -f $img 2>/dev/null
     done
 
-    docker image prune -f
     #
     # level4 : remove docker cache
     #
@@ -363,27 +362,42 @@ containers_build() {
 
     BUILD_BASE=0
     BUILD_NODEBASE=0
+    NODE_BASE_SERVICE="${FBM_VPN_NODE_BASE_SERVICE:-basenode}"
+    case "$NODE_BASE_SERVICE" in
+        basenode|basenode-no-gpu) ;;
+        *)
+            echo "** ERROR: invalid node base service '$NODE_BASE_SERVICE'"
+            return 1
+            ;;
+    esac
+
     for i in ${ONLY_CONTAINERS[@]}
     do
         case $i in
-            vpnserver|researcher) BUILD_BASE=1;;
+            vpnserver|researcher|gui|gui2) BUILD_BASE=1;;
             node|node2)           BUILD_NODEBASE=1;;
         esac
     done
 
     if [ $BUILD_BASE -eq 1 ]; then
         echo "- building 'base' container"
-        CONTAINER_UID=${CONTAINER_UID:-$(id -u)} CONTAINER_GID=${CONTAINER_GID:-$(id -g)} \
+        if ! CONTAINER_UID=${CONTAINER_UID:-$(id -u)} CONTAINER_GID=${CONTAINER_GID:-$(id -g)} \
             CONTAINER_USER=${CONTAINER_USER:-$(id -un | sed 's/[^[:alnum:]]/_/g')} \
             CONTAINER_GROUP=${CONTAINER_GROUP:-$(id -gn | sed 's/[^[:alnum:]]/_/g')} \
-            $DOCKER_COMPOSE build base
+            $DOCKER_COMPOSE build base; then
+            echo "** ERROR: failed to build 'base' container"
+            return 1
+        fi
     fi
     if [ $BUILD_NODEBASE -eq 1 ]; then
-        echo "- building 'basenode' container"
-        CONTAINER_UID=${CONTAINER_UID:-$(id -u)} CONTAINER_GID=${CONTAINER_GID:-$(id -g)} \
+        echo "- building '$NODE_BASE_SERVICE' container"
+        if ! CONTAINER_UID=${CONTAINER_UID:-$(id -u)} CONTAINER_GID=${CONTAINER_GID:-$(id -g)} \
             CONTAINER_USER=${CONTAINER_USER:-$(id -un | sed 's/[^[:alnum:]]/_/g')} \
             CONTAINER_GROUP=${CONTAINER_GROUP:-$(id -gn | sed 's/[^[:alnum:]]/_/g')} \
-            $DOCKER_COMPOSE build basenode
+            $DOCKER_COMPOSE build "$NODE_BASE_SERVICE"; then
+            echo "** ERROR: failed to build '$NODE_BASE_SERVICE' container"
+            return 1
+        fi
     fi
 
     for i in ${ONLY_CONTAINERS[@]}
@@ -391,10 +405,13 @@ containers_build() {
         echo "- stopping '$i' container"
         $DOCKER_COMPOSE rm -sf $i >/dev/null
         echo "- building '$i' container"
-        CONTAINER_UID=${CONTAINER_UID:-$(id -u)} CONTAINER_GID=${CONTAINER_GID:-$(id -g)} \
+        if ! CONTAINER_UID=${CONTAINER_UID:-$(id -u)} CONTAINER_GID=${CONTAINER_GID:-$(id -g)} \
             CONTAINER_USER=${CONTAINER_USER:-$(id -un | sed 's/[^[:alnum:]]/_/g')} \
             CONTAINER_GROUP=${CONTAINER_GROUP:-$(id -gn | sed 's/[^[:alnum:]]/_/g')} \
-            $DOCKER_COMPOSE build $i
+            $DOCKER_COMPOSE build "$i"; then
+            echo "** ERROR: failed to build '$i' container"
+            return 1
+        fi
     done
 }
 
@@ -721,7 +738,9 @@ fi
 # start doing something useful
 # -----------------------------
 [[ $CLEAN -gt 0 ]]          && { containers_clean; }
-[[ $BUILD -eq 1 ]]          && { containers_build; }
+if [[ $BUILD -eq 1 ]]; then
+    containers_build || exit $?
+fi
 [[ $CONFIGURE -eq 1 ]]      && { containers_configure; }
 [[ $START -eq 1 ]]          && { containers_start; }
 [[ $STOP -eq 1 ]]           && { containers_remove; }

--- a/tests/vpn_test.sh
+++ b/tests/vpn_test.sh
@@ -15,12 +15,59 @@ function info(){
 	  echo "${YLW}INFO:${NC} $1"
 }
 
+function assert_image_python(){
+	local component="$1"
+	local image="fedbiomed/vpn-${component}:${FBM_CONTAINER_VERSION_TAG}"
+	local actual
+
+	if ! actual=$(docker run --rm --entrypoint python "$image" -c \
+		'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")'); then
+		error "Could not run Python in $image"
+	fi
+	if [[ "$actual" != "$PYTHON_VERSION" ]]; then
+		error "Expected Python $PYTHON_VERSION in $image, found $actual"
+	fi
+	info "$image uses Python $actual"
+}
+
+function assert_image_cpu_torch(){
+	[[ "${FBM_EXPECT_CPU_TORCH:-false}" == "true" ]] || return 0
+
+	local component="$1"
+	local image="fedbiomed/vpn-${component}:${FBM_CONTAINER_VERSION_TAG}"
+	local actual
+
+	if ! actual=$(docker run --rm --entrypoint python "$image" -c \
+		'import torch; print("cpu" if torch.version.cuda is None else torch.version.cuda)'); then
+		error "Could not inspect PyTorch in $image"
+	fi
+	if [[ "$actual" != "cpu" ]]; then
+		error "Expected CPU-only PyTorch in $image, found CUDA $actual"
+	fi
+	info "$image uses CPU-only PyTorch"
+}
+
 # Clean images if existing
 basedir=$(cd $(dirname $0)/.. || exit ; pwd)
 cd $basedir || exit
 
 
 FEDBIOMED_DIR="$basedir"
+VPN_ENV_FILE="${FEDBIOMED_DIR}/envs/vpn/docker/.env"
+
+FBM_CONTAINER_VERSION_TAG="${FBM_CONTAINER_VERSION_TAG:-$(
+	source "$VPN_ENV_FILE"
+	echo "$FBM_CONTAINER_VERSION_TAG"
+)}"
+FBM_CONTAINER_INSTANCE_ID="${FBM_CONTAINER_INSTANCE_ID:-$(
+	source "$VPN_ENV_FILE"
+	echo "$FBM_CONTAINER_INSTANCE_ID"
+)}"
+PYTHON_VERSION="${PYTHON_VERSION:-$(
+	source "$VPN_ENV_FILE"
+	echo "$PYTHON_VERSION"
+)}"
+export FBM_CONTAINER_VERSION_TAG FBM_CONTAINER_INSTANCE_ID PYTHON_VERSION
 
 info "cleaning images created"
 
@@ -40,6 +87,10 @@ if ! ${FEDBIOMED_DIR}/scripts/fedbiomed_vpn build vpnserver researcher; then
 	error "Error while building vpnserver and researcher components"
 fi
 
+assert_image_python vpnserver
+assert_image_python researcher
+assert_image_cpu_torch researcher
+
 info "Configuring researcher component"
 
 if ! ${FEDBIOMED_DIR}/scripts/fedbiomed_vpn configure researcher; then
@@ -49,7 +100,8 @@ fi
 
 info "Starting researcher"
 ${FEDBIOMED_DIR}/scripts/fedbiomed_vpn start researcher
-if ! docker ps | grep -q fedbiomed-vpn-researcher; then
+if ! docker ps --format '{{.Names}}' | \
+	grep -Fxq "fedbiomed-vpn-researcher-${FBM_CONTAINER_INSTANCE_ID}"; then
      error "Fed-BioMed researcher container is not running"
 fi
 
@@ -62,6 +114,11 @@ info "Building node and GUI"
 if ! ${FEDBIOMED_DIR}/scripts/fedbiomed_vpn build node gui; then
 	error "Error while building node and gui images"
 fi
+
+assert_image_python node
+assert_image_python gui
+assert_image_cpu_torch node
+assert_image_cpu_torch gui
 
 cd ${FEDBIOMED_DIR}/envs/vpn/docker
 if ! docker compose exec vpnserver bash --login -c 'python ./vpn/bin/configure_peer.py genconf node node1'; then
@@ -79,17 +136,22 @@ docker compose exec vpnserver cat /config/config_peers/node/node2/config.env > $
 
 # Disable secure aggregation
 export FBM_SECURITY_FORCE_SECURE_AGGREGATION=False
+# The getting-started notebook defines a custom training plan. This functional
+# smoke test validates VPN connectivity and training, not plan approval.
+export FBM_SECURITY_TRAINING_PLAN_APPROVAL=False
 # Authorize default training plans
 export FBM_SECURITY_ALLOW_DEFAULT_TRAINING_PLANS=True
 
 docker compose up -d node
 docker compose up -d node2
 
-if ! docker ps | grep -q fedbiomed-vpn-node; then
+if ! docker ps --format '{{.Names}}' | \
+	grep -Fxq "fedbiomed-vpn-node-${FBM_CONTAINER_INSTANCE_ID}"; then
      error "Fed-BioMed node1 container is not running"
 fi
 
-if ! docker ps | grep -q fedbiomed-vpn-node2; then
+if ! docker ps --format '{{.Names}}' | \
+	grep -Fxq "fedbiomed-vpn-node2-${FBM_CONTAINER_INSTANCE_ID}"; then
      error "Fed-BioMed node 2 container is not running"
 fi
 


### PR DESCRIPTION
Part 4 of the Python compatibility CI series. Based on branch feature/compatibility-tests-across-different-python-packages . It tests building docker images for all 5 python versions, and tries to connect with vpn and execute Mnist notebook in the oldest and newest python versions.