### PR TITLE
Feature/minor fixes

### DIFF
--- a/fedbiomed/common/training_args.py
+++ b/fedbiomed/common/training_args.py
@@ -118,6 +118,10 @@ class TrainingArgs:
             logger.critical(msg)
             raise FedbiomedUserInputError(msg) from e
 
+        # Only the enum is passed on; the key is absent when only required args are set
+        if "test_metric" in self._ta:
+            self._ta["test_metric"] = self._as_metric_type(self._ta["test_metric"])
+
         # Validate DP arguments if it is existing in training arguments
         if self._ta["dp_args"] is not None:
             try:
@@ -240,6 +244,16 @@ class TrainingArgs:
         return False, f"Metric {metric} is not a supported Metric"
 
     @staticmethod
+    def _as_metric_type(
+        metric: Union[MetricTypes, str, None],
+    ) -> Optional[MetricTypes]:
+        """Converts an already validated metric name to the enum consumers expect."""
+        if isinstance(metric, str):
+            return MetricTypes.get_metric_type_by_name(metric.upper())
+
+        return metric
+
+    @staticmethod
     @validator_decorator
     def _fedprox_mu_validator(
         val: object,
@@ -337,7 +351,7 @@ class TrainingArgs:
         | test_on_local_updates | toggles validation after local training |
         | test_on_global_updates | toggles validation before local training |
         | shuffle_testing_dataset | whether reset or not the testing (and training) dataset for this `Round` |
-        | test_metric | metric to be used for validation |
+        | test_metric | metric to be used for validation, a `MetricTypes` or its name |
         | test_metric_args | supplemental arguments for the validation metric |
         | log_interval | output a training logging entry every log_interval model updates |
         | fedprox_mu | set the value of mu and enable FedProx correction |
@@ -459,6 +473,8 @@ class TrainingArgs:
             ta = deepcopy(self._ta)
             ta[key] = value
             self._sc.validate(ta)
+            if key == "test_metric":
+                value = self._as_metric_type(value)
             self._ta[key] = value  # only update it value is OK
         except (RuleError, ValidateError) as e:
             #
@@ -591,11 +607,6 @@ class TrainingArgs:
     @classmethod
     def load_state_breakpoint(cls, state: Dict) -> "TrainingArgs":
         """Loads training arguments state"""
-        if metric_name := state.get("test_metric"):
-            state.update(
-                {"test_metric": MetricTypes.get_metric_type_by_name(metric_name)}
-            )
-
         return cls(state)
 
     def get(self, key: str, default: Any = None) -> Any:

--- a/fedbiomed/researcher/federated_workflows/_federated_analytics.py
+++ b/fedbiomed/researcher/federated_workflows/_federated_analytics.py
@@ -813,7 +813,7 @@ class FederatedAnalytics:
         round1_stats = sorted(
             {s for s in stats if s not in self._CENTERED_DERIVED} | {"count", "sum"}
         )
-        r1 = self.fetch_stats(round1_stats, dataset_schema, _emit_log=False)
+        r1 = self.fetch_stats(round1_stats, dataset_schema)
         mean_tree = r1.global_stats("mean")
 
         # Round 2: Σ(x − μ)² centered on the round-1 global mean.
@@ -828,18 +828,10 @@ class FederatedAnalytics:
 
         return FAResult._combine(r1, r2)
 
-    def _log_global_stats(self, result: FAResult) -> None:
-        """Log the aggregated global statistics of *result* once, prettily."""
-        logger.info(
-            "Global statistics:\n%s",
-            json.dumps(result.global_stats(), indent=2, default=str, sort_keys=True),
-        )
-
     def fetch_stats(
         self,
         stats: Optional[str | list[str]] = None,
         dataset_schema: Optional[str | list[str | dict]] = None,
-        _emit_log: bool = True,
     ) -> FAResult:
         """Fetch named statistics across nodes. Already-cached statistics are not re-requested.
 
@@ -847,9 +839,6 @@ class FederatedAnalytics:
             stats: Statistic name(s) to request from nodes (e.g. ``"mean"``).
                 Defaults to ``["count", "mean", "variance"]``.
             dataset_schema: Optional schema definition for filtering the dataset.
-            _emit_log: Internal. When ``False``, suppresses the final global-stats
-                log line — used for intermediate rounds (e.g. the round-1 mean of
-                the variance/std two-pass) so the stats are logged once, at the end.
 
         Returns:
             A :class:`FAResult` containing per-node data and supporting global aggregation.
@@ -916,8 +905,6 @@ class FederatedAnalytics:
             else:
                 result = self._fetch_centered(stats, dataset_schema, node_ids)
                 self._cache_store(cache_key, result)
-            if _emit_log:
-                self._log_global_stats(result)
             return result
 
         # Re-requesting the same (node_ids, schema) key returns identical data, so a
@@ -945,9 +932,6 @@ class FederatedAnalytics:
                 f"All requested statistics {stats} are already cached — "
                 "skipping node requests."
             )
-
-        if _emit_log:
-            self._log_global_stats(cached)
 
         return cached
 

--- a/fedbiomed/researcher/federated_workflows/preproc/_fedcombat/_fedcombat_parameters.py
+++ b/fedbiomed/researcher/federated_workflows/preproc/_fedcombat/_fedcombat_parameters.py
@@ -134,7 +134,7 @@ class _FedCombatParameters:
 
         # FA returns sample variance/std (ddof=1). We request count too in order to
         # convert variance to population std (ddof=0): sqrt(var * (N - 1) / N).
-        result = analytics.fetch_stats(["mean", "variance", "count"], _emit_log=False)
+        result = analytics.fetch_stats(["mean", "variance", "count"])
 
         global_variance = result.global_stats("variance")
         global_count = result.global_stats("count")

--- a/tests/test_researcher_preproc_fedcombat_parameters.py
+++ b/tests/test_researcher_preproc_fedcombat_parameters.py
@@ -56,7 +56,7 @@ def mock_analytics():
 
     # Configure fetch_stats to return a structure compatible with _compute_global_mean_std
     # Each stat ("mean", "std") returns per-node tensors
-    def fetch_stats_side_effect(stat_names, _emit_log):
+    def fetch_stats_side_effect(stat_names):
         result = {
             "mean": {
                 "cov1": torch.tensor([1.0]),

--- a/tests/test_training_args.py
+++ b/tests/test_training_args.py
@@ -130,8 +130,12 @@ class TestTrainingArgs(unittest.TestCase):
         t ^= {"test_metric": None}
         self.assertEqual(t["test_metric"], None)
 
+        # A metric name is accepted, and normalised to the enum consumers expect
         t ^= {"test_metric": "ACCURACY"}
-        self.assertEqual(t["test_metric"], "ACCURACY")
+        self.assertEqual(t["test_metric"], MetricTypes.ACCURACY)
+
+        t ^= {"test_metric": "accuracy"}
+        self.assertEqual(t["test_metric"], MetricTypes.ACCURACY)
 
         t ^= {"test_metric": MetricTypes.ACCURACY}
         self.assertEqual(t["test_metric"], MetricTypes.ACCURACY)


### PR DESCRIPTION
This PR does two things:
- Removes log that displayed global statistics in FA.
- Ensures metric types enum after validation in training args to avoid logging issues.

**Developer Certificate Of Origin (DCO)**

By opening this merge request, you agree to the
[Developer Certificate of Origin (DCO)](https://github.com/fedbiomed/fedbiomed/blob/master/CONTRIBUTING.md#fed-biomed-developer-certificate-of-origin-dco)

This DCO essentially means that:

- you offer the changes under the same license agreement as the project, and
- you have the right to do that,
- you did not steal somebody else’s work.

**License**

Project code files should begin with these comment lines to help trace their origin:
```
# This file is originally part of Fed-BioMed
# SPDX-License-Identifier: Apache-2.0
```

Code files can be reused from another project with a compatible non-contaminating license.
They shall retain the original license and copyright mentions.
The `CREDIT.md` file and `credit/` directory shall be completed and updated accordingly.


**Guidelines for PR review**

General:

* give a glance to [DoD](https://fedbiomed.org/latest/developer/definition-of-done/)
* check [coding rules and coding style](https://fedbiomed.org/latest/developer/usage_and_tools/#coding-style)
* check docstrings (eg run `tests/docstrings/check_docstrings`)

Specific to some cases:

* update all conda envs consistently (`development` and `vpn`, Linux and MacOS)
* if modified researcher (eg new attributes in classes) check if breakpoint needs update (`breakpoint`/`load_breakpoint` in `Experiment()`, `save_state_breakpoint`/`load_state_breakpoint` in aggregators, strategies, secagg, etc.)
* if modified a component with versioning (config files, breakpoint, messaging protocol) then update the version following the rules in `common/utils/_versions.py`